### PR TITLE
Remove final from Kernel

### DIFF
--- a/symfony/framework-bundle/3.3/src/Kernel.php
+++ b/symfony/framework-bundle/3.3/src/Kernel.php
@@ -11,7 +11,7 @@ use Symfony\Component\Routing\RouteCollectionBuilder;
 /**
  * @author Fabien Potencier <fabien@symfony.com>
  */
-final class Kernel extends BaseKernel
+class Kernel extends BaseKernel
 {
     use MicroKernelTrait;
 

--- a/symfony/framework-bundle/3.3/src/Kernel.php
+++ b/symfony/framework-bundle/3.3/src/Kernel.php
@@ -8,9 +8,6 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel as BaseKernel;
 use Symfony\Component\Routing\RouteCollectionBuilder;
 
-/**
- * @author Fabien Potencier <fabien@symfony.com>
- */
 class Kernel extends BaseKernel
 {
     use MicroKernelTrait;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Remove the `final` keyword for the `Kernel` class. First, I don't think this is needed, but more important, that's why `cache:clear` with warmup does not work with Flex.
