### PR TITLE
fix error exit code

### DIFF
--- a/symfony/framework-bundle/3.3/Makefile
+++ b/symfony/framework-bundle/3.3/Makefile
@@ -13,7 +13,7 @@ sf_console:
 
 serve_as_sf: sf_console
 	@test -f $(CONSOLE) && $(CONSOLE)|grep server:start > /dev/null || ${MAKE} serve_as_php
-	@$(CONSOLE) server:start || exit 0
+	@$(CONSOLE) server:start || exit 1
 
 	@printf "Quit the server with \033[32;49mbin/console server:stop.\033[39m\n"
 


### PR DESCRIPTION
In case that the server could not start we should indicate the failure
with a non-zero exit code.

This addresses @stof's comment in https://github.com/symfony/recipes/pull/54#discussion_r116276643.