### PR TITLE
Ignoring 404 errors in the production logs by default

### DIFF
--- a/symfony/monolog-bundle/3.1/config/packages/prod/monolog.yaml
+++ b/symfony/monolog-bundle/3.1/config/packages/prod/monolog.yaml
@@ -4,6 +4,9 @@ monolog:
             type: fingers_crossed
             action_level: error
             handler: nested
+            excluded_404s:
+                # regex: exclude all 404 errors from the logs
+                - ^/
         nested:
             type: stream
             path: "%kernel.logs_dir%/%kernel.environment%.log"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Unless someone has a compelling argument against this, I think it makes sense to be opinionated and not log 404 errors in production by default.