### PR TITLE
[lexik/jwt-authentication-bundle] Fix configured key path

### DIFF
--- a/lexik/jwt-authentication-bundle/2.3/etc/packages/lexik_jwt_authentication.yaml
+++ b/lexik/jwt-authentication-bundle/2.3/etc/packages/lexik_jwt_authentication.yaml
@@ -1,4 +1,4 @@
 lexik_jwt_authentication:
-    private_key_path: '%env(JWT_PRIVATE_KEY_PATH)%'
-    public_key_path:  '%env(JWT_PUBLIC_KEY_PATH)%'
+    private_key_path: '%kernel.project_dir%/%env(JWT_PRIVATE_KEY_PATH)%'
+    public_key_path:  '%kernel.project_dir%/%env(JWT_PUBLIC_KEY_PATH)%'
     pass_phrase:      '%env(JWT_PASSPHRASE)%'

--- a/lexik/jwt-authentication-bundle/2.3/manifest.json
+++ b/lexik/jwt-authentication-bundle/2.3/manifest.json
@@ -7,6 +7,7 @@
     },
     "aliases": ["jwt-auth"],
     "env": {
+        "#1": "Key paths should be relative to the project directory",
         "JWT_PRIVATE_KEY_PATH": "%ETC_DIR%/jwt/private.pem",
         "JWT_PUBLIC_KEY_PATH": "%ETC_DIR%/jwt/public.pem",
         "JWT_PASSPHRASE": "%generate(secret)%"


### PR DESCRIPTION
Only using `%ETC_DIR%` leads to

> Private key "etc/jwt/private.pem" does not exist or is not readable.

This fixes it by prefixing paths by `%kernel.project_dir%/` in the bundle config.