### PR TITLE
[Routing] Use "controller" keyword in example config

### DIFF
--- a/symfony/routing/3.3/config/routes.yaml
+++ b/symfony/routing/3.3/config/routes.yaml
@@ -1,3 +1,3 @@
 #index:
 #    path: /
-#    controller: App\Controller\DefaultController::index
+#    defaults: { _controller: 'App\Controller\DefaultController::index' }

--- a/symfony/routing/3.3/config/routes.yaml
+++ b/symfony/routing/3.3/config/routes.yaml
@@ -1,3 +1,3 @@
 #index:
 #    path: /
-#    defaults: { _controller: 'App\Controller\DefaultController::index' }
+#    controller: App\Controller\DefaultController::index

--- a/symfony/routing/4.0/config/packages/dev/routing.yaml
+++ b/symfony/routing/4.0/config/packages/dev/routing.yaml
@@ -1,0 +1,3 @@
+framework:
+    router:
+        strict_requirements: true

--- a/symfony/routing/4.0/config/packages/routing.yaml
+++ b/symfony/routing/4.0/config/packages/routing.yaml
@@ -1,0 +1,3 @@
+framework:
+    router:
+        strict_requirements: ~

--- a/symfony/routing/4.0/config/routes.yaml
+++ b/symfony/routing/4.0/config/routes.yaml
@@ -1,0 +1,3 @@
+#index:
+#    path: /
+#    controller: App\Controller\DefaultController::index

--- a/symfony/routing/4.0/manifest.json
+++ b/symfony/routing/4.0/manifest.json
@@ -1,0 +1,6 @@
+{
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "aliases": ["router"]
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Since in Symfony 4  we encourage to use `controller` keyword in prefix, an example configuration should also use this keyword instead of `defaults`.
