### PR TITLE
Moved the "dev" security config to dev/security.yaml

### DIFF
--- a/symfony/security-bundle/3.3/etc/packages/dev/security.yaml
+++ b/symfony/security-bundle/3.3/etc/packages/dev/security.yaml
@@ -1,0 +1,5 @@
+security:
+    firewalls:
+        dev:
+            pattern: ^/(_(profiler|wdt)|css|images|js)/
+            security: false

--- a/symfony/security-bundle/3.3/etc/packages/security.yaml
+++ b/symfony/security-bundle/3.3/etc/packages/security.yaml
@@ -3,9 +3,8 @@ security:
     providers:
         in_memory: { memory: null }
     firewalls:
-        dev:
-            pattern: ^/(_(profiler|wdt)|css|images|js)/
-            security: false
+        dev: null
+
         main:
             anonymous: null
 


### PR DESCRIPTION
This is not a real PR. This is just to ask your opinion about this:

1. I don't like the `firewalls.dev` config in the security.yaml used in production.
2. We can't move the entire "dev" config to another file because of this limitation: https://github.com/symfony/symfony/issues/22308
3. So the only solution is to define a `dev: null` in prod and add the rest of config in dev.

But it's a bit ugly, isn't it?