### PR TITLE
[Doctrine] Add "server_version" option to the default DBAL config

### DIFF
--- a/doctrine/doctrine-bundle/1.6/etc/packages/doctrine.yaml
+++ b/doctrine/doctrine-bundle/1.6/etc/packages/doctrine.yaml
@@ -6,6 +6,8 @@ doctrine:
         dbname: "%env(DB_NAME)%"
         user: "%env(DB_USER)%"
         password: "%env(DB_PASSWORD)%"
+        # set your database server version to avoid edge-case exceptions and extra database calls
+        # server_version: 5.7
         charset: UTF8
         # if using pdo_sqlite as your database driver, uncomment next line:
         # path: "%kernel.root_dir%/../var/data.db"


### PR DESCRIPTION
Just a proposal. Maybe we should not add this option, but defining it:

* Saves 1 database call in production
* Avoids this exception explained in https://symfony.com/doc/current/reference/configuration/doctrine.html:

> If you don't define this option and you haven't created your database yet, you may get PDOException errors because Doctrine will try to guess the database server version automatically and none is available.