### PR TITLE
Remove unneeded flag

### DIFF
--- a/symfony/framework-bundle/3.3/Makefile
+++ b/symfony/framework-bundle/3.3/Makefile
@@ -25,7 +25,7 @@ ifndef CONSOLE
 	@${MAKE} serve_as_php
 endif
 	@$(CONSOLE) | grep server:start > /dev/null || ${MAKE} serve_as_php
-	@$(CONSOLE) server:start --docroot=public/
+	@$(CONSOLE) server:start
 
 	@printf "Quit the server with \033[32;49mbin/console server:stop.\033[39m\n"
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

This has been fixed in Symfony directly now.