### PR TITLE
Add `--dev` to composer require server suggestion

### DIFF
--- a/symfony/framework-bundle/3.3/post-install.txt
+++ b/symfony/framework-bundle/3.3/post-install.txt
@@ -8,6 +8,6 @@
     3. Browse to the <comment>http://localhost:8000/</> URL.
 
        Quit the server with CTRL-C.
-       Run <comment>composer require server</> for a better web server.
+       Run <comment>composer require server --dev</> for a better web server.
 
   * <fg=blue>Read</> the documentation at <comment>https://symfony.com/doc</>


### PR DESCRIPTION
Current advice results with adding `"symfony/web-server-bundle"` into `require` section in composer.json.

We should advice `composer require server --dev` in order to add 
`"symfony/web-server-bundle"` into `require-dev` section in composer.json

| Q             | A
| ------------- | ---
| License       | MIT

<!--
Please, carefully read the README before submitting a pull request.
-->
