### PR TITLE
Update the SwiftMailer recipe for dev environment

### DIFF
--- a/symfony/swiftmailer-bundle/2.5/config/packages/dev/swiftmailer.yaml
+++ b/symfony/swiftmailer-bundle/2.5/config/packages/dev/swiftmailer.yaml
@@ -1,2 +1,6 @@
-#swiftmailer:
-    #delivery_address: me@example.com
+# See https://symfony.com/doc/current/email/dev_environment.html
+swiftmailer:
+    # disable the sending of email altogether
+    disable_delivery: true
+    # ... or send all email to a specific address
+    #delivery_addresses: ['me@example.com']


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Proposed changes:

* Disable by default the sending of emails (as we currently do in Symfony 3.x: https://github.com/symfony/symfony-standard/blob/3.3/app/config/config_test.yml)
* Use `delivery_addresses` instead of `delivery_address`
* Added minimal help notes and a link to Symfony Docs
