### PR TITLE
[Proposal] Added "security" alias for the SecurityBundle

### DIFF
--- a/symfony/security-bundle/3.3/manifest.json
+++ b/symfony/security-bundle/3.3/manifest.json
@@ -4,5 +4,6 @@
     },
     "copy-from-recipe": {
         "etc/": "%ETC_DIR%/"
-    }
+    },
+    "aliases": ["security"]
 }


### PR DESCRIPTION
The "security" alias installed the core Security component for me:

```
$ composer req security

Using version ^3.3@dev for symfony/security
  - Removing symfony/security-core (dev-master 2cb0385)
  - Installing symfony/inflector (dev-master 3b19c08)
  - Installing symfony/property-access (dev-master 65b1197)
  - Removing symfony/security-csrf (dev-master 46ad802)
  - Installing symfony/security (dev-master a382b7c)
```

So I needed to execute this too:

```
$ composer req security-bundle

Using version ^3.3@dev for symfony/security-bundle
  - Installing symfony/security-bundle (dev-master acbf390)
```

... but given that "Security" is one of those components which are hard to use stand-alone outside the Symfony Framework, maybe most people expect "security" to install the SecurityBundle?