### PR TITLE
[framework-bundle] Set trusted proxies

### DIFF
--- a/symfony/framework-bundle/3.3/manifest.json
+++ b/symfony/framework-bundle/3.3/manifest.json
@@ -14,7 +14,10 @@
     "env": {
         "APP_ENV": "dev",
         "APP_DEBUG": "1",
-        "APP_SECRET": "%generate(secret)%"
+        "APP_SECRET": "%generate(secret)%",
+        "#1": "See https://symfony.com/doc/current/request/load_balancer_reverse_proxy.html",
+        "#TRUSTED_PROXIES": "0.0.0.0/0",
+        "#TRUSTED_HEADERS": "HEADER_FORWARDED"
     },
     "gitignore": [
         ".env",

--- a/symfony/framework-bundle/3.3/public/index.php
+++ b/symfony/framework-bundle/3.3/public/index.php
@@ -21,7 +21,9 @@ if (getenv('APP_DEBUG')) {
     Debug::enable();
 }
 
-// Request::setTrustedProxies(['0.0.0.0/0'], Request::HEADER_FORWARDED);
+if (($trustedProxies = getenv('TRUSTED_PROXIES')) && ($trustedHeaders = getenv('TRUSTED_HEADERS'))) {
+    Request::setTrustedProxies(explode(' ', $trustedProxies), constant(Request::class.'::'.$trustedHeaders));
+}
 
 $kernel = new Kernel(getenv('APP_ENV'), getenv('APP_DEBUG'));
 $request = Request::createFromGlobals();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Ideally, the user should not have to modify `index.php`. This removes one such case.

Space is used as separator, consistent with the `for` loop defined in POSIX shell: http://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_09_04_03