### PR TITLE
Load container config, instead of importing it

### DIFF
--- a/symfony/framework-bundle/3.3/src/Kernel.php
+++ b/symfony/framework-bundle/3.3/src/Kernel.php
@@ -40,11 +40,11 @@ final class Kernel extends BaseKernel
     protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader): void
     {
         $confDir = dirname(__DIR__).'/etc';
-        $loader->import($confDir.'/packages/*'.self::CONFIG_EXTS, 'glob');
+        $loader->load($confDir.'/packages/*'.self::CONFIG_EXTS, 'glob');
         if (is_dir($confDir.'/packages/'.$this->environment)) {
-            $loader->import($confDir.'/packages/'.$this->environment.'/**/*'.self::CONFIG_EXTS, 'glob');
+            $loader->load($confDir.'/packages/'.$this->environment.'/**/*'.self::CONFIG_EXTS, 'glob');
         }
-        $loader->import($confDir.'/container'.self::CONFIG_EXTS, 'glob');
+        $loader->load($confDir.'/container'.self::CONFIG_EXTS, 'glob');
     }
 
     protected function configureRoutes(RouteCollectionBuilder $routes): void


### PR DESCRIPTION
`import()` is an implementation detail; see https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Config/Loader/GlobFileLoader.php#L26

Fixed ticket: https://github.com/symfony/symfony/pull/22638