### PR TITLE
Removing \ which does not work for XML

### DIFF
--- a/doctrine/doctrine-bundle/1.6/config/packages/doctrine.yaml
+++ b/doctrine/doctrine-bundle/1.6/config/packages/doctrine.yaml
@@ -23,5 +23,5 @@ doctrine:
                 is_bundle: false
                 type: annotation
                 dir: '%kernel.project_dir%/src/Entity'
-                prefix: 'App\Entity\'
+                prefix: 'App\Entity'
                 alias: App


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

With annotations, the code seems to work with or without the trailing `\`. But if you change this to `type: xml`, then you *must* remove the trailing `\`.

So, let's remove it - it makes changing to XML easier... if you're into that sorta thing.

Thanks!
