### PR TITLE
Fixed CS of the default front controller

### DIFF
--- a/symfony/framework-bundle/3.3/public/index.php
+++ b/symfony/framework-bundle/3.3/public/index.php
@@ -1,9 +1,9 @@
 <?php
 
 use App\Kernel;
+use Symfony\Component\Debug\Debug;
 use Symfony\Component\Dotenv\Dotenv;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Debug\Debug;
 
 require __DIR__.'/../vendor/autoload.php';
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Let's sort the `use` statements because, otherwise, the default front controller triggers an error when using PHP CS Fixer:

![cs-front-controller](https://user-images.githubusercontent.com/73419/28754446-9d9489fa-7545-11e7-826f-c46bc9e1617f.png)
