### PR TITLE
fix CONSOLE path setting

### DIFF
--- a/symfony/framework-bundle/3.3/Makefile
+++ b/symfony/framework-bundle/3.3/Makefile
@@ -1,4 +1,9 @@
-CONSOLE := $(shell printf %q "`which bin/console`")
+ifeq ($(shell test -e bin/console && echo -n yes), yes)
+	CONSOLE=bin/console
+else
+	CONSOLE=''
+endif
+
 sf_console:
 ifeq ($(CONSOLE), '')
 	@printf "Run \033[32mcomposer require cli\033[39m to install the Symfony console.\n"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

This fix would fix the issue described in https://github.com/symfony/skeleton/issues/23 on my (ubuntu 16.04) mashine. No clue if there is a more elegant way to do it, but this one works. The former line gave me something equal to an empty string, but it was no empty string. Strange.