### PR TITLE
Add a recipe for Thanks and display an incentive to use it when installing FrameworkBundle

### DIFF
--- a/symfony/framework-bundle/3.3/post-install.txt
+++ b/symfony/framework-bundle/3.3/post-install.txt
@@ -11,3 +11,7 @@
        Run <comment>composer require server</> for a better web server.
 
   * <fg=blue>Read</> the documentation at <comment>https://symfony.com/doc</>
+
+  * <fg=blue>Thanks</> for using Symfony!
+    Spread some love by starring the GitHub repositories you use!
+    Run <comment>composer req thanks && composer thanks</>

--- a/symfony/thanks/1.0/manifest.json
+++ b/symfony/thanks/1.0/manifest.json
@@ -1,0 +1,3 @@
+{
+  "aliases": ["thanks", "thank"]
+}

--- a/symfony/thanks/1.0/post-install.txt
+++ b/symfony/thanks/1.0/post-install.txt
@@ -1,0 +1,5 @@
+Give thanks (in the form of a GitHub ⭐) to your fellow PHP package maintainers (not limited to Symfony components)!
+
+Run <comment>composer thanks</>
+
+This will find all of your Composer dependencies, find their github.com repository, and star their GitHub repositories.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Alternative to symfony/flex#256 and symfony/skeleton#49.

Benefits:

* All people installing Symfony 4 can't miss they **can** thank Symfony, PHP and the other packages they use.
* No extra dependencies installed by default
