### PR TITLE
Fixed default phpunit.xml.dist: add filter/whitelist

### DIFF
--- a/phpunit/phpunit/4.7/phpunit.xml.dist
+++ b/phpunit/phpunit/4.7/phpunit.xml.dist
@@ -22,4 +22,10 @@
             <directory>tests/</directory>
         </testsuite>
     </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/symfony/phpunit-bridge/3.3/phpunit.xml.dist
+++ b/symfony/phpunit-bridge/3.3/phpunit.xml.dist
@@ -23,6 +23,12 @@
         </testsuite>
     </testsuites>
 
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+        </whitelist>
+    </filter>
+
     <listeners>
         <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
     </listeners>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

If we don't do that, phpunit is not able to compute the code coverage.
We get the following error without it:

```
Error:         Incorrect whitelist config, no code coverage will be generated.
```