### PR TITLE
[framework-bundle] fix resources path

### DIFF
--- a/symfony/framework-bundle/3.3/config/services.yaml
+++ b/symfony/framework-bundle/3.3/config/services.yaml
@@ -16,14 +16,14 @@ services:
     # makes classes in src/ available to be used as services
     # this creates a service per class whose id is the fully-qualified class name
     App\:
-        resource: '../../src/*'
+        resource: '../src/*'
         # you can exclude directories or files
         # but if a service is unused, it's removed anyway
-        exclude: '../../src/{Entity,Repository,Tests}'
+        exclude: '../src/{Entity,Repository,Tests}'
 
     # controllers are imported separately to make sure they're public
     # and have a tag that allows actions to type-hint services
     App\Controller\:
-        resource: '../../src/Controller'
+        resource: '../src/Controller'
         public: true
         tags: ['controller.service_arguments']


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

> (2/2) FileLoaderLoadException
> The file "../../src" does not exist (in: /tmp/sf/config) in /tmp/sf/config/services.yaml (which is loaded in resource "/tmp/sf/config/services.yaml").