### PR TITLE
[DoctrineBundle] resolve parameters inside DATABASE_URL

### DIFF
--- a/doctrine/doctrine-bundle/1.6/config/packages/doctrine.yaml
+++ b/doctrine/doctrine-bundle/1.6/config/packages/doctrine.yaml
@@ -1,6 +1,7 @@
 doctrine:
     dbal:
-        url: '%env(DATABASE_URL)%'
+        # With Symfony 3.3, remove the `resolve:` prefix
+        url: '%env(resolve:DATABASE_URL)%'
     orm:
         auto_generate_proxy_classes: '%kernel.debug%'
         naming_strategy: doctrine.orm.naming_strategy.underscore


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Not ready to merge yet, because this relies on DI >=3.4.
If we want to allow this with 3.3, we might patch DoctrineBundle.
But before doing so, what about just moving to require >=3.4 for all Symfony components?
Any other idea?