### PR TITLE
Escape spaces in CONSOLE path

### DIFF
--- a/symfony/framework-bundle/3.3/Makefile
+++ b/symfony/framework-bundle/3.3/Makefile
@@ -1,4 +1,4 @@
-CONSOLE := $(shell which bin/console)
+CONSOLE := $(shell which bin/console | sed 's/ /\\ /g)
 sf_console:
 ifndef CONSOLE
 	@printf "Run \033[32mcomposer require cli\033[39m to install the Symfony console.\n"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Currently if we run make command in spaced path it will return error: Command not found. This PR fix that by escaping spaces in path using sed command.