### PR TITLE
[DoctrineBundle] Proposing utf table options

### DIFF
--- a/doctrine/doctrine-bundle/1.6/config/packages/doctrine.yaml
+++ b/doctrine/doctrine-bundle/1.6/config/packages/doctrine.yaml
@@ -2,6 +2,10 @@ doctrine:
     dbal:
         # With Symfony 3.3, remove the `resolve:` prefix
         url: '%env(resolve:DATABASE_URL)%'
+
+        default_table_options:
+            charset: utf8
+            collate: utf8_unicode_ci
     orm:
         auto_generate_proxy_classes: '%kernel.debug%'
         naming_strategy: doctrine.orm.naming_strategy.underscore


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

In #258, I propose putting the database `charset` into `doctrine.yaml` instead of having it in the `DATABASE_URL`. While updating the Doctrine docs, I noticed we also recommend setting the `default_table_options`.

Question: If `charset` is set to `utf8mb4` under `doctrine.dbal`, does the user also need to set these table options, or is it redundant? If it is not redundant, then I'd like to propose this change and properly set people up with UTF8 out-of-the-box.