### PR TITLE
Use escaping rather than quoting

### DIFF
--- a/doctrine/doctrine-bundle/1.6/manifest.json
+++ b/doctrine/doctrine-bundle/1.6/manifest.json
@@ -10,6 +10,6 @@
         "#1": "Format described at http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url",
         "#2": "For a sqlite database, use: \"sqlite:///%kernel.project_dir%/var/data.db\"",
         "#3": "Set \"serverVersion\" to your server version to avoid edge-case exceptions and extra database calls",
-        "DATABASE_URL": "\"mysql://root@127.0.0.1:3306/symfony?charset=utf8mb4&serverVersion=5.7\""
+        "DATABASE_URL": "mysql://root@127.0.0.1:3306/symfony?charset=utf8mb4\\&serverVersion=5.7"
     }
 }


### PR DESCRIPTION
This should make the recipe compatible with docker-compose's .env files,
which will keep quotes in the variable:

> There is no special handling of quotation marks (i.e. they will be
part of the VAL, you have been warned ;) ).

Refs #74

| Q             | A
| ------------- | ---
| License       | MIT

<!--
Please, carefully read the README before submitting a pull request.
-->
