### PR TITLE
[WIP] made hardcoded paths configurable

### DIFF
--- a/api-platform/core/2.1/config/packages/api_platform.yaml
+++ b/api-platform/core/2.1/config/packages/api_platform.yaml
@@ -1,3 +1,3 @@
 api_platform:
     mapping:
-        paths: ['%kernel.project_dir%/src/Entity']
+        paths: ['%kernel.project_dir%/%SRC_DIR%/Entity']

--- a/doctrine/doctrine-bundle/1.6/config/packages/doctrine.yaml
+++ b/doctrine/doctrine-bundle/1.6/config/packages/doctrine.yaml
@@ -22,6 +22,6 @@ doctrine:
             App:
                 is_bundle: false
                 type: annotation
-                dir: '%kernel.project_dir%/src/Entity'
+                dir: '%kernel.project_dir%/%SRC_DIR%/Entity'
                 prefix: 'App\Entity'
                 alias: App

--- a/doctrine/doctrine-bundle/1.6/manifest.json
+++ b/doctrine/doctrine-bundle/1.6/manifest.json
@@ -8,7 +8,7 @@
     },
     "env": {
         "#1": "Format described at http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url",
-        "#2": "For an SQLite database, use: \"sqlite:///%kernel.project_dir%/var/data.db\"",
+        "#2": "For an SQLite database, use: \"sqlite:///%kernel.project_dir%/%VAR_DIR%/data.db\"",
         "#3": "Configure your db driver and server_version in config/packages/doctrine.yaml",
         "DATABASE_URL": "mysql://db_user:db_password@127.0.0.1:3306/db_name"
     }

--- a/doctrine/doctrine-migrations-bundle/1.2/config/packages/doctrine_migrations.yaml
+++ b/doctrine/doctrine-migrations-bundle/1.2/config/packages/doctrine_migrations.yaml
@@ -1,5 +1,5 @@
 doctrine_migrations:
-    dir_name: '%kernel.project_dir%/src/Migrations'
+    dir_name: '%kernel.project_dir%/%SRC_DIR%/Migrations'
     # namespace is arbitrary but should be different from App\Migrations
     # as migrations classes should NOT be autoloaded
     namespace: DoctrineMigrations

--- a/symfony/framework-bundle/3.3/config/services.yaml
+++ b/symfony/framework-bundle/3.3/config/services.yaml
@@ -16,13 +16,13 @@ services:
     # makes classes in src/ available to be used as services
     # this creates a service per class whose id is the fully-qualified class name
     App\:
-        resource: '../src/*'
+        resource: '../%SRC_DIR%/*'
         # you can exclude directories or files
         # but if a service is unused, it's removed anyway
-        exclude: '../src/{DataFixtures,Entity,Migrations,Tests}'
+        exclude: '../%SRC_DIR%/{DataFixtures,Entity,Migrations,Tests}'
 
     # controllers are imported separately to make sure they
     # have the tag that allows actions to type-hint services
     App\Controller\:
-        resource: '../src/Controller'
+        resource: '../%SRC_DIR%/Controller'
         tags: ['controller.service_arguments']

--- a/symfony/framework-bundle/3.3/src/Kernel.php
+++ b/symfony/framework-bundle/3.3/src/Kernel.php
@@ -16,17 +16,17 @@ class Kernel extends BaseKernel
 
     public function getCacheDir()
     {
-        return $this->getProjectDir().'/var/cache/'.$this->environment;
+        return $this->getProjectDir().'/%VAR_DIR%/cache/'.$this->environment;
     }
 
     public function getLogDir()
     {
-        return $this->getProjectDir().'/var/log';
+        return $this->getProjectDir().'/%VAR_DIR%/log';
     }
 
     public function registerBundles()
     {
-        $contents = require $this->getProjectDir().'/config/bundles.php';
+        $contents = require $this->getProjectDir().'/%CONFIG_DIR%/bundles.php';
         foreach ($contents as $class => $envs) {
             if (isset($envs['all']) || isset($envs[$this->environment])) {
                 yield new $class();
@@ -38,7 +38,7 @@ class Kernel extends BaseKernel
     {
         $container->setParameter('container.autowiring.strict_mode', true);
         $container->setParameter('container.dumper.inline_class_loader', true);
-        $confDir = $this->getProjectDir().'/config';
+        $confDir = $this->getProjectDir().'/%CONFIG_DIR%';
         $loader->load($confDir.'/packages/*'.self::CONFIG_EXTS, 'glob');
         if (is_dir($confDir.'/packages/'.$this->environment)) {
             $loader->load($confDir.'/packages/'.$this->environment.'/**/*'.self::CONFIG_EXTS, 'glob');
@@ -49,7 +49,7 @@ class Kernel extends BaseKernel
 
     protected function configureRoutes(RouteCollectionBuilder $routes)
     {
-        $confDir = $this->getProjectDir().'/config';
+        $confDir = $this->getProjectDir().'/%CONFIG_DIR%';
         if (is_dir($confDir.'/routes/')) {
             $routes->import($confDir.'/routes/*'.self::CONFIG_EXTS, '/', 'glob');
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT


Comes hand in hand with https://github.com/symfony/flex/pull/204/files
The goal ist, to have the configuration variables (like `%SRC_DIR%` and `%CONFIG_DIR%` also available inside of the files, that are copied. More information inside the PR from Flex-Plugin