### PR TITLE
Added DataFixtures in excludes Folder

### DIFF
--- a/symfony/framework-bundle/3.3/config/services.yaml
+++ b/symfony/framework-bundle/3.3/config/services.yaml
@@ -19,7 +19,7 @@ services:
         resource: '../src/*'
         # you can exclude directories or files
         # but if a service is unused, it's removed anyway
-        exclude: '../src/{Entity,Migrations,Tests}'
+        exclude: '../src/{Entity,Migrations,Tests,DataFixtures}'
 
     # controllers are imported separately to make sure they
     # have the tag that allows actions to type-hint services


### PR DESCRIPTION
I added this folder because if you have DataFixtures in AppKernel in environment Dev mode, it returns error in the deploy when I apply --no-dev config. And we don't need autoload this folder.
So.. is a bug.
(It is the same PR as https://github.com/symfony/symfony-standard/pull/1115)