### PR TITLE
Using the alias

### DIFF
--- a/symfony/framework-bundle/3.3/post-install.txt
+++ b/symfony/framework-bundle/3.3/post-install.txt
@@ -8,6 +8,6 @@
     3. Browse to the <comment>http://localhost:8000/</> URL.
 
        Quit the server with CTRL-C.
-       Run <comment>composer require symfony/web-server-bundle</> for a better web server.
+       Run <comment>composer require server</> for a better web server.
 
   * <fg=blue>Read</> the documentation at <comment>https://symfony.com/doc</>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

In this setup docs, we're already using the `composer require server` alias. Why not also use it here?