### PR TITLE
Tweaked a help note about routing

### DIFF
--- a/symfony/framework-bundle/3.3/etc/routing.yaml
+++ b/symfony/framework-bundle/3.3/etc/routing.yaml
@@ -2,7 +2,7 @@
 #    path: /
 #    defaults: { _controller: 'App\Controller\DefaultController::index' }
 
-# Depends on sensio/framework-extra-bundle:^3.0 and doctrine/annotations
+# requires installing the 'sensio/framework-extra-bundle:^3.0' package
 #controllers:
 #    resource: ../src/Controller/
 #    type: annotation


### PR DESCRIPTION
If you want to use annotations in your Flex app, you must execute this:

```
$ composer req sensio/framework-extra-bundle:^3.0
```

That's why I propose to reword the original help note to make it as close as possible to that command ... and to avoid confusing people with the Doctrine mention.

PS: it'd be cool if the package was named `symfony/annotations` instead of `sensio/framework-extra-bundle` 😉 