### PR TITLE
Proposed to remove a confusing help note about Doctrine

### DIFF
--- a/doctrine/doctrine-bundle/1.6/manifest.json
+++ b/doctrine/doctrine-bundle/1.6/manifest.json
@@ -9,7 +9,6 @@
     "env": {
         "#1": "Format described at http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url",
         "#2": "For a sqlite database, use: \"sqlite:///%kernel.project_dir%/var/data.db\"",
-        "#3": "Set \"serverVersion\" to your server version to avoid edge-case exceptions and extra database calls",
         "DATABASE_URL": "mysql://root@127.0.0.1:3306/symfony?charset=utf8mb4&serverVersion=5.7"
     }
 }


### PR DESCRIPTION
I originally proposed to add this help note:

```
# Set "serverVersion" to your server version to avoid edge-case exceptions
and extra database calls
```

Now I propose to remove it because it's confusing:

* It doesn't truly explain the consequences: "edge cases" and "database calls" sounds vague.
* The proposed solution ("set the serverVersion") is confusing: which server version? how do I get that? how do I set up that option?

I think this option requires a lengthy explanation to be really understood, so maybe we should leave that for Symfony Docs.