### PR TITLE
[FrameworkBundle] improve Makefile serve target

### DIFF
--- a/symfony/framework-bundle/3.3/Makefile
+++ b/symfony/framework-bundle/3.3/Makefile
@@ -6,9 +6,23 @@ cache-warmup: cache-clear
 	@test -f bin/console && bin/console cache:warmup || echo "cannot warmup the cache (needs symfony/console)"
 .PHONY: cache-warmup
 
-serve:
-	@echo -e "\033[32;49mServer listening on http://127.0.0.1:8000\033[39m"
-	@echo "Quit the server with CTRL-C."
-	@echo -e "Run \033[32mcomposer require symfony/web-server-bundle\033[39m for a better web server"
+CONSOLE=bin/console
+sf_console:
+	@test -f $(CONSOLE) || printf "Run \033[32mcomposer require cli\033[39m to install the Symfony console.\n"
+	@exit
+
+serve_as_sf: sf_console
+	@test -f $(CONSOLE) && $(CONSOLE)|grep server:start > /dev/null || ${MAKE} serve_as_php
+	@$(CONSOLE) server:start || exit 0
+
+	@printf "Quit the server with \033[32;49mbin/console server:stop.\033[39m\n"
+
+serve_as_php:
+	@printf "\033[32;49mServer listening on http://127.0.0.1:8000\033[39m\n";
+	@printf "Quit the server with CTRL-C.\n"
+	@printf "Run \033[32mcomposer require symfony/web-server-bundle\033[39m for a better web server\n"
 	php -S 127.0.0.1:8000 -t web
-.PHONY: serve
+
+serve:
+	@${MAKE} serve_as_sf
+.PHONY: sf_console serve serve_as_sf serve_as_php


### PR DESCRIPTION
Related to #49, I don't know if this the best way to do it. But as the Makefile is composed I don't think it's possible to use advanced Makefile features 😟

@greg0ire suggested something like this: 

```makefile
.PHONY: serve

CONSOLE=bin/console

$(CONSOLE):
    @echo 'Woops! The console does not exist'
    @exit

serve: bin/console
    bin/console list server|grep server:start
    bin/console server:start
```

But don't know if you can have multiple targets with the same name but different conditions?