### PR TITLE
Add checks for Dotenv before calling it

### DIFF
--- a/behat/symfony2-extension/2.1/features/bootstrap/bootstrap.php
+++ b/behat/symfony2-extension/2.1/features/bootstrap/bootstrap.php
@@ -4,5 +4,8 @@ use Symfony\Component\Dotenv\Dotenv;
 
 // The check is to ensure we don't use .env in production
 if (!isset($_SERVER['APP_ENV'])) {
+    if (!class_exists(Dotenv::class)) {
+        throw new \RuntimeException('APP_ENV environment variable is not defined. You need to define environment variables for configuration or add "symfony/dotenv" as a Composer dependency to load variables from a .env file.');
+    }
     (new Dotenv())->load(__DIR__.'/../../.env');
 }

--- a/symfony/console/3.3/bin/console
+++ b/symfony/console/3.3/bin/console
@@ -16,6 +16,9 @@ if (!class_exists(Application::class)) {
 }
 
 if (!isset($_SERVER['APP_ENV'])) {
+    if (!class_exists(Dotenv::class)) {
+        throw new \RuntimeException('APP_ENV environment variable is not defined. You need to define environment variables for configuration or add "symfony/dotenv" as a Composer dependency to load variables from a .env file.');
+    }
     (new Dotenv())->load(__DIR__.'/../.env');
 }
 

--- a/symfony/framework-bundle/3.3/public/index.php
+++ b/symfony/framework-bundle/3.3/public/index.php
@@ -9,6 +9,9 @@ require __DIR__.'/../vendor/autoload.php';
 
 // The check is to ensure we don't use .env in production
 if (!isset($_SERVER['APP_ENV'])) {
+    if (!class_exists(Dotenv::class)) {
+        throw new \RuntimeException('APP_ENV environment variable is not defined. You need to define environment variables for configuration or add "symfony/dotenv" as a Composer dependency to load variables from a .env file.');
+    }
     (new Dotenv())->load(__DIR__.'/../.env');
 }
 


### PR DESCRIPTION
`composer install --no-dev` fails when Dotenv is a dev dependency (which
it is in skeleton) and you're running in an environment without an
APP_ENV variable set (say you're testing prod-like settings locally).

After that `bin/console help` also fails, as does
`bin/console --env=prod help` (as Dotenv is loaded before the argument
can be read).

`APP_ENV=prod bin/console help` works but instead lets avoid needing to
remember that by only trying to load Dotenv if it actually exists.

Strictly speaking this is only required for console, however I have
placed the check in the other places Dotenv is included for consistency.

See https://github.com/symfony/skeleton/issues/32 for some initial pondering relating to this.

| Q             | A
| ------------- | ---
| License       | MIT