### PR TITLE
Exclude DataFixtures/ from the autowired services

### DIFF
--- a/symfony/framework-bundle/3.3/config/services.yaml
+++ b/symfony/framework-bundle/3.3/config/services.yaml
@@ -19,7 +19,7 @@ services:
         resource: '../src/*'
         # you can exclude directories or files
         # but if a service is unused, it's removed anyway
-        exclude: '../src/{Entity,Migrations,Tests}'
+        exclude: '../src/{DataFixtures,Entity,Migrations,Tests}'
 
     # controllers are imported separately to make sure they
     # have the tag that allows actions to type-hint services


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

This was proposed in #250 and #251 but closed without merging. But it looks like a needed change. In the Symfony Demo we also exclude this dir to avoid errors. See https://github.com/symfony/demo/blob/e186324d39c43bd0d251ab5c201a4444f3c84f3a/config/services.yaml#L31