### PR TITLE
Fix PHPUnit xsd version

### DIFF
--- a/phpunit/phpunit/4.7/phpunit.xml.dist
+++ b/phpunit/phpunit/4.7/phpunit.xml.dist
@@ -2,7 +2,7 @@
 
 <!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.8/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.1/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"


### PR DESCRIPTION
The base supported version is ~4.7~ 6.1 as specified in the ~directory~ version aliases