### PR TITLE
[RFC] Added a recipe for the Workflow component

### DIFF
--- a/symfony/workflow/3.3/config/packages/workflow.yaml
+++ b/symfony/workflow/3.3/config/packages/workflow.yaml
@@ -1,0 +1,2 @@
+framework:
+    workflows: ~

--- a/symfony/workflow/3.3/manifest.json
+++ b/symfony/workflow/3.3/manifest.json
@@ -1,0 +1,5 @@
+{
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Just a proposal. Reasons:

* it would allow to better separate the app config;
* it improves discoverability (you no longer would have to guess that workflows were configured in config/packages/framework.yaml);
* it aligns with Flex philosophy (small and stand alone config files instead of just 1 big config file).