### PR TITLE
Add DoctrineCacheBundle (non-standard bundle name)

### DIFF
--- a/doctrine/doctrine-cache-bundle/1.0/manifest.json
+++ b/doctrine/doctrine-cache-bundle/1.0/manifest.json
@@ -1,0 +1,5 @@
+{
+    "bundles": {
+        "Doctrine\\Bundle\\DoctrineCacheBundle\\DoctrineCacheBundle": ["all"]
+    }
+}


### PR DESCRIPTION
The bundle class name doesn't follow Symfony standards, so it cannot be autodetected.