### PR TITLE
Use route.controller instead of route.defaults._controller

### DIFF
--- a/symfony/routing/3.3/config/routes.yaml
+++ b/symfony/routing/3.3/config/routes.yaml
@@ -1,3 +1,3 @@
 #index:
 #    path: /
-#    defaults: { _controller: 'App\Controller\DefaultController::index' }
+#    controller: 'App\Controller\DefaultController::index'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Recently, after 2+ years working with Symfony I've learned by accident that we don't have to specify controller in `defaults` section. Maybe we should promote it more.