### PR TITLE
Support alternative bin dirs for the security checker

### DIFF
--- a/sensiolabs/security-checker/4.0/manifest.json
+++ b/sensiolabs/security-checker/4.0/manifest.json
@@ -3,7 +3,7 @@
         "etc/": "%ETC_DIR%/"
     },
     "composer-scripts": {
-        "vendor/bin/security-checker security:check": "php-script"
+        "security-checker security:check": "script"
     },
     "aliases": ["security-check", "security-checker", "sec-checker", "sec-check", "sec-checks"]
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

The auto-scripts entry now relies on the fact that Composer adds the bin-dir in the PATH instead of asking the Flex plugin to run a php-script.

Fixes https://github.com/symfony/flex/issues/109
