### PR TITLE
Introduce SearchBundle recipe

### DIFF
--- a/algolia/search-bundle/3.0/manifest.json
+++ b/algolia/search-bundle/3.0/manifest.json
@@ -1,0 +1,12 @@
+{
+    "bundles": {
+        "Algolia\\SearchBundle\\AlgoliaSearchBundle": ["all"]
+    },
+    "env": {
+        "#1": "Create a free account on www.algolia.com",
+        "#2": "and get your credentials from the API Keys tab.",
+        "ALGOLIA_APP_ID": "...",
+        "ALGOLIA_API_KEY": "..."
+    },
+    "aliases": ["search", "search-engine", "algolia"]
+}

--- a/algolia/search-bundle/3.0/post-install.txt
+++ b/algolia/search-bundle/3.0/post-install.txt
@@ -1,0 +1,8 @@
+<bg=blue;fg=white>                                  </>
+<bg=blue;fg=white> Next: SearchBundle Configuration </>
+<bg=blue;fg=white>                                  </>
+
+  * The Algolia/SearchBundle ships with Algolia by default. Create a free
+    account on http://www.algolia.com and get credentials from the API Keys tab.
+
+  * Modify your ALGOLIA_APP_ID and ALGOLIA_API_KEY config in <fg=green>.env</>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Inspired by Symfony Flex and Symfony4, I have rewritten the [Algolia Bundle for Symfony](https://github.com/algolia/search-bundle). We talked with Nicolas about adding it to the official recipes, that's why I'm opening this PR.
Note that the package is in Beta2, so you shouldn't merge it yet but I wanted to start the conversation.

The main reason behind the rewrite was to improve the developer experience and to make it more extensible. You can get started with 5 lines of YAML. Also, you can use this package with another search engine, if you write the driver for it :)
You can find out more about the package here: https://discourse.algolia.com/t/introducing-the-new-algolia-search-bundle-for-symfony/3842


Any feedback about the package is very welcome.