### PR TITLE
Prefer simple-phpunit over direct phpunit deps

### DIFF
--- a/phpunit/phpunit/4.7/manifest.json
+++ b/phpunit/phpunit/4.7/manifest.json
@@ -2,5 +2,7 @@
     "copy-from-recipe": {
         "phpunit.xml.dist": "phpunit.xml.dist"
     },
-    "aliases": ["phpunit"]
+    "gitignore": [
+        "/phpunit.xml"
+    ]
 }

--- a/phpunit/phpunit/4.7/phpunit.xml.dist
+++ b/phpunit/phpunit/4.7/phpunit.xml.dist
@@ -21,4 +21,8 @@
             <directory>tests/</directory>
         </testsuite>
     </testsuites>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
 </phpunit>

--- a/phpunit/phpunit/4.7/post-install.txt
+++ b/phpunit/phpunit/4.7/post-install.txt
@@ -1,0 +1,2 @@
+Adding <comment>phpunit/phpunit</> as a dependency is <comment>discouraged</>.
+You should require <fg=green>simple-phpunit</> instead.

--- a/symfony/phpunit-bridge/3.3/bin/phpunit
+++ b/symfony/phpunit-bridge/3.3/bin/phpunit
@@ -1,0 +1,18 @@
+#!/usr/bin/env php
+<?php
+
+if (!file_exists(dirname(__DIR__).'/vendor/symfony/phpunit-bridge/bin/simple-phpunit')) {
+    echo "Unable to find the `simple-phpunit` script in `vendor/symfony/phpunit-bridge/bin/`.\n";
+    exit(1);
+}
+if (false === getenv('SYMFONY_PHPUNIT_REMOVE')) {
+    putenv('SYMFONY_PHPUNIT_REMOVE=symfony/yaml');
+}
+if (false === getenv('SYMFONY_PHPUNIT_VERSION')) {
+    putenv('SYMFONY_PHPUNIT_VERSION=6.4');
+}
+if (false === getenv('SYMFONY_PHPUNIT_DIR')) {
+    putenv('SYMFONY_PHPUNIT_DIR='.__DIR__.'/.phpunit');
+}
+
+require dirname(__DIR__).'/vendor/symfony/phpunit-bridge/bin/simple-phpunit';

--- a/symfony/phpunit-bridge/3.3/manifest.json
+++ b/symfony/phpunit-bridge/3.3/manifest.json
@@ -1,9 +1,10 @@
 {
     "copy-from-recipe": {
+        "bin/": "%BIN_DIR%/",
         "phpunit.xml.dist": "phpunit.xml.dist"
     },
     "gitignore": [
         "/phpunit.xml"
     ],
-    "aliases": ["simple-phpunit"]
+    "aliases": ["phpunit", "simple-phpunit"]
 }

--- a/symfony/phpunit-bridge/3.3/phpunit.xml.dist
+++ b/symfony/phpunit-bridge/3.3/phpunit.xml.dist
@@ -21,4 +21,8 @@
             <directory>tests/</directory>
         </testsuite>
     </testsuites>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
 </phpunit>

--- a/symfony/phpunit-bridge/3.3/post-install.txt
+++ b/symfony/phpunit-bridge/3.3/post-install.txt
@@ -1,0 +1,1 @@
+Run <comment>php bin/phpunit</> to launch your test suite.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Several changes to have a better phpunit integration:

- ~~move `phpunit.xml.dist` to framework bundle so that a global phpunit works, and env vars are correctly added to it from the beginning~~
- add `SymfonyTestsListener` to `phpunit.xml.dist` so that using phpunit directly still enables the bridge (if the bridge is not installed, phpunit just ignores the listener)
- recommend installing `simple-phpunit` when `phpunit/phpunit` is installed
- add `bin/phpunit` helper script to run phpunit when simple-phpunit is installed (borrowed from [our own in symfony/symfony](https://github.com/symfony/symfony/blob/master/phpunit))