### PR TITLE
Add the Behat recipe

### DIFF
--- a/behat/symfony2-extension/2.1/behat.yml.dist
+++ b/behat/symfony2-extension/2.1/behat.yml.dist
@@ -9,5 +9,4 @@ default:
         Behat\Symfony2Extension:
             kernel:
                 bootstrap: features/bootstrap/bootstrap.php
-                path: src/Kernel.php
                 class: App\Kernel

--- a/behat/symfony2-extension/2.1/behat.yml.dist
+++ b/behat/symfony2-extension/2.1/behat.yml.dist
@@ -1,0 +1,13 @@
+default:
+    suites:
+        default:
+            contexts:
+                - FeatureContext:
+                    kernel: '@kernel'
+
+    extensions:
+        Behat\Symfony2Extension:
+            kernel:
+                bootstrap: features/bootstrap/bootstrap.php
+                path: src/Kernel.php
+                class: App\Kernel

--- a/behat/symfony2-extension/2.1/features/bootstrap/FeatureContext.php
+++ b/behat/symfony2-extension/2.1/features/bootstrap/FeatureContext.php
@@ -1,0 +1,40 @@
+<?php
+
+use Behat\Behat\Context\Context;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+class FeatureContext implements Context
+{
+    /**
+     * @var KernelInterface
+     */
+    private $kernel;
+
+    /**
+     * @var Response|null
+     */
+    private $response;
+
+    public function __construct(KernelInterface $kernel)
+    {
+        $this->kernel = $kernel;
+    }
+
+    /**
+     * @When this is a demo scenario that sends a request to :path
+     */
+    public function thisIsADemoScenarioThatSendsARequestTo(string $path)
+    {
+        $this->response = $this->kernel->handle(Request::create($path, 'GET'));
+    }
+
+    /**
+     * @Then the response should be received
+     */
+    public function theResponseShouldBeReceived()
+    {
+        assert($this->response !== null);
+    }
+}

--- a/behat/symfony2-extension/2.1/features/bootstrap/FeatureContext.php
+++ b/behat/symfony2-extension/2.1/features/bootstrap/FeatureContext.php
@@ -41,6 +41,8 @@ class FeatureContext implements Context
      */
     public function theResponseShouldBeReceived()
     {
-        assert($this->response !== null);
+        if ($this->response === null) {
+            throw new \RuntimeException('No response received');
+        }
     }
 }

--- a/behat/symfony2-extension/2.1/features/bootstrap/FeatureContext.php
+++ b/behat/symfony2-extension/2.1/features/bootstrap/FeatureContext.php
@@ -23,9 +23,9 @@ class FeatureContext implements Context
     }
 
     /**
-     * @When this is a demo scenario that sends a request to :path
+     * @When a demo scenario sends a request to :path
      */
-    public function thisIsADemoScenarioThatSendsARequestTo(string $path)
+    public function aDemoScenarioSendsARequestTo(string $path)
     {
         $this->response = $this->kernel->handle(Request::create($path, 'GET'));
     }

--- a/behat/symfony2-extension/2.1/features/bootstrap/FeatureContext.php
+++ b/behat/symfony2-extension/2.1/features/bootstrap/FeatureContext.php
@@ -5,6 +5,12 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\KernelInterface;
 
+/**
+ * This context class contains the definitions of the steps used by the demo 
+ * feature file. Learn how to get started with Behat and BDD on Behat's website.
+ * 
+ * @see http://behat.org/en/latest/quick_start.html
+ */
 class FeatureContext implements Context
 {
     /**

--- a/behat/symfony2-extension/2.1/features/bootstrap/bootstrap.php
+++ b/behat/symfony2-extension/2.1/features/bootstrap/bootstrap.php
@@ -1,0 +1,10 @@
+<?php
+
+use Symfony\Component\Dotenv\Dotenv;
+
+require __DIR__.'/../../vendor/autoload.php';
+
+// The check is to ensure we don't use .env in production
+if (!getenv('APP_ENV')) {
+    (new Dotenv())->load(__DIR__.'/../../.env');
+}

--- a/behat/symfony2-extension/2.1/features/bootstrap/bootstrap.php
+++ b/behat/symfony2-extension/2.1/features/bootstrap/bootstrap.php
@@ -2,8 +2,6 @@
 
 use Symfony\Component\Dotenv\Dotenv;
 
-require __DIR__.'/../../vendor/autoload.php';
-
 // The check is to ensure we don't use .env in production
 if (!getenv('APP_ENV')) {
     (new Dotenv())->load(__DIR__.'/../../.env');

--- a/behat/symfony2-extension/2.1/features/demo.feature
+++ b/behat/symfony2-extension/2.1/features/demo.feature
@@ -1,3 +1,7 @@
+# This file contains a user story for demonstration only.
+# Learn how to get started with Behat and BDD on Behat's website:
+# http://behat.org/en/latest/quick_start.html
+
 Feature:
   In order to prove that the Behat Symfony extension is correctly installed
   As a user

--- a/behat/symfony2-extension/2.1/features/demo.feature
+++ b/behat/symfony2-extension/2.1/features/demo.feature
@@ -1,0 +1,8 @@
+Feature:
+  In order to proves that the Behat Symfony extension is correctly installed
+  As a user
+  I want to have a demo scenario
+
+  Scenario: It receives a response from Symfony's kernel
+    When this is a demo scenario that sends a request to "/"
+    Then the response should be received

--- a/behat/symfony2-extension/2.1/features/demo.feature
+++ b/behat/symfony2-extension/2.1/features/demo.feature
@@ -1,8 +1,8 @@
 Feature:
-  In order to proves that the Behat Symfony extension is correctly installed
+  In order to prove that the Behat Symfony extension is correctly installed
   As a user
   I want to have a demo scenario
 
   Scenario: It receives a response from Symfony's kernel
-    When this is a demo scenario that sends a request to "/"
+    When a demo scenario sends a request to "/"
     Then the response should be received

--- a/behat/symfony2-extension/2.1/manifest.json
+++ b/behat/symfony2-extension/2.1/manifest.json
@@ -1,0 +1,7 @@
+{
+    "copy-from-recipe": {
+        "behat.yml.dist": "behat.yml.dist",
+        "features/": "features/"
+    },
+    "aliases": ["behat"]
+}

--- a/behat/symfony2-extension/2.1/manifest.json
+++ b/behat/symfony2-extension/2.1/manifest.json
@@ -3,5 +3,6 @@
         "behat.yml.dist": "behat.yml.dist",
         "features/": "features/"
     },
-    "aliases": ["behat"]
+    "aliases": ["behat"],
+    "gitignore": ["behat.yml"]
 }

--- a/behat/symfony2-extension/2.1/post-install.txt
+++ b/behat/symfony2-extension/2.1/post-install.txt
@@ -1,0 +1,2 @@
+<bg=blue;fg=white> Next for Behat/SymfonyExtension </>
+    Run <comment>vendor/bin/behat</> to run the demo tests.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

As Behat is part of the official Symfony documentation, I'm creating this PR in here. This recipe will create files already configured for Symfony 4 and will create a demo working scenario showing how to get access to Symfony's kernel and send a request to it.
