### PR TITLE
Fix the prefix of the Twig dev routes

### DIFF
--- a/symfony/twig-bundle/3.3/config/routing/dev/twig.yaml
+++ b/symfony/twig-bundle/3.3/config/routing/dev/twig.yaml
@@ -1,3 +1,3 @@
 _errors:
     resource: '@TwigBundle/Resources/config/routing/errors.xml'
-    prefix:   /_errors
+    prefix:   /_error


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

This prefix has always been `/_error`, in singular (see https://github.com/symfony/symfony-standard/blob/3.3/app/config/routing_dev.yml#L11).

In addition to avoiding a BC break, I think `/_error/404,500,...` reads better than `/_errors/404,500,...`