### PR TITLE
Change the default route to API platform to /api

### DIFF
--- a/api-platform/core/2.1/config/routes/api_platform.yaml
+++ b/api-platform/core/2.1/config/routes/api_platform.yaml
@@ -1,3 +1,4 @@
 api_platform:
     resource: .
     type: api_platform
+    prefix: /api


### PR DESCRIPTION
If not, it overrides the / namespace, which is not so nice.

| Q             | A
| ------------- | ---
| License       | MIT

<!--
Please, carefully read the README before submitting a pull request.
-->
