### PR TITLE
Move the debug alias to the pack instead of the bundle

### DIFF
--- a/symfony/debug-bundle/3.3/manifest.json
+++ b/symfony/debug-bundle/3.3/manifest.json
@@ -1,6 +1,5 @@
 {
     "bundles": {
         "Symfony\\Bundle\\DebugBundle\\DebugBundle": ["dev", "test"]
-    },
-    "aliases": ["debug"]
+    }
 }

--- a/symfony/debug-pack/1.0/manifest.json
+++ b/symfony/debug-pack/1.0/manifest.json
@@ -1,0 +1,3 @@
+{
+    "aliases": ["debug"]
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Right now, the `debug` alias installs the debug bundle. I think it's better to actually link this alias to the debug pack. I thought this was the case, but apparently, that's an oversight. Should fix many issue people have right now.
