### PR TITLE
Updating notice wording

### DIFF
--- a/phpunit/phpunit/4.7/post-install.txt
+++ b/phpunit/phpunit/4.7/post-install.txt
@@ -1,5 +1,5 @@
 <bg=yellow;fg=black>                                                                                              </>
-<bg=yellow;fg=black> Adding phpunit/phpunit as a dependency is discouraged in favour of Symfony's PHPUnit Bridge. </>
+<bg=yellow;fg=black> Adding phpunit/phpunit as a dependency is discouraged in favor of Symfony's PHPUnit Bridge. </>
 <bg=yellow;fg=black>                                                                                              </>
 
   * <fg=blue>Instead</>:

--- a/phpunit/phpunit/4.7/post-install.txt
+++ b/phpunit/phpunit/4.7/post-install.txt
@@ -1,6 +1,6 @@
-<bg=yellow;fg=black>                                                                                              </>
+<bg=yellow;fg=black>                                                                                             </>
 <bg=yellow;fg=black> Adding phpunit/phpunit as a dependency is discouraged in favor of Symfony's PHPUnit Bridge. </>
-<bg=yellow;fg=black>                                                                                              </>
+<bg=yellow;fg=black>                                                                                             </>
 
   * <fg=blue>Instead</>:
     1. Remove it now: <comment>composer remove phpunit/phpunit</>

--- a/phpunit/phpunit/4.7/post-install.txt
+++ b/phpunit/phpunit/4.7/post-install.txt
@@ -1,7 +1,7 @@
-<bg=yellow;fg=black>                                                        </>
-<bg=yellow;fg=black> Adding phpunit/phpunit as a dependency is discouraged. </>
-<bg=yellow;fg=black>                                                        </>
+<bg=yellow;fg=black>                                                                                              </>
+<bg=yellow;fg=black> Adding phpunit/phpunit as a dependency is discouraged in favour of Symfony's PHPUnit Bridge. </>
+<bg=yellow;fg=black>                                                                                              </>
 
   * <fg=blue>Instead</>:
     1. Remove it now: <comment>composer remove phpunit/phpunit</>
-    2. Use Symfony's bridge: <comment>composer require phpunit</>
+    2. Use Symfony's bridge: <comment>composer require --dev phpunit</>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

I found the current wording confusing as to why phpunit/phpunit was being discouraged. Was there a bug in it? A security flaw? Is the recipe bad? After speaking with the community, it turns out it was merely because Symfony's bridge is more useful to the user than vanilla phpunit. I feel this new message is more useful to developers.
