### PR TITLE
Clear cache and warm up properly in symfony/framework-bundle

### DIFF
--- a/symfony/framework-bundle/3.3/manifest.json
+++ b/symfony/framework-bundle/3.3/manifest.json
@@ -8,7 +8,8 @@
         "src/": "%SRC_DIR%/"
     },
     "composer-scripts": {
-        "cache:clear": "symfony-cmd",
+        "cache:clear --no-warmup": "symfony-cmd",
+        "cache:warmup": "symfony-cmd",
         "assets:install --symlink --relative %PUBLIC_DIR%": "symfony-cmd"
     },
     "env": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

<!--
Please, carefully read the README before submitting a pull request.
-->
`cache:clear --no-warmup` [seems not to have been removed](https://symfony.com/blog/new-in-symfony-3-3-deprecated-cache-clear-with-warmup) in SF4. Nevertheless, composer should clear then warm the cache properly as per the [deployment guide](https://symfony.com/doc/current/deployment.html).