### PR TITLE
Fix Doctrine migrations default configuration

### DIFF
--- a/doctrine/doctrine-migrations-bundle/1.2/config/packages/doctrine_migrations.yaml
+++ b/doctrine/doctrine-migrations-bundle/1.2/config/packages/doctrine_migrations.yaml
@@ -1,2 +1,5 @@
 doctrine_migrations:
     dir_name: '%kernel.project_dir%/src/Migrations'
+    # namespace is arbitrary but should be different from App\Migrations
+    # as migrations classes should NOT be autoloaded
+    namespace: DoctrineMigrations

--- a/symfony/framework-bundle/3.3/config/services.yaml
+++ b/symfony/framework-bundle/3.3/config/services.yaml
@@ -19,7 +19,7 @@ services:
         resource: '../src/*'
         # you can exclude directories or files
         # but if a service is unused, it's removed anyway
-        exclude: '../src/{Entity,Repository,Tests}'
+        exclude: '../src/{Entity,Migrations,Repository,Tests}'
 
     # controllers are imported separately to make sure they're public
     # and have a tag that allows actions to type-hint services


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Alternative to #87

Migration classes are very different from "regular" classes. They should not be autoloaded (and they cannot be autoloaded anyway if you are using `organize_migrations: BY_YEAR` as the namespace generated by Doctrine does not take into account sub-directories).

So, to sump up, even if Doctrine migration classes look like regular classes, they are not.

That said, I propose to make some tweaks to the current configuration to have a better default:

 * I think renaming `Migrations/` to `Migration/` should not be done (see #87) as having `Migrations` is a signal that this directory is not like the other ones.

 * Excluding `Migrations/` from container auto-configuration is required to avoid errors (classes do not follow PSR-4).

 * To signal that classes are not PSR-4, I propose to set the default namespace to `DoctrineMigrations`. The library default is `Application\Migrations`, which is too close to `App\Migrations`, which gives a false sense of PSR-4 misconfiguration.

People migrating from Symfony 2/3 must change the namespace to this new default, or update the configuration.
