### PR TITLE
Add env var to specify the dotenv file to use

### DIFF
--- a/symfony/framework-bundle/3.3/public/index.php
+++ b/symfony/framework-bundle/3.3/public/index.php
@@ -9,7 +9,8 @@ require __DIR__.'/../vendor/autoload.php';
 
 // The check is to ensure we don't use .env in production
 if (!isset($_SERVER['APP_ENV'])) {
-    (new Dotenv())->load(__DIR__.'/../.env');
+    $envFile = $_SERVER['ENV_FILE'] ?? '.env';
+    (new Dotenv())->load(__DIR__.'/../' . $envFile);
 }
 
 if ($_SERVER['APP_DEBUG'] ?? false) {

--- a/symfony/framework-bundle/3.3/public/index.php
+++ b/symfony/framework-bundle/3.3/public/index.php
@@ -10,7 +10,7 @@ require __DIR__.'/../vendor/autoload.php';
 // The check is to ensure we don't use .env in production
 if (!isset($_SERVER['APP_ENV'])) {
     $envFile = $_SERVER['ENV_FILE'] ?? '.env';
-    (new Dotenv())->load(__DIR__.'/../' . $envFile);
+    (new Dotenv())->load(__DIR__.'/../'.$envFile);
 }
 
 if ($_SERVER['APP_DEBUG'] ?? false) {


### PR DESCRIPTION
| Q | A |
|-- | -- |
|License | MIT |



I have a use case where I will test different environments locally, e.g. dev, uat, test etc. It would be helpful to be able to store the env vars in different files rather having to constantly update one file.