### PR TITLE
Work out values for env and debug once

### DIFF
--- a/symfony/framework-bundle/3.3/public/index.php
+++ b/symfony/framework-bundle/3.3/public/index.php
@@ -15,7 +15,10 @@ if (!isset($_SERVER['APP_ENV'])) {
     (new Dotenv())->load(__DIR__.'/../.env');
 }
 
-if ($_SERVER['APP_DEBUG'] ?? ('prod' !== ($_SERVER['APP_ENV'] ?? 'dev'))) {
+$env = $_SERVER['APP_ENV'] ?? 'dev';
+$debug = $_SERVER['APP_DEBUG'] ?? ('prod' !== $env);
+
+if ($debug) {
     umask(0000);
 
     Debug::enable();
@@ -29,7 +32,7 @@ if ($trustedHosts = $_SERVER['TRUSTED_HOSTS'] ?? false) {
     Request::setTrustedHosts(explode(',', $trustedHosts));
 }
 
-$kernel = new Kernel($_SERVER['APP_ENV'] ?? 'dev', $_SERVER['APP_DEBUG'] ?? ('prod' !== ($_SERVER['APP_ENV'] ?? 'dev')));
+$kernel = new Kernel($env, $debug);
 $request = Request::createFromGlobals();
 $response = $kernel->handle($request);
 $response->send();


### PR DESCRIPTION
Previously the null coalescing logic was duplicated, this puts it into
one place.

Variable names match those used in [bin/console](https://github.com/symfony/recipes/blob/fc9b47d94185fa51a1c7c1ddf3f91b7c4ff5bc93/symfony/console/3.3/bin/console#L26-L27)

| Q             | A
| ------------- | ---
| License       | MIT