### PR TITLE
Remove framework.trusted_proxies option

### DIFF
--- a/symfony/framework-bundle/3.3/etc/packages/framework.yaml
+++ b/symfony/framework-bundle/3.3/etc/packages/framework.yaml
@@ -4,7 +4,6 @@ framework:
     #csrf_protection: null
     #http_method_override: true
     #trusted_hosts: null
-    #trusted_proxies: null
     # https://symfony.com/doc/current/reference/configuration/framework.html#handler-id
     #session:
     #    handler_id: session.handler.native_file


### PR DESCRIPTION
As deprecated and "removed" in https://github.com/symfony/symfony/pull/21830 and https://github.com/symfony/symfony/pull/22238 (BC break)