### PR TITLE
adding DoctrineFixturesBundle 3.0 recipe

### DIFF
--- a/doctrine/doctrine-fixtures-bundle/3.0/manifest.json
+++ b/doctrine/doctrine-fixtures-bundle/3.0/manifest.json
@@ -1,0 +1,8 @@
+{
+    "bundles": {
+        "Doctrine\\Bundle\\FixturesBundle\\DoctrineFixturesBundle": ["dev", "test"]
+    },
+    "copy-from-recipe": {
+        "src/": "%SRC_DIR%/"
+    }
+}

--- a/doctrine/doctrine-fixtures-bundle/3.0/manifest.json
+++ b/doctrine/doctrine-fixtures-bundle/3.0/manifest.json
@@ -1,4 +1,5 @@
 {
+    "aliases": ["orm-fixtures"],
     "bundles": {
         "Doctrine\\Bundle\\FixturesBundle\\DoctrineFixturesBundle": ["dev", "test"]
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

We released DoctrineFixturesBundle 3.0 yesterday. In it, we actually recommend putting fixtures classes in the more "shallow" `DataFixtures` directory. The `ORM` is not needed anymore, because fixtures are tagged services - they can really live anywhere.

There is a 2.4 recipe in `recipes-contrib`. But I thought 3.0 could be official.

There are no documentation changes needed. We don't doc usage of this bundle on `symfony-docs` currently, and the docs in the bundle are already updated.
