### PR TITLE
Fix default namespace for generated migration classes

### DIFF
--- a/doctrine/doctrine-migrations-bundle/1.2/config/packages/doctrine_migrations.yaml
+++ b/doctrine/doctrine-migrations-bundle/1.2/config/packages/doctrine_migrations.yaml
@@ -1,2 +1,3 @@
 doctrine_migrations:
     dir_name: '%kernel.project_dir%/src/Migrations'
+    namespace: 'App\Migrations'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Currently, migration classes are generate with the default namespace `Application\Migrations`, which means they cannot be autoloaded since the default namespace of Symfony Flex is `App`. This PR fixes it.