### PR TITLE
[symfony/framework-bundle] Enable session support by default

### DIFF
--- a/symfony/framework-bundle/3.3/config/packages/framework.yaml
+++ b/symfony/framework-bundle/3.3/config/packages/framework.yaml
@@ -4,10 +4,10 @@ framework:
     #csrf_protection: ~
     #http_method_override: true
 
-    # uncomment this entire section to enable sessions
-    #session:
-    #    # With this config, PHP's native session handling is used
-    #    handler_id: ~
+    # Enables session support. Note that the session will ONLY be started if you read or write from it.
+    # Remove or comment this section to explicitly disable session support.
+    session:
+        handler_id: ~
 
     #esi: ~
     #fragments: ~

--- a/symfony/framework-bundle/3.3/config/packages/test/framework.yaml
+++ b/symfony/framework-bundle/3.3/config/packages/test/framework.yaml
@@ -1,5 +1,4 @@
 framework:
     test: ~
-    # Uncomment this section if you're using sessions
-    #session:
-    #    storage_id: session.storage.mock_file
+    session:
+        storage_id: session.storage.mock_file


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Enabling session by default has only one practical downside: some classes/services are loaded but never used. Not a big deal.
STILL, this is something that is going to be fixed on Symfony by https://github.com/symfony/symfony/pull/25699, where the session is made extra-lazy.

Thus, this is my proposal to fix #262.

  