### PR TITLE
Remove templating as an alias

### DIFF
--- a/symfony/twig-bundle/3.3/manifest.json
+++ b/symfony/twig-bundle/3.3/manifest.json
@@ -6,5 +6,5 @@
         "config/": "%CONFIG_DIR%/",
         "templates/": "templates/"
     },
-    "aliases": ["twig", "template", "templates", "templating"]
+    "aliases": ["twig", "template", "templates"]
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

`templating` being also `symfony/templating`, when using `composer req templating`, it's ambiguous. Right now, the alias takes precedence, which means that you get an error like "Templating component is not installed" and it's kind of difficult to debug. So, let's remove the alias.

