### PR TITLE
[doctrine/doctrine-bundle] Use apcu provider instead of deprecated apc

### DIFF
--- a/doctrine/doctrine-bundle/1.6/etc/packages/prod/doctrine.yaml
+++ b/doctrine/doctrine-bundle/1.6/etc/packages/prod/doctrine.yaml
@@ -1,5 +1,5 @@
 doctrine:
     orm:
-        #metadata_cache_driver: apc
-        #result_cache_driver: apc
-        #query_cache_driver: apc
+        #metadata_cache_driver: apcu
+        #result_cache_driver: apcu
+        #query_cache_driver: apcu


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

It's time to move forward.

`doctrine/cache` since [1.6.0](https://github.com/doctrine/cache/releases/tag/v1.6.0) (see doctrine/cache#115):
* `ApcuCache` added
* `ApcCache` deprecated

`doctrine/doctrine-cache-bundle` since [1.3.0](https://github.com/doctrine/DoctrineCacheBundle/releases/tag/1.3.0) (see doctrine/DoctrineCacheBundle#86):
* `apcu` added in the configuration