### PR TITLE
Always using umask(0000) in debug mode

### DIFF
--- a/symfony/console/3.3/bin/console
+++ b/symfony/console/3.3/bin/console
@@ -7,7 +7,6 @@ use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Debug\Debug;
 use Symfony\Component\Dotenv\Dotenv;
 
-umask(0000);
 set_time_limit(0);
 
 require __DIR__.'/../vendor/autoload.php';
@@ -24,8 +23,12 @@ $input = new ArgvInput();
 $env = $input->getParameterOption(['--env', '-e'], $_SERVER['APP_ENV'] ?? 'dev');
 $debug = ($_SERVER['APP_DEBUG'] ?? true) !== '0' && !$input->hasParameterOption(['--no-debug', '']);
 
-if ($debug && class_exists(Debug::class)) {
-    Debug::enable();
+if ($debug) {
+    umask(0000);
+
+    if (class_exists(Debug::class)) {
+        Debug::enable();
+    }
 }
 
 $kernel = new Kernel($env, $debug);

--- a/symfony/framework-bundle/3.3/public/index.php
+++ b/symfony/framework-bundle/3.3/public/index.php
@@ -13,9 +13,6 @@ if (!isset($_SERVER['APP_ENV'])) {
 }
 
 if ($_SERVER['APP_DEBUG'] ?? false) {
-    // WARNING: You should setup permissions the proper way!
-    // REMOVE the following PHP line and read
-    // https://symfony.com/doc/current/book/installation.html#checking-symfony-application-configuration-and-setup
     umask(0000);
 
     Debug::enable();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

In debug mode, cache files need to be writeable by everyone for a good dev experience. In `prod`, they do not (and the way the cache system is built these days makes this very easy - yay!).

This change is consistent with how `index.php` already exists: enable `umask` for debug, but not otherwise. This gives great DX for dev, and forces users to setup permissions properly for prod.

I've also proposed removing the warning about permissions... basically because if this is for debug mode only, is there really an issue with `umask(0000)`? There are many things in debug mode you would not want to do/expose in prod mode (e.g. web debug toolbar). This is just another one of those.

P.S. I wasn't sure why there is a `class_exists(Debug::class)` in `console`, but not in `index.php`, but I left that alone.