### PR TITLE
[RFC] Revert the move of translations/ into config/

### DIFF
--- a/symfony/translation/3.3/config/packages/translation.yaml
+++ b/symfony/translation/3.3/config/packages/translation.yaml
@@ -2,6 +2,6 @@ framework:
     default_locale: '%locale%'
     translator:
         paths:
-            - '%kernel.project_dir%/config/translations'
+            - '%kernel.project_dir%/translations'
         fallbacks:
             - '%locale%'

--- a/symfony/translation/3.3/manifest.json
+++ b/symfony/translation/3.3/manifest.json
@@ -1,6 +1,7 @@
 {
     "copy-from-recipe": {
-        "config/": "%CONFIG_DIR%/"
+        "config/": "%CONFIG_DIR%/",
+        "translations/": "translations/"
     },
     "container": {
         "locale": "en"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

I propose to revert the changes done in #249. These are my reasons for doing so ... but of course there could be strong reasons too to not do it.

-----

We've been using `translations/` for months ... and two days ago it was suddenly changed to `config/translations/`. There wasn't a public discussion about it. Not even a single comment in #249. The proposal was made at 18:12 CET and merged at 18:50 CET. Just 38 minutes!!

-----

The full dir structure of a modern Symfony project is:

```
assets/
bin/
config/
public/
src/
templates/
tests/
translations/
var/
vendor/
```

Removing `translations/` won't make it significantly more compact. However, hiding it inside `config/` has a serious drawback: instead of being self-explanatory (*"translations are stored in the translations/ dir. done!"*) you need to explain things: *"translations are stored inside the config/ dir"*

-----

Related to the previous point, it's very debatable to consider translations as part of the config. Some people do, others don't. In fact, the way translations are often used in Symfony, they are part of templates ... so they should be stored in `templates/translations/` instead of `config/`

-----

Historically, translations were never part of Symfony's config (`app/config/`) but of Symfony's resources (`app/Resources/translations/`).

-----

Discoverability of this directory is important because it's one of those dirs that could be browsed by non backend developers (such as `assets/` and `templates/`).