### PR TITLE
[API Platform] Update the API Platform config to use the new mapping paths

### DIFF
--- a/api-platform/core/2.1/config/packages/api_platform.yaml
+++ b/api-platform/core/2.1/config/packages/api_platform.yaml
@@ -1,3 +1,3 @@
 api_platform:
-    loader_paths:
-        annotation: ['%kernel.project_dir%/src/Entity']
+    mapping:
+        paths: ['%kernel.project_dir%/src/Entity']


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

We recently changed the way to configure resources' paths in API Platform 2.1.0 beta 3, see https://github.com/api-platform/core/pull/1271.
