### PR TITLE
Remove the Exception folder from autowiring configuration

### DIFF
--- a/symfony/framework-bundle/3.3/config/services.yaml
+++ b/symfony/framework-bundle/3.3/config/services.yaml
@@ -19,7 +19,7 @@ services:
         resource: '../src/*'
         # you can exclude directories or files
         # but if a service is unused, it's removed anyway
-        exclude: '../src/{Entity,Repository,Tests}'
+        exclude: '../src/{Entity,Repository,Exception,Tests}'
 
     # controllers are imported separately to make sure they're public
     # and have a tag that allows actions to type-hint services


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

By default, the `Exception` folder is also registered for Autowiring. It should be not be the case. 
As the folder exists in many projects, it might be worth adding it to the exclusion filter.