### PR TITLE
[lexik/jwt-authentication-bundle] Fix generate-jwt-keys target in Makefile

### DIFF
--- a/lexik/jwt-authentication-bundle/2.3/Makefile
+++ b/lexik/jwt-authentication-bundle/2.3/Makefile
@@ -1,6 +1,7 @@
+OPENSSL_BIN := $(shell which openssl)
 generate-jwt-keys:
-ifeq (, $(shell which openssl))
-$(error "Unable to generate keys (needs OpenSSL)")
+ifndef OPENSSL_BIN
+	$(error "Unable to generate keys (needs OpenSSL)")
 endif
 	mkdir -p etc/jwt
 	openssl genrsa -passout pass:${JWT_PASSPHRASE} -out ${JWT_PRIVATE_KEY_PATH} -aes256 4096


### PR DESCRIPTION
| Q | A |
| --- | --- |
| License | MIT |

The definition of the `generate-jwt-keys` target broke the `Makefile` when the `openssl` binary is not available.