### PR TITLE
checking for .env file exists instead of using the env variable

### DIFF
--- a/behat/symfony2-extension/2.1/features/bootstrap/bootstrap.php
+++ b/behat/symfony2-extension/2.1/features/bootstrap/bootstrap.php
@@ -3,6 +3,6 @@
 use Symfony\Component\Dotenv\Dotenv;
 
 // The check is to ensure we don't use .env in production
-if (!isset($_SERVER['APP_ENV'])) {
+if (file_exists(__DIR__.'/../../.env')) {
     (new Dotenv())->load(__DIR__.'/../../.env');
 }

--- a/symfony/console/3.3/bin/console
+++ b/symfony/console/3.3/bin/console
@@ -16,7 +16,7 @@ if (!class_exists(Application::class)) {
     throw new \RuntimeException('You need to add "symfony/framework-bundle" as a Composer dependency.');
 }
 
-if (!isset($_SERVER['APP_ENV'])) {
+if (file_exists(__DIR__.'/../.env')) {
     (new Dotenv())->load(__DIR__.'/../.env');
 }
 

--- a/symfony/framework-bundle/3.3/public/index.php
+++ b/symfony/framework-bundle/3.3/public/index.php
@@ -8,7 +8,7 @@ use Symfony\Component\HttpFoundation\Request;
 require __DIR__.'/../vendor/autoload.php';
 
 // The check is to ensure we don't use .env in production
-if (!isset($_SERVER['APP_ENV'])) {
+if (file_exists(__DIR__.'/../.env')) {
     (new Dotenv())->load(__DIR__.'/../.env');
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Hi guys!

This comes from a workshop I gave last week. One user - from using Laravel - already had an `APP_ENV` environment variable defined in their VM. Because of this, their `.env` file was being completely ignored, which was difficult to track down.

I think it's much simpler if we require the `.env` file simply if it exists. If you agree, there's one other change to make (https://github.com/symfony/flex/blob/d68d28624e3ec972d6887cca06f7df5e07ba03a9/src/Configurator/MakefileConfigurator.php#L34), which I can do.

Cheers!