### PR TITLE
Store voters in Security

### DIFF
--- a/symfony/framework-bundle/3.3/etc/packages/app.yaml
+++ b/symfony/framework-bundle/3.3/etc/packages/app.yaml
@@ -5,7 +5,7 @@ services:
         public: false
 
     App\:
-        resource: '../../src/{Command,Form,EventSubscriber,Twig,Voter}'
+        resource: '../../src/{Command,Form,EventSubscriber,Twig,Security}'
 
     App\Controller\:
         resource: '../../src/Controller'


### PR DESCRIPTION
[As caught by @xabbuh](https://github.com/symfony/symfony-standard/pull/1064#discussion_r114080504), in the docs, voters are stored in `Security`, not in `Voter`.