### PR TITLE
Always set Doctrine server version & platform

### DIFF
--- a/doctrine/doctrine-bundle/1.6/config/packages/doctrine.yaml
+++ b/doctrine/doctrine-bundle/1.6/config/packages/doctrine.yaml
@@ -1,13 +1,9 @@
 parameters:
-    # update these for your app
-    doctrine.database_server: mysql
-    doctrine.server_version: 5.7
-
     # adds a fallback URL if the env var is not set
     # this is useful to allow you to run cache:warmup
     # even when your environment variables don't yet exist
     # you should not need to change this value
-    DATABASE_URL: '%doctrine.database_server%://'
+    env(DATABASE_URL): '%doctrine.database_server%://'
 
 doctrine:
     dbal:

--- a/doctrine/doctrine-bundle/1.6/config/packages/doctrine.yaml
+++ b/doctrine/doctrine-bundle/1.6/config/packages/doctrine.yaml
@@ -10,6 +10,7 @@ doctrine:
         # configure these for your database server
         driver: 'pdo_mysql'
         server_version: '5.7'
+        charset: utf8mb4
 
         # With Symfony 3.3, remove the `resolve:` prefix
         url: '%env(resolve:DATABASE_URL)%'

--- a/doctrine/doctrine-bundle/1.6/config/packages/doctrine.yaml
+++ b/doctrine/doctrine-bundle/1.6/config/packages/doctrine.yaml
@@ -1,8 +1,19 @@
+parameters:
+    # update these for your app
+    doctrine.database_server: mysql
+    doctrine.server_version: 5.7
+
+    # adds a fallback URL if the env var is not set
+    # this is useful to allow you to run cache:warmup
+    # even when your environment variables don't yet exist
+    # you should not need to change this value
+    DATABASE_URL: '%doctrine.database_server%://'
+
 doctrine:
     dbal:
         # With Symfony 3.3, remove the `resolve:` prefix
         url: '%env(resolve:DATABASE_URL)%'
-        server_version: 5.7
+        server_version: '%doctrine.server_version%'
     orm:
         auto_generate_proxy_classes: '%kernel.debug%'
         naming_strategy: doctrine.orm.naming_strategy.underscore

--- a/doctrine/doctrine-bundle/1.6/config/packages/doctrine.yaml
+++ b/doctrine/doctrine-bundle/1.6/config/packages/doctrine.yaml
@@ -1,15 +1,18 @@
 parameters:
-    # adds a fallback URL if the env var is not set
-    # this is useful to allow you to run cache:warmup
-    # even when your environment variables don't yet exist
-    # you should not need to change this value
-    env(DATABASE_URL): '%doctrine.database_server%://'
+    # Adds a fallback DATABASE_URL if the env var is not set.
+    # This allows you to run cache:warmup even if your
+    # environment variables are not available yet.
+    # You should not need to change this value.
+    env(DATABASE_URL): ''
 
 doctrine:
     dbal:
+        # configure these for your database server
+        driver: 'pdo_mysql'
+        server_version: '5.7'
+
         # With Symfony 3.3, remove the `resolve:` prefix
         url: '%env(resolve:DATABASE_URL)%'
-        server_version: '%doctrine.server_version%'
     orm:
         auto_generate_proxy_classes: '%kernel.debug%'
         naming_strategy: doctrine.orm.naming_strategy.underscore

--- a/doctrine/doctrine-bundle/1.6/config/packages/doctrine.yaml
+++ b/doctrine/doctrine-bundle/1.6/config/packages/doctrine.yaml
@@ -2,6 +2,7 @@ doctrine:
     dbal:
         # With Symfony 3.3, remove the `resolve:` prefix
         url: '%env(resolve:DATABASE_URL)%'
+        server_version: 5.7
     orm:
         auto_generate_proxy_classes: '%kernel.debug%'
         naming_strategy: doctrine.orm.naming_strategy.underscore

--- a/doctrine/doctrine-bundle/1.6/manifest.json
+++ b/doctrine/doctrine-bundle/1.6/manifest.json
@@ -10,6 +10,6 @@
         "#1": "Format described at http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url",
         "#2": "For an SQLite database, use: \"sqlite:///%kernel.project_dir%/var/data.db\"",
         "#3": "Set \"serverVersion\" to your server version to avoid edge-case exceptions and extra database calls",
-        "DATABASE_URL": "mysql://db_user:db_password@127.0.0.1:3306/db_name?charset=utf8mb4&serverVersion=5.7"
+        "DATABASE_URL": "mysql://db_user:db_password@127.0.0.1:3306/db_name?charset=utf8mb4"
     }
 }

--- a/doctrine/doctrine-bundle/1.6/manifest.json
+++ b/doctrine/doctrine-bundle/1.6/manifest.json
@@ -11,5 +11,9 @@
         "#2": "For an SQLite database, use: \"sqlite:///%kernel.project_dir%/var/data.db\"",
         "#3": "Set \"serverVersion\" to your server version to avoid edge-case exceptions and extra database calls",
         "DATABASE_URL": "mysql://db_user:db_password@127.0.0.1:3306/db_name?charset=utf8mb4"
+    },
+    "container": {
+        "doctrine.database_server": "mysql",
+        "doctrine.server_version": "5.7"
     }
 }

--- a/doctrine/doctrine-bundle/1.6/manifest.json
+++ b/doctrine/doctrine-bundle/1.6/manifest.json
@@ -9,7 +9,7 @@
     "env": {
         "#1": "Format described at http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url",
         "#2": "For an SQLite database, use: \"sqlite:///%kernel.project_dir%/var/data.db\"",
-        "#3": "Set \"serverVersion\" to your server version to avoid edge-case exceptions and extra database calls",
+        "#3": "Configure your db driver and server_version in config/packages/doctrine.yaml",
         "DATABASE_URL": "mysql://db_user:db_password@127.0.0.1:3306/db_name"
     }
 }

--- a/doctrine/doctrine-bundle/1.6/manifest.json
+++ b/doctrine/doctrine-bundle/1.6/manifest.json
@@ -11,9 +11,5 @@
         "#2": "For an SQLite database, use: \"sqlite:///%kernel.project_dir%/var/data.db\"",
         "#3": "Set \"serverVersion\" to your server version to avoid edge-case exceptions and extra database calls",
         "DATABASE_URL": "mysql://db_user:db_password@127.0.0.1:3306/db_name?charset=utf8mb4"
-    },
-    "container": {
-        "doctrine.database_server": "mysql",
-        "doctrine.server_version": "5.7"
     }
 }

--- a/doctrine/doctrine-bundle/1.6/manifest.json
+++ b/doctrine/doctrine-bundle/1.6/manifest.json
@@ -10,6 +10,6 @@
         "#1": "Format described at http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url",
         "#2": "For an SQLite database, use: \"sqlite:///%kernel.project_dir%/var/data.db\"",
         "#3": "Set \"serverVersion\" to your server version to avoid edge-case exceptions and extra database calls",
-        "DATABASE_URL": "mysql://db_user:db_password@127.0.0.1:3306/db_name?charset=utf8mb4"
+        "DATABASE_URL": "mysql://db_user:db_password@127.0.0.1:3306/db_name"
     }
 }

--- a/doctrine/doctrine-bundle/1.6/post-install.txt
+++ b/doctrine/doctrine-bundle/1.6/post-install.txt
@@ -3,4 +3,6 @@
 <bg=blue;fg=white>                         </>
 
   * Modify your DATABASE_URL config in <fg=green>.env</>
-  * Check your server_version in <fg=green>config/packages/doctrine.yaml</>
+
+  * Configure the <fg=green>database_server</> (mysql) and
+    <fg=green>server_version</fg> (5.7) in <fg=green>config/packages/doctrine.yaml</>

--- a/doctrine/doctrine-bundle/1.6/post-install.txt
+++ b/doctrine/doctrine-bundle/1.6/post-install.txt
@@ -5,4 +5,4 @@
   * Modify your DATABASE_URL config in <fg=green>.env</>
 
   * Configure the <fg=green>database_server</> (mysql) and
-    <fg=green>server_version</fg> (5.7) in <fg=green>config/packages/doctrine.yaml</>
+    <fg=green>server_version</fg> (5.7) in <fg=green>config/services.yaml</>

--- a/doctrine/doctrine-bundle/1.6/post-install.txt
+++ b/doctrine/doctrine-bundle/1.6/post-install.txt
@@ -1,8 +1,8 @@
-<bg=blue;fg=white>                         </>
-<bg=blue;fg=white> Configure your database </>
-<bg=blue;fg=white>                         </>
+<bg=blue;fg=white>                      </>
+<bg=blue;fg=white> Next: Configuration  </>
+<bg=blue;fg=white>                      </>
 
   * Modify your DATABASE_URL config in <fg=green>.env</>
 
-  * Configure the <fg=green>database_server</> (mysql) and
-    <fg=green>server_version</fg> (5.7) in <fg=green>config/services.yaml</>
+  * Configure the <fg=green>driver</> (mysql) and
+    <fg=green>server_version</fg> (5.7) in <fg=green>config/packages/doctrine.yaml</>

--- a/doctrine/doctrine-bundle/1.6/post-install.txt
+++ b/doctrine/doctrine-bundle/1.6/post-install.txt
@@ -1,6 +1,6 @@
-<bg=blue;fg=white>                      </>
-<bg=blue;fg=white> Next: Configuration  </>
-<bg=blue;fg=white>                      </>
+<bg=blue;fg=white>                     </>
+<bg=blue;fg=white> Next: Configuration </>
+<bg=blue;fg=white>                     </>
 
   * Modify your DATABASE_URL config in <fg=green>.env</>
 

--- a/doctrine/doctrine-bundle/1.6/post-install.txt
+++ b/doctrine/doctrine-bundle/1.6/post-install.txt
@@ -1,0 +1,6 @@
+<bg=blue;fg=white>                         </>
+<bg=blue;fg=white> Configure your database </>
+<bg=blue;fg=white>                         </>
+
+  * Modify your DATABASE_URL config in <fg=green>.env</>
+  * Check your server_version in <fg=green>config/packages/doctrine.yaml</>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

In order to run `cache:warmup`, you need to set the server platform and server version. I believe this can be accomplished by using some fake string like `DATABASE_URL: 'mysql://?server_version=5.7`

In this PR, I attempt to make the `DATABASE_URL` *truly* optional during `cache:warmup`. I do this by committing the server (e.g. mysql) and version (e.g. 5.7) into a config file. This allows us to create a fallback when needed.

On the downside, `doctrine.yaml` looks a little strange. Also, I suppose it might be less obvious if you forget to specify `DATABASE_URL` on production (because your connection will fail vs a `Missing DATABASE_URL environment variable` error).

On the upside, you can once again run `cache:warmup` with no environment variables at all (very nice for PAAS).
