### PR TITLE
Use the native PHP session handler by default

### DIFF
--- a/symfony/framework-bundle/3.3/config/packages/framework.yaml
+++ b/symfony/framework-bundle/3.3/config/packages/framework.yaml
@@ -6,7 +6,7 @@ framework:
     #trusted_hosts: ~
     # https://symfony.com/doc/current/reference/configuration/framework.html#handler-id
     #session:
-    #    The native PHP session handler will be used
+    #    # The native PHP session handler will be used
     #    handler_id: ~
     #esi: ~
     #fragments: ~

--- a/symfony/framework-bundle/3.3/config/packages/framework.yaml
+++ b/symfony/framework-bundle/3.3/config/packages/framework.yaml
@@ -6,8 +6,8 @@ framework:
     #trusted_hosts: ~
     # https://symfony.com/doc/current/reference/configuration/framework.html#handler-id
     #session:
-    #    handler_id: session.handler.native_file
-    #    save_path: '%kernel.project_dir%/var/sessions/%kernel.environment%'
+    #    The native PHP session handler will be used
+    #    handler_id: ~
     #esi: ~
     #fragments: ~
     php_errors:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

In 2015, we changed from the native PHP session handler to the file based one, which stores in `var/session`. Here is the history: https://github.com/symfony/symfony-standard/pull/904

In that PR, we (imo) narrowly decided to do that (versus keeping with the native session handler), and one big reason was because the SE had a `var/session` dir (the argument being... if we have that dir, shouldn't we use it?). @xabbuh also had one argument about conflicting sessions with multiple PHP apps on one machine (https://github.com/symfony/symfony-standard/pull/904#issuecomment-163192748). Is that actually a real issue?

There are 2 big advantages to using the native PHP session handler:
* This is one less directory that you need to worry about making writeable, making deploying and local development less error-prone
* To make it writeable, in practice, people will commonly deploy and make `var/sessions` 777. This is not ideal security. PHP's native file session handler automatically handles this in a more secure way.

Cheers!