### PR TITLE
Update full manifest.json example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -313,32 +313,32 @@ one used by ``symfony/framework-bundle``:
 
 .. code-block:: json
 
-    {
-        "bundles": {
-            "Symfony\\Bundle\\FrameworkBundle\\FrameworkBundle": ["all"]
-        },
-        "copy-from-recipe": {
-            "config/": "%CONFIG_DIR%/",
-            "public/": "%PUBLIC_DIR%/",
-            "src/": "%SRC_DIR%/"
-        },
-        "composer-scripts": {
-            "make cache-warmup": "script",
-            "assets:install --symlink --relative %PUBLIC_DIR%": "symfony-cmd"
-        },
-        "env": {
-            "APP_ENV": "dev",
-            "APP_DEBUG": "1",
-            "APP_SECRET": "%generate(secret)%"
-        },
-        "gitignore": [
-            ".env",
-            "/public/bundles/"
-            "/var/",
-            "/vendor/"
-        ]
-    }
 
+{
+    "bundles": {
+        "Symfony\\Bundle\\FrameworkBundle\\FrameworkBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/",
+        "public/": "%PUBLIC_DIR%/",
+        "src/": "%SRC_DIR%/"
+    },
+    "composer-scripts": {
+        "cache:clear": "symfony-cmd",
+        "assets:install --symlink --relative %PUBLIC_DIR%": "symfony-cmd"
+    },
+    "env": {
+        "APP_ENV": "dev",
+        "APP_DEBUG": "1",
+        "APP_SECRET": "%generate(secret)%"
+    },
+    "gitignore": [
+        ".env",
+        "/public/bundles/",
+        "/var/",
+        "/vendor/"
+    ]
+}
 .. _`Symfony Flex`: https://github.com/symfony/flex
 .. _`contrib repository`: https://github.com/symfony/recipes-contrib
 .. _`Symfony Console styles and colors`: https://symfony.com/doc/current/console/coloring.html

--- a/README.rst
+++ b/README.rst
@@ -314,31 +314,31 @@ one used by ``symfony/framework-bundle``:
 .. code-block:: json
 
 
-{
-    "bundles": {
-        "Symfony\\Bundle\\FrameworkBundle\\FrameworkBundle": ["all"]
-    },
-    "copy-from-recipe": {
-        "config/": "%CONFIG_DIR%/",
-        "public/": "%PUBLIC_DIR%/",
-        "src/": "%SRC_DIR%/"
-    },
-    "composer-scripts": {
-        "cache:clear": "symfony-cmd",
-        "assets:install --symlink --relative %PUBLIC_DIR%": "symfony-cmd"
-    },
-    "env": {
-        "APP_ENV": "dev",
-        "APP_DEBUG": "1",
-        "APP_SECRET": "%generate(secret)%"
-    },
-    "gitignore": [
-        ".env",
-        "/public/bundles/",
-        "/var/",
-        "/vendor/"
-    ]
-}
+    {
+        "bundles": {
+            "Symfony\\Bundle\\FrameworkBundle\\FrameworkBundle": ["all"]
+        },
+        "copy-from-recipe": {
+            "config/": "%CONFIG_DIR%/",
+            "public/": "%PUBLIC_DIR%/",
+            "src/": "%SRC_DIR%/"
+        },
+        "composer-scripts": {
+            "cache:clear": "symfony-cmd",
+            "assets:install --symlink --relative %PUBLIC_DIR%": "symfony-cmd"
+        },
+        "env": {
+            "APP_ENV": "dev",
+            "APP_DEBUG": "1",
+            "APP_SECRET": "%generate(secret)%"
+        },
+        "gitignore": [
+            ".env",
+            "/public/bundles/",
+            "/var/",
+            "/vendor/"
+        ]
+    }
 .. _`Symfony Flex`: https://github.com/symfony/flex
 .. _`contrib repository`: https://github.com/symfony/recipes-contrib
 .. _`Symfony Console styles and colors`: https://symfony.com/doc/current/console/coloring.html

--- a/README.rst
+++ b/README.rst
@@ -313,7 +313,6 @@ one used by ``symfony/framework-bundle``:
 
 .. code-block:: json
 
-
     {
         "bundles": {
             "Symfony\\Bundle\\FrameworkBundle\\FrameworkBundle": ["all"]
@@ -339,6 +338,7 @@ one used by ``symfony/framework-bundle``:
             "/vendor/"
         ]
     }
+
 .. _`Symfony Flex`: https://github.com/symfony/flex
 .. _`contrib repository`: https://github.com/symfony/recipes-contrib
 .. _`Symfony Console styles and colors`: https://symfony.com/doc/current/console/coloring.html


### PR DESCRIPTION
The example `manifest.json` from `symfony/framwork-bundle` is a little outdated, uses `make` etc..

| Q             | A
| ------------- | ---
| License       | MIT

<!--
Please, carefully read the README before submitting a pull request.
-->
