### PR TITLE
add translations alias for translator recipe

### DIFF
--- a/symfony/translation/3.3/manifest.json
+++ b/symfony/translation/3.3/manifest.json
@@ -6,5 +6,5 @@
     "container": {
         "locale": "en"
     },
-    "aliases": ["translator"]
+    "aliases": ["translator", "translations"]
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

My first Flex experience: How to get the `translations` folder?
`composer require translations => supported aliases: "translation", "translator"`

This adds a `translations` alias for the translator recipe. Maybe its helpful
