### PR TITLE
Fallback to line formatter on missing cli dumper

### DIFF
--- a/symfony/monolog-bundle/3.1/config/packages/dev/monolog.php
+++ b/symfony/monolog-bundle/3.1/config/packages/dev/monolog.php
@@ -2,6 +2,7 @@
 
 use Symfony\Component\Config\Resource\ClassExistenceResource;
 use Symfony\Component\Console\Application;
+use Symfony\Component\VarDumper\Dumper\CliDumper;
 
 $handlers = [
     'main' => [
@@ -29,6 +30,9 @@ if (class_exists(Application::class)) {
         'process_psr_3_messages' => false,
         'channels' => ['!event', '!doctrine', '!console'],
     ];
+    if (!class_exists(CliDumper::class)) {
+        $handlers['console']['formatter'] = 'monolog.formatter.line';
+    }
 }
 
 $container->loadFromExtension('monolog', [


### PR DESCRIPTION
The ConsoleFormatter is not so great when it does not come configured
with a dumper. A better fix might be to provide a poor man's dumper when
the var dumper component is not installed.

| Q             | A
| ------------- | ---
| License       | MIT

<!--
Please, carefully read the README before submitting a pull request.
-->
