### PR TITLE
Move Composer scripts requiring the console to its recipe

### DIFF
--- a/symfony/console/3.3/manifest.json
+++ b/symfony/console/3.3/manifest.json
@@ -2,5 +2,9 @@
     "copy-from-recipe": {
         "bin/": "%BIN_DIR%/"
     },
+    "composer-scripts": {
+        "make cache-warmup": "script",
+        "assets:install --symlink --relative %PUBLIC_DIR%": "symfony-cmd"
+    },
     "aliases": ["cli"]
 }

--- a/symfony/framework-bundle/3.3/manifest.json
+++ b/symfony/framework-bundle/3.3/manifest.json
@@ -7,10 +7,6 @@
         "public/": "%PUBLIC_DIR%/",
         "src/": "%SRC_DIR%/"
     },
-    "composer-scripts": {
-        "make cache-warmup": "script",
-        "assets:install --symlink --relative %PUBLIC_DIR%": "symfony-cmd"
-    },
     "env": {
         "APP_ENV": "dev",
         "APP_DEBUG": "1",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Currently, on a fresh Flex install, you get an error when you try to install a package and it is not installed:

```
Using version ^3.3 for symfony/twig-bundle
./composer.json has been updated
Loading composer repositories with package information
Updating dependencies (including require-dev)
Package operations: 3 installs, 0 updates, 0 removals
  - Installing twig/twig (v2.4.3): Loading from cache
  - Installing symfony/twig-bridge (v3.3.5): Loading from cache
  - Installing symfony/twig-bundle (v3.3.5): Loading from cache
Writing lock file
Generating autoload files
Symfony operations: 1 recipe
  - Configuring symfony/twig-bundle (3.3): From github.com/symfony/recipes:master
Executing script make cache-warmup [KO]
 [KO]
Script make cache-warmup returned with error code 2
!!  cannot warmup the cache (needs symfony/console)
!!
!!  make: *** [cache-warmup] Error 1
!!
!!

Installation failed, reverting ./composer.json to its original content.
```

It's even worse when doing a `composer install`: it fails.

This PR moves the addition of scripts requiring Console from the `symfony/framework-bundle` recipe to the `symfony/console` recipe.