### PR TITLE
[FrameworkBundle] Add a env vars to configure trusted proxies and hosts

### DIFF
--- a/symfony/framework-bundle/3.3/config/packages/framework.yaml
+++ b/symfony/framework-bundle/3.3/config/packages/framework.yaml
@@ -3,7 +3,6 @@ framework:
     #default_locale: en
     #csrf_protection: ~
     #http_method_override: true
-    #trusted_hosts: ~
 
     # uncomment this entire section to enable sessions
     #session:

--- a/symfony/framework-bundle/3.3/manifest.json
+++ b/symfony/framework-bundle/3.3/manifest.json
@@ -14,8 +14,8 @@
     "env": {
         "APP_ENV": "dev",
         "APP_SECRET": "%generate(secret)%",
-        "#APP_TRUSTED_PROXIES": "127.0.0.1,127.0.0.2",
-        "#APP_TRUSTED_HOSTS": "localhost,example.com"
+        "#TRUSTED_PROXIES": "127.0.0.1,127.0.0.2",
+        "#TRUSTED_HOSTS": "localhost,example.com"
     },
     "gitignore": [
         ".env",

--- a/symfony/framework-bundle/3.3/manifest.json
+++ b/symfony/framework-bundle/3.3/manifest.json
@@ -13,7 +13,9 @@
     },
     "env": {
         "APP_ENV": "dev",
-        "APP_SECRET": "%generate(secret)%"
+        "APP_SECRET": "%generate(secret)%",
+        "#APP_TRUSTED_PROXIES": "127.0.0.1,127.0.0.2",
+        "#APP_TRUSTED_HOSTS": "localhost,example.com"
     },
     "gitignore": [
         ".env",

--- a/symfony/framework-bundle/3.3/public/index.php
+++ b/symfony/framework-bundle/3.3/public/index.php
@@ -21,11 +21,11 @@ if ($_SERVER['APP_DEBUG'] ?? ('prod' !== ($_SERVER['APP_ENV'] ?? 'dev'))) {
     Debug::enable();
 }
 
-if ($trustedProxies = $_SERVER['APP_TRUSTED_PROXIES'] ?? false) {
+if ($trustedProxies = $_SERVER['TRUSTED_PROXIES'] ?? false) {
     Request::setTrustedProxies(explode(',', $trustedProxies), Request::HEADER_X_FORWARDED_ALL ^ Request::HEADER_X_FORWARDED_HOST);
 }
 
-if ($trustedHosts = $_SERVER['APP_TRUSTED_HOSTS'] ?? false) {
+if ($trustedHosts = $_SERVER['TRUSTED_HOSTS'] ?? false) {
     Request::setTrustedHosts(explode(',', $trustedHosts));
 }
 

--- a/symfony/framework-bundle/3.3/public/index.php
+++ b/symfony/framework-bundle/3.3/public/index.php
@@ -21,7 +21,13 @@ if ($_SERVER['APP_DEBUG'] ?? ('prod' !== ($_SERVER['APP_ENV'] ?? 'dev'))) {
     Debug::enable();
 }
 
-// Request::setTrustedProxies(['0.0.0.0/0'], Request::HEADER_FORWARDED);
+if ($trustedProxies = $_SERVER['APP_TRUSTED_PROXIES'] ?? false) {
+    Request::setTrustedProxies(explode(',', $trustedProxies), Request::HEADER_X_FORWARDED_ALL ^ Request::HEADER_X_FORWARDED_HOST);
+}
+
+if ($trustedHosts = $_SERVER['APP_TRUSTED_HOSTS'] ?? false) {
+    Request::setTrustedHosts(explode(',', $trustedHosts));
+}
 
 $kernel = new Kernel($_SERVER['APP_ENV'] ?? 'dev', $_SERVER['APP_DEBUG'] ?? ('prod' !== ($_SERVER['APP_ENV'] ?? 'dev')));
 $request = Request::createFromGlobals();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Add two convenient environment variables to set trusted proxies and hosts: `APP_TRUSTED_PROXIES` and `APP_TRUSTED_HOSTS`.

This very convenient when deploying a Symfony app to a cloud platform using load balancers (exemple: Google Container Engine) and/or when using Docker for local development (ex: HTTP/2 reverse proxy, Varnish...). For an example of real world usage see api-platform/api-platform#422.

Backported from api-platform/api-platform#422
