### PR TITLE
Removing csrf_protection now that is is auto-enabled

### DIFF
--- a/symfony/framework-bundle/3.3/config/packages/framework.yaml
+++ b/symfony/framework-bundle/3.3/config/packages/framework.yaml
@@ -1,7 +1,6 @@
 framework:
     secret: '%env(APP_SECRET)%'
     #default_locale: en
-    #csrf_protection: ~
     #http_method_override: true
 
     # uncomment this entire section to enable sessions


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Starting in Symfony 4.0.2 (symfony/symfony#25151), the `csrf_protection` config is never needed: if the component is installed, it's activated.
