### PR TITLE
Enable container.autowiring.strict_mode

### DIFF
--- a/symfony/framework-bundle/3.3/src/Kernel.php
+++ b/symfony/framework-bundle/3.3/src/Kernel.php
@@ -36,6 +36,7 @@ class Kernel extends BaseKernel
 
     protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader)
     {
+        $container->setParameter('container.autowiring.strict_mode', true);
         $confDir = dirname(__DIR__).'/config';
         $loader->load($confDir.'/packages/*'.self::CONFIG_EXTS, 'glob');
         if (is_dir($confDir.'/packages/'.$this->environment)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

To preserve BC, autowiring still wires things in hybrid 2.8/3.3 modes.
But 2.8 mode is really a foot gun.
I propose to add a new parameter in SF3.4, to opt-out of this 2.8 mode, and enable this strict mode for all new projects.
WDYT?
