### PR TITLE
Remove unneeded configuration

### DIFF
--- a/sensio/framework-extra-bundle/4.0/config/packages/framework_extra.yaml
+++ b/sensio/framework-extra-bundle/4.0/config/packages/framework_extra.yaml
@@ -1,2 +1,0 @@
-framework:
-    annotations: true

--- a/sensio/framework-extra-bundle/4.0/manifest.json
+++ b/sensio/framework-extra-bundle/4.0/manifest.json
@@ -2,8 +2,5 @@
     "bundles": {
         "Sensio\\Bundle\\FrameworkExtraBundle\\SensioFrameworkExtraBundle": ["all"]
     },
-    "copy-from-recipe": {
-        "config/": "%CONFIG_DIR%/"
-    },
     "aliases": ["annotations", "annotation", "annot", "annots"]
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

As of 3.3, Symfony automatically registers the annotations when installed.
