### PR TITLE
Rename container.yaml to services.yaml

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -105,11 +105,11 @@ The previous recipe is transformed into the following PHP code:
 ``container`` Configurator
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Adds new container parameters in the ``container.yaml`` file by adding your parameters
-in the ``container`` option.
+Adds new container parameters in the ``services.yaml`` file by adding your
+parameters in the ``container`` option.
 
-This example creates a new ``locale`` container parameter with a default value in your
-container:
+This example creates a new ``locale`` container parameter with a default value
+in your container:
 
 .. code-block:: json
 

--- a/symfony/framework-bundle/3.3/src/Kernel.php
+++ b/symfony/framework-bundle/3.3/src/Kernel.php
@@ -44,7 +44,7 @@ final class Kernel extends BaseKernel
         if (is_dir($confDir.'/packages/'.$this->environment)) {
             $loader->load($confDir.'/packages/'.$this->environment.'/**/*'.self::CONFIG_EXTS, 'glob');
         }
-        $loader->load($confDir.'/container'.self::CONFIG_EXTS, 'glob');
+        $loader->load($confDir.'/services'.self::CONFIG_EXTS, 'glob');
     }
 
     protected function configureRoutes(RouteCollectionBuilder $routes): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

With the changes in #123, we would have the three main way of configuring Symfony using the same naming convention: `services.yaml`, `routes.yaml`, and `bundles.php`.