### PR TITLE
Adding HTTPlug pack

### DIFF
--- a/php-http/httplug-bundle/1.6/config/packages/httplug.yaml
+++ b/php-http/httplug-bundle/1.6/config/packages/httplug.yaml
@@ -1,0 +1,14 @@
+httplug:
+    plugins:
+        redirect:
+            preserve_header: true
+
+    discovery:
+        client: 'auto'
+
+    clients:
+        app:
+            http_methods_client: true
+            plugins:
+                - 'httplug.plugin.logger'
+                - 'httplug.plugin.redirect'

--- a/php-http/httplug-bundle/1.6/config/packages/httplug.yaml
+++ b/php-http/httplug-bundle/1.6/config/packages/httplug.yaml
@@ -10,5 +10,5 @@ httplug:
         app:
             http_methods_client: true
             plugins:
-                - 'httplug.plugin.logger'
+                - 'httplug.plugin.content_length'
                 - 'httplug.plugin.redirect'

--- a/php-http/httplug-bundle/1.6/manifest.json
+++ b/php-http/httplug-bundle/1.6/manifest.json
@@ -1,0 +1,8 @@
+{
+    "bundles": {
+        "Http\\HttplugBundle\\HttplugBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    }
+}

--- a/php-http/httplug-pack/1.0/manifest.json
+++ b/php-http/httplug-pack/1.0/manifest.json
@@ -1,0 +1,3 @@
+{
+    "aliases": ["http", "http-client", "httplug"]
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

I know this repo should be for packages endorsed by  "Symfony Core Team". There are a few Symfony core team developers active in HTTPlug and I really think this package should be in the "official" recipe repository. 

The HTTPlug bundle and client abstraction should be the default/recommended way to send HTTP request in a Symfony application. This pack includes Guzzles PSR7 implementation and the lightweight [curl client](https://github.com/php-http/curl-client) from php-http. 

FYI, early next year we will have a PSR for HTTP client that are compatible with HTTPlug. 

See docs: http://docs.php-http.org/en/latest/index.html
See bundle docs: http://docs.php-http.org/en/latest/integrations/symfony-bundle.html

------------

I added WIP because I want to test this first. 