### PR TITLE
[DoctrineBundle] Enable caches by default on prod

### DIFF
--- a/doctrine/doctrine-bundle/1.6/config/packages/prod/doctrine.yaml
+++ b/doctrine/doctrine-bundle/1.6/config/packages/prod/doctrine.yaml
@@ -1,5 +1,31 @@
 doctrine:
     orm:
-        #metadata_cache_driver: apcu
-        #result_cache_driver: apcu
-        #query_cache_driver: apcu
+        metadata_cache_driver:
+            type: service
+            id: doctrine.system_cache_provider
+        query_cache_driver:
+            type: service
+            id: doctrine.system_cache_provider
+        result_cache_driver:
+            type: service
+            id: doctrine.result_cache_provider
+
+services:
+    doctrine.result_cache_provider:
+        class: Symfony\Component\Cache\DoctrineProvider
+        public: false
+        arguments:
+            - '@doctrine.result_cache_pool'
+    doctrine.system_cache_provider:
+        class: Symfony\Component\Cache\DoctrineProvider
+        public: false
+        arguments:
+            - '@doctrine.system_cache_pool'
+
+framework:
+    cache:
+        pools:
+            doctrine.result_cache_pool:
+                adapter: cache.app
+            doctrine.system_cache_pool:
+                adapter: cache.system


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

by leveraging Symfony's cache pools, we can provide a default cache configuration for Doctrine.
Using "cache.system" for metadata and query caches will make them cleareable with a simple "cache:clear", even when APCu is used as a backend - and will auto-select the best available backend, usually APCu, or OPcache.
The result cache is not a system cache, so it should not be cleared on cache:clear, and should be shared when eg a Redis cache is configured for cache.app.

ping @weaverryan as you were interested into this.