### PR TITLE
Add PHP CS Fixer recipe

### DIFF
--- a/friendsofphp/php-cs-fixer/2.2/.php_cs.dist
+++ b/friendsofphp/php-cs-fixer/2.2/.php_cs.dist
@@ -1,6 +1,5 @@
 <?php
 
-// adjust configuration to your needs
 return PhpCsFixer\Config::create()
     ->setRules([
         '@Symfony' => true,

--- a/friendsofphp/php-cs-fixer/2.2/.php_cs.dist
+++ b/friendsofphp/php-cs-fixer/2.2/.php_cs.dist
@@ -1,0 +1,9 @@
+<?php
+
+// adjust configuration to your needs
+return PhpCsFixer\Config::create()
+    ->setRules([
+        '@Symfony' => true,
+        'array_syntax' => ['syntax' => 'short'],
+    ])
+;

--- a/friendsofphp/php-cs-fixer/2.2/manifest.json
+++ b/friendsofphp/php-cs-fixer/2.2/manifest.json
@@ -1,0 +1,9 @@
+{
+    "copy-from-recipe": {
+        ".php_cs.dist": ".php_cs.dist"
+    },
+    "gitignore": [
+        ".php_cs",
+        ".php_cs.cache"
+    ]
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

I let myself add proposal for main repo, as PHP CS Fixer came from Sensio Labs.
If you disagree, simple close this PR :+1:

I added recipe for PHP CS Fixer 2.2, as it's oldest supported version. Recipe is valid for any `^2.2`