### PR TITLE
Added an alias for FrameworkBundle 3.4

### DIFF
--- a/symfony/framework-bundle/3.3/manifest.json
+++ b/symfony/framework-bundle/3.3/manifest.json
@@ -21,5 +21,6 @@
         "/var/",
         "/vendor/",
         "/web/bundles/"
-    ]
+    ],
+    "version_aliases": ["3.4"]
 }


### PR DESCRIPTION
A user reported in Symfony Slack a problem with Flex ... and I'm facing the same problem. As you can see, the FrameworkBundle recipe is completely ignored:

```
$ composer create-project symfony/skeleton:3.3.x-dev my-project

Installing symfony/skeleton (3.3.x-dev 19daacfd7ca93335963b7dd0e5ea4e18c228135c)
  - Installing symfony/skeleton (3.3.x-dev 19daacf): Cloning 19daacfd7c from cache

Created project in all-exception-pages
Loading composer repositories with package information
Updating dependencies (including require-dev)
Package operations: 22 installs, 0 updates, 0 removals

  - Installing symfony/flex (dev-master 40c8b45): Loading from cache
    Detected auto-configuration settings for "symfony/flex"
    Setting configuration and copying files
  - Installing symfony/stopwatch (3.4.x-dev 162ab93): Loading from cache
  - Installing symfony/routing (3.4.x-dev 6dbb39f): Loading from cache
  - Installing symfony/polyfill-mbstring (dev-master e79d363): Loading from cache
  - Installing psr/log (dev-master 4ebe3a8): Loading from cache
  - Installing symfony/debug (3.4.x-dev 627c397): Loading from cache
  - Installing symfony/http-foundation (3.4.x-dev 3e35088): Loading from cache
  - Installing symfony/event-dispatcher (3.4.x-dev dc71961): Loading from cache
  - Installing symfony/http-kernel (3.4.x-dev 755a852): Loading from cache
  - Installing symfony/finder (3.4.x-dev a90f2ad): Loading from cache
  - Installing symfony/filesystem (3.4.x-dev 45e8dd4): Loading from cache
  - Installing psr/container (dev-master b7ce3b1): Loading from cache
  - Installing symfony/dependency-injection (3.4.x-dev fee0f72): Loading from cache
  - Installing symfony/config (3.4.x-dev de6faa2): Loading from cache
  - Installing symfony/class-loader (3.4.x-dev 8c7ae3c): Loading from cache
  - Installing psr/simple-cache (dev-master 753fa59): Loading from cache
  - Installing psr/cache (dev-master 78c5a01): Loading from cache
  - Installing symfony/cache (3.4.x-dev a56a943): Loading from cache
  - Installing doctrine/cache (dev-master 0da649f): Loading from cache
  - Installing symfony/framework-bundle (3.4.x-dev d3053f4): Loading from cache
    Detected auto-configuration settings for "symfony/framework-bundle"
    Enabling the package as a Symfony bundle
  - Installing symfony/yaml (3.4.x-dev 19248c8): Loading from cache
  - Installing symfony/dotenv (3.4.x-dev c6eb017): Loading from cache

Writing lock file
Generating autoload files
```

FrameworkBundle is detected as a bundle and enabled automatically, but its recipe is ignored (for example, the Makefile is not created). This PR may fix the issue.