### PR TITLE
[doctrine/doctrine-bundle] Escape DATABASE_URL env value

### DIFF
--- a/doctrine/doctrine-bundle/1.6/manifest.json
+++ b/doctrine/doctrine-bundle/1.6/manifest.json
@@ -10,6 +10,6 @@
         "#1": "Format described at http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url",
         "#2": "For a sqlite database, use: \"sqlite:///%kernel.project_dir%/var/data.db\"",
         "#3": "Set \"serverVersion\" to your server version to avoid edge-case exceptions and extra database calls",
-        "DATABASE_URL": "mysql://root@127.0.0.1:3306/symfony?charset=utf8mb4&serverVersion=5.7"
+        "DATABASE_URL": "\"mysql://root@127.0.0.1:3306/symfony?charset=utf8mb4&serverVersion=5.7\""
     }
 }


### PR DESCRIPTION
When requiring `doctrine/doctrine-bundle` (more often `orm-pack`), the following is added to the project `.env`:

```
DATABASE_URL=mysql://root@127.0.0.1:3306/symfony?charset=utf8mb4&serverVersion=5.7
```
The makefile seems to parse that properly (tested on OSX and debian).
But running `source .env` from the cli (for debugging the .env vars, as shown in [dotenv docs](http://symfony.com/doc/master/components/dotenv.html)) gives

> .env:15: parse error near `&'

This fixes it by adding quotes around the value.