### PR TITLE
Revert the change of null to ~

### DIFF
--- a/symfony/framework-bundle/3.3/config/packages/framework.yaml
+++ b/symfony/framework-bundle/3.3/config/packages/framework.yaml
@@ -1,14 +1,14 @@
 framework:
     secret: '%env(APP_SECRET)%'
     #default_locale: en
-    #csrf_protection: ~
+    #csrf_protection: null
     #http_method_override: true
-    #trusted_hosts: ~
+    #trusted_hosts: null
     # https://symfony.com/doc/current/reference/configuration/framework.html#handler-id
     #session:
     #    handler_id: session.handler.native_file
     #    save_path: '%kernel.project_dir%/var/sessions/%kernel.environment%'
-    #esi: ~
-    #fragments: ~
+    #esi: null
+    #fragments: null
     php_errors:
         log: true

--- a/symfony/framework-bundle/3.3/config/packages/test/framework.yaml
+++ b/symfony/framework-bundle/3.3/config/packages/test/framework.yaml
@@ -1,4 +1,4 @@
 framework:
-    test: ~
+    test: null
     session:
         storage_id: session.storage.mock_file

--- a/symfony/routing/3.3/config/packages/routing.yaml
+++ b/symfony/routing/3.3/config/packages/routing.yaml
@@ -1,3 +1,3 @@
 framework:
     router:
-        strict_requirements: ~
+        strict_requirements: null

--- a/symfony/security-bundle/3.3/config/packages/security.yaml
+++ b/symfony/security-bundle/3.3/config/packages/security.yaml
@@ -1,18 +1,18 @@
 security:
     # https://symfony.com/doc/current/book/security.html#where-do-users-come-from-user-providers
     providers:
-        in_memory: { memory: ~ }
+        in_memory: { memory: null }
     firewalls:
         dev:
             pattern: ^/(_(profiler|wdt)|css|images|js)/
             security: false
         main:
-            anonymous: ~
+            anonymous: null
 
             # activate different ways to authenticate
 
-            # http_basic: ~
+            # http_basic: null
             # https://symfony.com/doc/current/book/security.html#a-configuring-how-your-users-will-authenticate
 
-            # form_login: ~
+            # form_login: null
             # https://symfony.com/doc/current/cookbook/security/form_login_setup.html


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

I can't believe that #143 was merged. To me it's **a big step backwards** in the right direction Symfony 4 was heading.

Why? Because in Symfony 4 we're replacing a lot of things that need an explanation for **things that are self-explained**.

Examples?

* "etc/" is a great name for config ... but "config/" is better and needs no explanation. 
* "web/" is a great name for front controllers ... but "public/" is better because it's the standard in the computing industry and it fits multiple use cases, not only web apps.
* "app.php" and "app_dev.php" are great front controller names ... but "index.php" is better and requires no explanation.
* "app.yaml" and "container.yaml" are great names ... but a single "services.yaml" file is better and requires no explanation.
* etc.

So, why should we change the perfect `null` value which requires no explanation, by the strange `~` symbol that requires explaining and learning it.

*(You may tell me that every existing Symfony developer knows the meaning of `~`. That's true ... but we're not making Symfony 4 only for the existing Symfony developers. We want to onboard new developers).*