### PR TITLE
FrameworkBundle kernel should be compatible

### DIFF
--- a/symfony/framework-bundle/3.3/src/Kernel.php
+++ b/symfony/framework-bundle/3.3/src/Kernel.php
@@ -14,12 +14,12 @@ class Kernel extends BaseKernel
 
     const CONFIG_EXTS = '.{php,xml,yaml,yml}';
 
-    public function getCacheDir(): string
+    public function getCacheDir()
     {
         return dirname(__DIR__).'/var/cache/'.$this->environment;
     }
 
-    public function getLogDir(): string
+    public function getLogDir()
     {
         return dirname(__DIR__).'/var/log';
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Hello,

This PR fix an issue when creating a new `symfony/skeleton` project.

`Fatal error: Declaration of App\Kerne_::getCacheDir() must be compatible with App\Kernel::getCacheDir(): string`

The exception appear when configuring `symfony/framework-bundle`

Hope it's helpful.