### PR TITLE
Do not enable session in test env by default

### DIFF
--- a/symfony/framework-bundle/3.3/config/packages/test/framework.yaml
+++ b/symfony/framework-bundle/3.3/config/packages/test/framework.yaml
@@ -1,4 +1,4 @@
 framework:
     test: ~
-    session:
-        storage_id: session.storage.mock_file
+    #session:
+    #    storage_id: session.storage.mock_file


### PR DESCRIPTION
Session system is not enabled by default in prod & dev. see https://github.com/symfony/recipes/blob/master/symfony/framework-bundle/3.3/config/packages/framework.yaml#L8
So it should also not be enabled by default in test env.

| Q             | A
| ------------- | ---
| License       | MIT


