### PR TITLE
Added "debug" as an alias of DebugBundle

### DIFF
--- a/symfony/debug-bundle/3.3/manifest.json
+++ b/symfony/debug-bundle/3.3/manifest.json
@@ -1,5 +1,6 @@
 {
     "bundles": {
         "Symfony\\Bundle\\DebugBundle\\DebugBundle": ["dev", "test"]
-    }
+    },
+    "aliases": ["debug"]
 }


### PR DESCRIPTION
Otherwise we have the same problem as with "security" and "security-bundle":  `composer req --dev debug` installs `symfony/debug` instead of `symfony/debug-bundle`