### PR TITLE
Don’t break when not using env vars

### DIFF
--- a/symfony/console/3.3/bin/console
+++ b/symfony/console/3.3/bin/console
@@ -15,16 +15,14 @@ if (!class_exists(Application::class)) {
     throw new \RuntimeException('You need to add "symfony/framework-bundle" as a Composer dependency.');
 }
 
-if (!isset($_SERVER['APP_ENV'])) {
-    if (!class_exists(Dotenv::class)) {
-        throw new \RuntimeException('APP_ENV environment variable is not defined. You need to define environment variables for configuration or add "symfony/dotenv" as a Composer dependency to load variables from a .env file.');
-    }
-    (new Dotenv())->load(__DIR__.'/../.env');
-}
-
 $input = new ArgvInput();
 $env = $input->getParameterOption(['--env', '-e'], $_SERVER['APP_ENV'] ?? 'dev');
 $debug = ($_SERVER['APP_DEBUG'] ?? ('prod' !== $env)) && !$input->hasParameterOption(['--no-debug', '']);
+
+// The check is to ensure we don't use .env in production
+if ($debug && class_exists(Dotenv::class)) {
+    (new Dotenv())->load(__DIR__.'/../.env');
+}
 
 if ($debug) {
     umask(0000);

--- a/symfony/framework-bundle/3.3/public/index.php
+++ b/symfony/framework-bundle/3.3/public/index.php
@@ -7,16 +7,13 @@ use Symfony\Component\HttpFoundation\Request;
 
 require __DIR__.'/../vendor/autoload.php';
 
-// The check is to ensure we don't use .env in production
-if (!isset($_SERVER['APP_ENV'])) {
-    if (!class_exists(Dotenv::class)) {
-        throw new \RuntimeException('APP_ENV environment variable is not defined. You need to define environment variables for configuration or add "symfony/dotenv" as a Composer dependency to load variables from a .env file.');
-    }
-    (new Dotenv())->load(__DIR__.'/../.env');
-}
-
 $env = $_SERVER['APP_ENV'] ?? 'dev';
 $debug = $_SERVER['APP_DEBUG'] ?? ('prod' !== $env);
+
+// The check is to ensure we don't use .env in production
+if ($debug && class_exists(Dotenv::class)) {
+    (new Dotenv())->load(__DIR__.'/../.env');
+}
 
 if ($debug) {
     umask(0000);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

This is an implementation of https://github.com/symfony/recipes/pull/247#issuecomment-356599423

### Background

In our case we are not using env vars, as they are too cumbersome for our hosting situation.
 With one exception: `APP_ENV`, as on the dev machines it can just default to `dev`, `APP_DEBUG` will nicely map to the correct value with the current default implementation and it is easy to pass the env in a `symfony/console` CLI call.

In this case the `console` and `framework-bundle` could be more lenient.

Current workflow:
1. `composer create-project symfony/skeleton .`
2. `composer remove --dev symfony/dotenv`
3. Exception 💥  (`APP_ENV environment variable is not defined. You need to define environment variables for configuration or add "symfony/dotenv" as a Composer dependency to load variables from a .env file.`)

I am sure this could be more comfortable, in a way that would just work for both ways.


### Implementation

Just use default values, if no explicit env vars are set. Overwrite the env vars with the ones from the `.env` file, if the package is loaded.

This should work for both ways.

* One of the issues sort-of reintroduced is that the nice error message introduce in #247 is gone. Maybe it would be possible to just check for errors during compilation and look for missing parameters. If they are `env(...)` and the `DotEnv` class doesn't exists, show the error message from the previous pr?
* Also I wasn't sure what to do about https://github.com/symfony/recipes/blob/master/behat/symfony2-extension/2.1/features/bootstrap/bootstrap.php#L6-L11