### PR TITLE
Remove "Repository" directory from being ignored in service auto-registration

### DIFF
--- a/symfony/framework-bundle/3.3/config/services.yaml
+++ b/symfony/framework-bundle/3.3/config/services.yaml
@@ -19,7 +19,7 @@ services:
         resource: '../src/*'
         # you can exclude directories or files
         # but if a service is unused, it's removed anyway
-        exclude: '../src/{Entity,Migrations,Repository,Tests}'
+        exclude: '../src/{Entity,Migrations,Tests}'
 
     # controllers are imported separately to make sure they
     # have the tag that allows actions to type-hint services


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| License       | MIT

See https://github.com/doctrine/DoctrineBundle/pull/727

But also, this directory was always safe to auto-register. If they cannot be autowired, unless you try to *use* them as services, they will be discarded without showing the autowiring failure.