### PR TITLE
Fix composer remove phpunit/phpunit command

### DIFF
--- a/phpunit/phpunit/4.7/post-install.txt
+++ b/phpunit/phpunit/4.7/post-install.txt
@@ -3,5 +3,5 @@
 <bg=yellow;fg=black>                                                                                             </>
 
   * <fg=blue>Instead</>:
-    1. Remove it now: <comment>composer remove phpunit/phpunit</>
+    1. Remove it now: <comment>composer remove --dev phpunit/phpunit</>
     2. Use Symfony's bridge: <comment>composer require --dev phpunit</>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Composer just gives a 'phpunit/phpunit could not be found in require but it is present in require-dev' notice without the `--dev` switch.

(Assumes PHPUnit isn't being used in production of course. 😉)