### PR TITLE
Clarify when you would uncomment the session config

### DIFF
--- a/symfony/framework-bundle/3.3/config/packages/test/framework.yaml
+++ b/symfony/framework-bundle/3.3/config/packages/test/framework.yaml
@@ -1,4 +1,5 @@
 framework:
     test: ~
+    # Uncomment this section if you're using sessions
     #session:
     #    storage_id: session.storage.mock_file


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Hi guys!

Honestly, the session is a bit of a usability issue - see #262. This at least clarifies what's going on in this file - e.g. "Do I need to uncomment this? Or is the default value ok for my tests?". This was added in #223 so the test environment was consistent with the other environments (no session by default). That was the correct decisions... but this session stuff is annoying (you need to remember to uncomment it in 2 places now).
