### PR TITLE
Use getenv() instead of $_SERVER

### DIFF
--- a/symfony/framework-bundle/3.3/public/index.php
+++ b/symfony/framework-bundle/3.3/public/index.php
@@ -8,11 +8,11 @@ use Symfony\Component\HttpFoundation\Request;
 require __DIR__.'/../vendor/autoload.php';
 
 // The check is to ensure we don't use .env in production
-if (!isset($_SERVER['APP_ENV'])) {
+if (!getenv('APP_ENV')) {
     (new Dotenv())->load(__DIR__.'/../.env');
 }
 
-if ($_SERVER['APP_DEBUG'] ?? false) {
+if (getenv('APP_DEBUG')) {
     umask(0000);
 
     Debug::enable();
@@ -20,7 +20,7 @@ if ($_SERVER['APP_DEBUG'] ?? false) {
 
 // Request::setTrustedProxies(['0.0.0.0/0'], Request::HEADER_FORWARDED);
 
-$kernel = new Kernel($_SERVER['APP_ENV'] ?? 'dev', $_SERVER['APP_DEBUG'] ?? false);
+$kernel = new Kernel(getenv('APP_ENV') ?: 'dev', getenv('APP_DEBUG'));
 $request = Request::createFromGlobals();
 $response = $kernel->handle($request);
 $response->send();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

From documentation:
> There is no guarantee that every web server will provide any of these; servers may omit some, or provide others not listed here.

For example, PHP built-in web server doesn't copy environment variables into `$_SERVER` array.
More straight approach is to use `getenv` function as it's purpose is clear.