### PR TITLE
Recommend specifying the controller itself for EasyAdmin

### DIFF
--- a/javiereguiluz/easyadmin-bundle/master/etc/routing/easy_admin.yaml
+++ b/javiereguiluz/easyadmin-bundle/master/etc/routing/easy_admin.yaml
@@ -1,4 +1,4 @@
 easy_admin_bundle:
-    resource: "@EasyAdminBundle/Controller"
+    resource: "@EasyAdminBundle/Controller/AdminController.php"
     prefix: /admin
     type: annotation


### PR DESCRIPTION
I think it's a better idea to expose the controller itself directly.

It would encourage people to add their own controller by just changing the name of the bundle if they want to override it.

Also, I would suggest to change `master` for a lower requirement (1.14 or 1.15 maybe, there are some without much BC breaks, and they'd still share the same recipe) and add `version_aliases`, but haven't done it in the PR because `master` might have been added for a specific reason 🙂 