### PR TITLE
[DoctrineMigrationBundle] Add `namespace` value to doctrine_migrations.yaml

### DIFF
--- a/doctrine/doctrine-migrations-bundle/1.2/config/packages/doctrine_migrations.yaml
+++ b/doctrine/doctrine-migrations-bundle/1.2/config/packages/doctrine_migrations.yaml
@@ -1,2 +1,3 @@
 doctrine_migrations:
     dir_name: '%kernel.project_dir%/src/Migrations'
+    namespace: 'App\Migrations'


### PR DESCRIPTION
Now migrations generated in `Application\Migrations` namespace by default that cause error in autoloader. This PR fix the namespace.

| Q             | A
| ------------- | ---
| License       | MIT

<!--
Please, carefully read the README before submitting a pull request.
-->
