### PR TITLE
Removing security test config (reverts 131)

### DIFF
--- a/symfony/security-bundle/3.3/config/packages/security.yaml
+++ b/symfony/security-bundle/3.3/config/packages/security.yaml
@@ -6,7 +6,6 @@ security:
         dev:
             pattern: ^/(_(profiler|wdt)|css|images|js)/
             security: false
-        # if you change the name of the firewall, update it in the packages/test/security.yaml file too
         main:
             anonymous: ~
 

--- a/symfony/security-bundle/3.3/config/packages/test/security.yaml
+++ b/symfony/security-bundle/3.3/config/packages/test/security.yaml
@@ -1,7 +1,0 @@
-# This configuration simplifies testing URLs protected by the security mechanism
-# See https://symfony.com/doc/current/cookbook/testing/http_authentication.html
-security:
-    firewalls:
-        # replace 'main' by the name of your own firewall
-        main:
-            http_basic: ~


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

This reverts #131. See: https://github.com/symfony/recipes/pull/131#issuecomment-333964855

And while I think this should be reverted, I'd still like to brainstorm ways to make testing with authentication easier :).
