### PR TITLE
[Doc] Add missing doc about the "container" configurator

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -122,8 +122,7 @@ container:
     }
 
 **Note:** For now, when you remove a package, container parameters that were added this
-way are not removed. This configurator should be used only when environment variables do
-not fit your recipe needs.
+way are not removed.
 
 ``copy-from-package`` Configurator
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -104,6 +104,27 @@ The previous recipe is transformed into the following PHP code:
         'Symfony\Bundle\MonologBundle\MonologBundle' => ['all' => true],
     ];
 
+``container`` Configurator
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Adds new container parameters in the ``container.yaml`` file by adding your parameters
+in the ``container`` option.
+
+This example creates a new ``locale`` container parameter with a default value in your
+container:
+
+.. code-block:: json
+
+    {
+        "container": {
+            "locale": "en"
+        }
+    }
+
+**Note:** For now, when you remove a package, container parameters that were added this
+way are not removed. This configurator should be used only when environment variables do
+not fit your recipe needs.
+
 ``copy-from-package`` Configurator
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Was missing, not sure it was by purpose or not, but I propose to add it anyway, feel free to close it if you think it's not relevant.

Just about the bottom-note I added, it's because of [this "fixme" comment](https://github.com/symfony/flex/blob/master/src/Configurator/ContainerConfigurator.php#L27-L30), I'm not sure this warning should be present in the docs or if we shouldn't tell about it as the "fixme" might be solved one day 🤔 