### PR TITLE
Correctly cast $_SERVER['APP_DEBUG'].

### DIFF
--- a/symfony/console/3.3/bin/console
+++ b/symfony/console/3.3/bin/console
@@ -24,7 +24,9 @@ if (!isset($_SERVER['APP_ENV'])) {
 
 $input = new ArgvInput();
 $env = $input->getParameterOption(['--env', '-e'], $_SERVER['APP_ENV'] ?? 'dev');
-$debug = ($_SERVER['APP_DEBUG'] ?? ('prod' !== $env)) && !$input->hasParameterOption(['--no-debug', '']);
+$debug = (
+        (!isset($_SERVER['APP_DEBUG']) ? null : filter_var($_SERVER['APP_DEBUG'], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE)) ?? ('prod' !== $env)
+    ) && !$input->hasParameterOption(['--no-debug', '']);
 
 if ($debug) {
     umask(0000);

--- a/symfony/framework-bundle/3.3/public/index.php
+++ b/symfony/framework-bundle/3.3/public/index.php
@@ -16,7 +16,7 @@ if (!isset($_SERVER['APP_ENV'])) {
 }
 
 $env = $_SERVER['APP_ENV'] ?? 'dev';
-$debug = $_SERVER['APP_DEBUG'] ?? ('prod' !== $env);
+$debug = (!isset($_SERVER['APP_DEBUG']) ? null : filter_var($_SERVER['APP_DEBUG'], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE)) ?? ('prod' !== $env)
 
 if ($debug) {
     umask(0000);


### PR DESCRIPTION
If .env defines APP_DEBUG parameter, APP_DEBUG is populated in string type in $_SERVER. String "false" will be casted in boolean true.
So, if you define APP_DEBUG=false in .env, your debug is enable.

| Q             | A
| ------------- | ---
| License       | MIT

