### PR TITLE
Adding travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+language: php
+sudo: false
+
+cache:
+    directories:
+        - $HOME/.composer/cache/files
+
+matrix:
+    fast_finish: true
+    include:
+        - php: 7.1
+          env: SKELETON_VERSION="^3.4"
+        - php: 7.1
+          env: SKELETON_VERSION="^4.0"
+
+before_install:
+    - phpenv config-rm xdebug.ini || true
+    - export SYMFONY_ENDPOINT=https://symfony.sh/r/github.com/symfony/recipes/${TRAVIS_PULL_REQUEST}
+    - export PACKAGES=$(curl -s $SYMFONY_ENDPOINT | sed -En 's/.*composer req "([^"]+)".*/\1/p')
+
+install:
+    - composer create-project "symfony/skeleton:${SKELETON_VERSION}" flex
+    - cd flex
+
+script:
+    - composer req "${PACKAGES}"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

The travis file has been proven useful in the recipe-contrib repo. I do not have to manually install and test all PRs anymore. I also notice that authors detect issues when their package being installed on a fresh symfony project. 

