### PR TITLE
Remove final attribute from the kernel class

### DIFF
--- a/symfony/framework-bundle/3.3/src/Kernel.php
+++ b/symfony/framework-bundle/3.3/src/Kernel.php
@@ -11,7 +11,7 @@ use Symfony\Component\Routing\RouteCollectionBuilder;
 /**
  * @author Fabien Potencier <fabien@symfony.com>
  */
-final class Kernel extends BaseKernel
+class Kernel extends BaseKernel
 {
     use MicroKernelTrait;
 


### PR DESCRIPTION
The Kernel is declared as `final` which breaks the cache:clear command included in the `framework-bundle`. 

I am not aware of all implication but is there any reason to keep this `final`? It seems the Kernel in the symfony standard edition on the 3.3 branch is not final. 

| Q             | A
| ------------- | ---
| License       | MIT

 Fixes symfony/flex#121