### PR TITLE
Exclude Tests from being scanned

### DIFF
--- a/symfony/framework-bundle/3.3/etc/packages/app.yaml
+++ b/symfony/framework-bundle/3.3/etc/packages/app.yaml
@@ -15,7 +15,7 @@ services:
         resource: '../../src/*'
         # you can exclude directories or files
         # but if a service is unused, it's removed anyway
-        exclude: '../../src/{Entity,Repository}'
+        exclude: '../../src/{Entity,Repository,Tests}'
 
     # controllers are imported separately to make sure they're public
     # and have a tag that allows actions to type-hint services


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Even if the best practice is to store tests under `tests/`, some might still want to store them under `src/Tests` in which case, we want to exclude them for several reasons: first, no service should be defined there, so no need to scan the directory. But, more important, if PHPUnit is only install as a dev dependency, scanning on production will fail as the PHPUnit classes won't be available. This PR fixes this.
