### PR TITLE
Removed extra slash for sqlite example

### DIFF
--- a/doctrine/doctrine-bundle/1.6/manifest.json
+++ b/doctrine/doctrine-bundle/1.6/manifest.json
@@ -8,7 +8,7 @@
     },
     "env": {
         "#1": "Format described at http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url",
-        "#2": "For a sqlite database, use: \"sqlite:///%kernel.project_dir%/var/data.db\"",
+        "#2": "For a sqlite database, use: \"sqlite://%kernel.project_dir%/var/data.db\"",
         "#3": "Set \"serverVersion\" to your server version to avoid edge-case exceptions and extra database calls",
         "DATABASE_URL": "mysql://root@127.0.0.1:3306/symfony?charset=utf8mb4&serverVersion=5.7"
     }


### PR DESCRIPTION
Cannot create sqlite database, removing extra slash makes it work as expected.