### PR TITLE
Bump phpunit to 6.5, discourage phpunit/phpunit more

### DIFF
--- a/phpunit/phpunit/4.7/post-install.txt
+++ b/phpunit/phpunit/4.7/post-install.txt
@@ -1,2 +1,7 @@
-Adding <comment>phpunit/phpunit</> as a dependency is <comment>discouraged</>.
-You should require <fg=green>simple-phpunit</> instead.
+<bg=yellow;fg=black>                                                        </>
+<bg=yellow;fg=black> Adding phpunit/phpunit as a dependency is discouraged. </>
+<bg=yellow;fg=black>                                                        </>
+
+  * <fg=blue>Instead</>:
+    1. Remove it now: <comment>composer remove phpunit/phpunit</>
+    2. Use Symfony's bridge: <comment>composer require phpunit</>

--- a/symfony/phpunit-bridge/3.3/bin/phpunit
+++ b/symfony/phpunit-bridge/3.3/bin/phpunit
@@ -9,7 +9,7 @@ if (false === getenv('SYMFONY_PHPUNIT_REMOVE')) {
     putenv('SYMFONY_PHPUNIT_REMOVE=symfony/yaml');
 }
 if (false === getenv('SYMFONY_PHPUNIT_VERSION')) {
-    putenv('SYMFONY_PHPUNIT_VERSION=6.4');
+    putenv('SYMFONY_PHPUNIT_VERSION=6.5');
 }
 if (false === getenv('SYMFONY_PHPUNIT_DIR')) {
     putenv('SYMFONY_PHPUNIT_DIR='.__DIR__.'/.phpunit');

--- a/symfony/phpunit-bridge/3.3/post-install.txt
+++ b/symfony/phpunit-bridge/3.3/post-install.txt
@@ -1,1 +1,6 @@
-Run <comment>php bin/phpunit</> to launch your test suite.
+<bg=blue;fg=white>              </>
+<bg=blue;fg=white> How to test? </>
+<bg=blue;fg=white>              </>
+
+  * <fg=blue>Write</> test cases in the <comment>tests/</> folder
+  * <fg=blue>Run</> <comment>php bin/phpunit</>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

phpunit 6.5 is the last to support 7.0, so this is the last bump.

when installing phpunit/phpunit:
![image](https://user-images.githubusercontent.com/243674/33527588-b1698004-d853-11e7-98db-53c89a0c531b.png)

when installing the bridge:
![image](https://user-images.githubusercontent.com/243674/33527583-96d1c756-d853-11e7-85a5-b3eeae4d60ea.png)
