### PR TITLE
[framework-bundle] Remove the IP check in web/index.php

### DIFF
--- a/symfony/framework-bundle/3.3/web/index.php
+++ b/symfony/framework-bundle/3.3/web/index.php
@@ -18,16 +18,6 @@ if (getenv('APP_DEBUG')) {
     // https://symfony.com/doc/current/book/installation.html#checking-symfony-application-configuration-and-setup
     umask(0000);
 
-    // This check prevents access to debug front controllers that are deployed by accident to production servers.
-    // Feel free to remove this, extend it, or make something more sophisticated.
-    if (isset($_SERVER['HTTP_CLIENT_IP'])
-        || isset($_SERVER['HTTP_X_FORWARDED_FOR'])
-        || !(in_array(@$_SERVER['REMOTE_ADDR'], ['127.0.0.1', '::1']) || PHP_SAPI === 'cli-server')
-    ) {
-        header('HTTP/1.0 403 Forbidden');
-        exit('You are not allowed to access this file. Check '.basename(__FILE__).' for more information.');
-    }
-
     Debug::enable();
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

This PR removes the check blocking access to debug features if `APP_DEBUG` is set and the IP is not a local one because:

* unlike with the old system of front controllers (`app.php` and `app_dev.php`), it's very unlikely that someone will set `APP_DEBUG` to true in production and if the variable isn't set, debug features aren't enabled
* it makes Flex painful to use (by default) in virtualized environments (example with Docker: https://github.com/dunglas/symfony-docker-skeleton/pull/3#issuecomment-310892861)
* the spirit of Flex is to be minimalist by default, this kind of check should be added by the user if he wants it, not removed if he doesn't need it

The goal of this PR is mainly to open the discussion about this.