### PR TITLE
Change the default mailer configuration

### DIFF
--- a/symfony/swiftmailer-bundle/2.5/config/packages/dev/swiftmailer.yaml
+++ b/symfony/swiftmailer-bundle/2.5/config/packages/dev/swiftmailer.yaml
@@ -1,6 +1,4 @@
 # See https://symfony.com/doc/current/email/dev_environment.html
 swiftmailer:
-    # disable the sending of email altogether
-    disable_delivery: true
-    # ... or send all email to a specific address
+    #  send all emails to a specific address
     #delivery_addresses: ['me@example.com']

--- a/symfony/swiftmailer-bundle/2.5/manifest.json
+++ b/symfony/swiftmailer-bundle/2.5/manifest.json
@@ -7,8 +7,9 @@
     },
     "env": {
         "#1": "For Gmail as a transport, use: \"gmail://username:password@localhost\"",
-        "#2": "To disable sending emails, use: \"null://localhost\"",
-        "MAILER_URL": "smtp://localhost:25?encryption=&auth_mode="
+        "#2": "For a generic SMTP server, use: \"smtp://localhost:25?encryption=&auth_mode=\"",
+        "#3": "Delivery is disabled by default via \"null://localhost\"",
+        "MAILER_URL": "null://localhost"
     },
     "aliases": ["mailer", "mail"]
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

The current configuration for the mailer is done in 2 different places:

* `.env` configures the mailer to use localhost as a transport;
* but the `dev` environment disables delivery.

That's very confusing. As `.env` is for dev, I propose to use a `null` transport by default (which disables delivery) and remove `disable_delivery` in the `dev` configuration. That makes the configuration centralized in one file instead of two (and yes, I had a WTF moment with this :)).

I'm not sure about the test environment as we don't have a good story about test env + env vars for now, so I haven't changed it for now.
