### PR TITLE
Dont use getenv(), use $_SERVER instead

### DIFF
--- a/behat/symfony2-extension/2.1/features/bootstrap/bootstrap.php
+++ b/behat/symfony2-extension/2.1/features/bootstrap/bootstrap.php
@@ -3,6 +3,6 @@
 use Symfony\Component\Dotenv\Dotenv;
 
 // The check is to ensure we don't use .env in production
-if (!getenv('APP_ENV')) {
+if (!isset($_SERVER['APP_ENV'])) {
     (new Dotenv())->load(__DIR__.'/../../.env');
 }

--- a/symfony/console/3.3/bin/console
+++ b/symfony/console/3.3/bin/console
@@ -16,13 +16,13 @@ if (!class_exists(Application::class)) {
     throw new \RuntimeException('You need to add "symfony/framework-bundle" as a Composer dependency.');
 }
 
-if (!getenv('APP_ENV')) {
+if (!isset($_SERVER['APP_ENV'])) {
     (new Dotenv())->load(__DIR__.'/../.env');
 }
 
 $input = new ArgvInput();
-$env = $input->getParameterOption(['--env', '-e'], getenv('APP_ENV') ?: 'dev');
-$debug = getenv('APP_DEBUG') !== '0' && !$input->hasParameterOption(['--no-debug', '']);
+$env = $input->getParameterOption(['--env', '-e'], $_SERVER['APP_ENV'] ?? 'dev');
+$debug = ($_SERVER['APP_DEBUG'] ?? true) !== '0' && !$input->hasParameterOption(['--no-debug', '']);
 
 if ($debug && class_exists(Debug::class)) {
     Debug::enable();

--- a/symfony/framework-bundle/3.3/public/index.php
+++ b/symfony/framework-bundle/3.3/public/index.php
@@ -8,11 +8,11 @@ use Symfony\Component\HttpFoundation\Request;
 require __DIR__.'/../vendor/autoload.php';
 
 // The check is to ensure we don't use .env in production
-if (!getenv('APP_ENV')) {
+if (!isset($_SERVER['APP_ENV'])) {
     (new Dotenv())->load(__DIR__.'/../.env');
 }
 
-if (getenv('APP_DEBUG')) {
+if ($_SERVER['APP_DEBUG'] ?? true) {
     // WARNING: You should setup permissions the proper way!
     // REMOVE the following PHP line and read
     // https://symfony.com/doc/current/book/installation.html#checking-symfony-application-configuration-and-setup
@@ -23,7 +23,7 @@ if (getenv('APP_DEBUG')) {
 
 // Request::setTrustedProxies(['0.0.0.0/0'], Request::HEADER_FORWARDED);
 
-$kernel = new Kernel(getenv('APP_ENV'), getenv('APP_DEBUG'));
+$kernel = new Kernel($_SERVER['APP_ENV'] ?? 'dev', $_SERVER['APP_DEBUG'] ?? true);
 $request = Request::createFromGlobals();
 $response = $kernel->handle($request);
 $response->send();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

As described in https://github.com/laravel/framework/issues/7354 and linked issues, getenv() is not thread safe - this can lead to issue with concurrent requests, on Windows especially.