### PR TITLE
Making it more clear how to enable sessions

### DIFF
--- a/symfony/framework-bundle/3.3/config/packages/framework.yaml
+++ b/symfony/framework-bundle/3.3/config/packages/framework.yaml
@@ -4,10 +4,12 @@ framework:
     #csrf_protection: ~
     #http_method_override: true
     #trusted_hosts: ~
-    # https://symfony.com/doc/current/reference/configuration/framework.html#handler-id
+
+    # uncomment this entire section to enable sessions
     #session:
-    #    # The native PHP session handler will be used
+    #    # With this config, PHP's native session handling is used
     #    handler_id: ~
+
     #esi: ~
     #fragments: ~
     php_errors:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Hey guys!

Today, I saw someone accidentally enable sessions with this config:

```yml
framework:
    session: ~
    #    # The native PHP session handler will be used
    #    handler_id: ~
```

This mean that their app tried to store sessions in `var/`, and things got weird (especially because it was on Vagrant). This change is to make it as obvious as possible that you should uncomment all *three* lines to get the recommended behavior.

Cheers!
