### PR TITLE
[Translation] Allow using "etc/translations" to store translations files

### DIFF
--- a/symfony/translation/3.3/etc/packages/symfony_translation.yaml
+++ b/symfony/translation/3.3/etc/packages/symfony_translation.yaml
@@ -1,0 +1,7 @@
+framework:
+    translator:
+        paths:
+            - '%kernel.project_dir%/etc/translations/'
+        fallbacks:
+            # Setup your app locales here
+            - 'en'

--- a/symfony/translation/3.3/etc/packages/symfony_translation.yaml
+++ b/symfony/translation/3.3/etc/packages/symfony_translation.yaml
@@ -1,7 +1,0 @@
-framework:
-    translator:
-        paths:
-            - '%kernel.project_dir%/etc/translations/'
-        fallbacks:
-            # Setup your app locales here
-            - 'en'

--- a/symfony/translation/3.3/etc/packages/translation.yaml
+++ b/symfony/translation/3.3/etc/packages/translation.yaml
@@ -1,0 +1,11 @@
+parameters:
+    # Change this locale depending on your app's default language
+    locale: 'en'
+
+framework:
+    default_locale: '%locale%'
+    translator:
+        paths:
+            - '%kernel.project_dir%/etc/translations/'
+        fallbacks:
+            - '%locale%'

--- a/symfony/translation/3.3/etc/packages/translation.yaml
+++ b/symfony/translation/3.3/etc/packages/translation.yaml
@@ -1,11 +1,7 @@
-parameters:
-    # Change this locale depending on your app's default language
-    locale: 'en'
-
 framework:
     default_locale: '%locale%'
     translator:
         paths:
-            - '%kernel.project_dir%/etc/translations/'
+            - '%kernel.project_dir%/translations/'
         fallbacks:
             - '%locale%'

--- a/symfony/translation/3.3/manifest.json
+++ b/symfony/translation/3.3/manifest.json
@@ -1,6 +1,10 @@
 {
     "copy-from-recipe": {
-        "etc/": "%ETC_DIR%/"
+        "etc/": "%ETC_DIR%/",
+        "translations/": "translations/"
+    },
+    "container": {
+        "locale": "en"
     },
     "aliases": ["translator"]
 }

--- a/symfony/translation/3.3/manifest.json
+++ b/symfony/translation/3.3/manifest.json
@@ -1,3 +1,6 @@
 {
+    "copy-from-recipe": {
+        "etc/": "%ETC_DIR%/"
+    },
     "aliases": ["translator"]
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

For now, translations are stored in Symfony's default directory which is `%kernel.root_dir%/Resources/translations`, resolved to `src/Resources/translations`.

I find it much more convenient to store it in `etc/translations`.

I'm not sure about some things though:

* The yaml file name, `translation.yaml`, as this config is part of the framework and we cannot "update" the `framework.yaml` file with this recipe 😕 Maybe should I rename it `symfony_translation.yaml` or `translator`, or even maybe `symfony_translator`?
* Adding `%locale%` parameter with `en` by default. As it's not mandatory to have a `%locale%` parameter in Symfony apps anymore, I thought it would be useful to setup at least this value and add a comment to tell the user to update it depending on his/her application.

What do you think?