### PR TITLE
tweak internal web server arguments

### DIFF
--- a/symfony/framework-bundle/3.3/post-install.txt
+++ b/symfony/framework-bundle/3.3/post-install.txt
@@ -4,7 +4,7 @@
 
   * <fg=blue>Run</> your application:
     1. Change to the project directory
-    2. Execute the <comment>php -S 127.0.0.1:8000 -t public</> command;
+    2. Execute the <comment>php -S 127.0.0.1:8000 public/index.php</> command;
     3. Browse to the <comment>http://localhost:8000/</> URL.
 
        Quit the server with CTRL-C.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

It looks like only passing the document root when starting PHP's internal web server behaves slightly different compared to the process that is bootstrapped when using the WebServerBundle (see symfony/symfony#25911). This changes the command suggestion to be (almost) the same of what is done when using the `server:start` command.
