### PR TITLE
[framework-bundle][console] Introduce APP_DIR environment variable

### DIFF
--- a/symfony/console/3.3/bin/console
+++ b/symfony/console/3.3/bin/console
@@ -17,7 +17,9 @@ if (!class_exists(Application::class)) {
 }
 
 if (!getenv('APP_ENV')) {
-    (new Dotenv())->load(__DIR__.'/../.env');
+    $dotEnv = new Dotenv();
+    $dotEnv->populate(['APP_DIR' => dirname(__DIR__)]);
+    $dotEnv->load(__DIR__.'/../.env');
 }
 
 $input = new ArgvInput();

--- a/symfony/framework-bundle/3.3/public/index.php
+++ b/symfony/framework-bundle/3.3/public/index.php
@@ -9,7 +9,9 @@ require __DIR__.'/../vendor/autoload.php';
 
 // The check is to ensure we don't use .env in production
 if (!getenv('APP_ENV')) {
-    (new Dotenv())->load(__DIR__.'/../.env');
+    $dotEnv = new Dotenv();
+    $dotEnv->populate(['APP_DIR' => dirname(__DIR__)]);
+    $dotEnv->load(__DIR__.'/../.env');
 }
 
 if (getenv('APP_DEBUG')) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

In the Symfony demo application (see https://github.com/symfony/symfony-demo/pull/617) we need to set an absolute path to a database, but we can't get it in the `.env` file. This PR introduces an environment variable which contains the absolute path to the application's folder (it works like the `%kernel.project_dir%` container parameter).

Example:
```sh
# .env
DATABASE_URL="sqlite:///${APP_DIR}/var/data/blog.sqlite"
```
