### PR TITLE
Adding services_test.yaml when you install phpunit

### DIFF
--- a/symfony/phpunit-bridge/3.3/config/services_test.yaml
+++ b/symfony/phpunit-bridge/3.3/config/services_test.yaml
@@ -1,0 +1,9 @@
+services:
+    _defaults:
+        public: true
+
+    # If you need to access services in a test, create an alias
+    # and then fetch that alias from the container. As a convention,
+    # aliases are prefixed with test. For example:
+    #
+    # test.App\Service\MyService: '@App\Service\MyService'

--- a/symfony/phpunit-bridge/3.3/manifest.json
+++ b/symfony/phpunit-bridge/3.3/manifest.json
@@ -1,6 +1,7 @@
 {
     "copy-from-recipe": {
         "bin/": "%BIN_DIR%/",
+        "config/": "%CONFIG_DIR%/",
         "phpunit.xml.dist": "phpunit.xml.dist",
         "tests/": "tests/"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Soon, we will document that you should create public aliases if you need to access a private service from a test. What do you guys think about giving them this configuration file? Creating it in the FWBundle recipe seemed overkill. But if you install phpunit, it seems much more likely that it will be needed. 
