### PR TITLE
Make it possible create environment-specific services and parameters.

### DIFF
--- a/symfony/framework-bundle/3.3/src/Kernel.php
+++ b/symfony/framework-bundle/3.3/src/Kernel.php
@@ -42,6 +42,7 @@ class Kernel extends BaseKernel
             $loader->load($confDir.'/packages/'.$this->environment.'/**/*'.self::CONFIG_EXTS, 'glob');
         }
         $loader->load($confDir.'/services'.self::CONFIG_EXTS, 'glob');
+        $loader->load($confDir.'/services_'.$this->environment.self::CONFIG_EXTS, 'glob');
     }
 
     protected function configureRoutes(RouteCollectionBuilder $routes): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

<!--
Please, carefully read the README before submitting a pull request.
-->

I ran into issues trying to create parameters based on `%env()%` during compile-time. This made sense and was expected once I thought about it more.

In discussion with @nicolas-grekas, the solution I was looking for was being able to set parameters directly based on environment. However, `parameters.ini` is no longer a thing going forward.

Since there was no easy or obvious way to do this, we discussed adding `/conf/services_{envs}.yaml` as optional files that can be read to configure the container's services and parameters based on the appropriate environment.

This should allow me to configure `/conf/services_dev.yaml` to be specific to my local develompent environment without having any impact on anyone else running my application.