### PR TITLE
Remove version_aliases configuration setting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,25 +63,6 @@ more aliases to make it easier to install:
 
 Developers can now install this dependency with ``composer require acme-log``.
 
-``version_aliases`` option
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-This option lists all the additional dependency versions (using the ``x.y``
-format) that work with this very same recipe. This avoids duplicating recipes
-when a new version of the package is released:
-
-.. code-block:: json
-
-    // vendor/package-name/3.2/manifest.json
-    {
-        "version_aliases": ["3.3", "3.4", "4.0"]
-    }
-
-.. note::
-
-    When using ``version_aliases``, the directory where the recipe is defined
-    must be the oldest supported version (``3.2`` in the previous example).
-
 Configurators
 -------------
 
@@ -300,8 +281,6 @@ the recipe:
 * JSON files must use 4 space indentations;
 * Aliases are only supported in the main repository, not the contrib one;
 * Aliases must not be already defined by another package;
-* All versions listed in `version_aliases` and the main version should be valid;
-* Version defined in the directory must be the oldest amongst those defined in `version_aliases`;
 * The manifest file only contains supported keys;
 * The package must exist on Packagist;
 * The package must have at least one version on Packagist;

--- a/phpunit/phpunit/4.7/manifest.json
+++ b/phpunit/phpunit/4.7/manifest.json
@@ -2,6 +2,5 @@
     "copy-from-recipe": {
         "phpunit.xml.dist": "phpunit.xml.dist"
     },
-    "aliases": ["phpunit"],
-    "version_aliases": ["4.8", "5.0", "5.1", "5.2", "5.3", "5.4", "5.5", "5.6", "5.7", "6.0", "6.1"]
+    "aliases": ["phpunit"]
 }


### PR DESCRIPTION
`version_aliases` was a bad idea as it incurs too much manual maintenance as we need to remember to add new minor and major versions. That's fragile and we will probably forget to do it promptly. That's even worse for contributed recipes.

So, instead (and as already documented in the README, so not part of the diff), the version of the recipe if the minimum version that the recipe supports. So, if there is only one recipe for version "3.3", the recipe will be applied for all versions >= 3.3 (including 3.x, 4.x, ...).

If a version introduces changes that has an impact on the recipe , then a new directory with the version when the break appeared should be created with the new recipe, which makes total sense.
