### PR TITLE
Discard 403 error from production

### DIFF
--- a/symfony/framework-bundle/3.3/web/index.php
+++ b/symfony/framework-bundle/3.3/web/index.php
@@ -23,6 +23,7 @@ if (getenv('APP_DEBUG')) {
     if (isset($_SERVER['HTTP_CLIENT_IP'])
         || isset($_SERVER['HTTP_X_FORWARDED_FOR'])
         || !(in_array(@$_SERVER['REMOTE_ADDR'], ['127.0.0.1', '::1']) || PHP_SAPI === 'cli-server')
+        && getenv('APP_ENV') !== 'prod'
     ) {
         header('HTTP/1.0 403 Forbidden');
         exit('You are not allowed to access this file. Check '.basename(__FILE__).' for more information.');


### PR DESCRIPTION
As we have only one frontal we dont need to show 403 error on production

| Q             | A
| ------------- | ---
| License       | MIT

<!--
Please, carefully read the README before submitting a pull request.
-->
