### PR TITLE
[WIP][RFC] Stop using ~ in config files

### DIFF
--- a/symfony/framework-bundle/3.3/config/packages/framework.yaml
+++ b/symfony/framework-bundle/3.3/config/packages/framework.yaml
@@ -1,16 +1,16 @@
 framework:
     secret: '%env(APP_SECRET)%'
     #default_locale: en
-    #csrf_protection: ~
+    #csrf_protection: true
     #http_method_override: true
 
     # Enables session support. Note that the session will ONLY be started if you read or write from it.
     # Remove or comment this section to explicitly disable session support.
     session:
-        handler_id: ~
+        handler_id: null
 
-    #esi: ~
-    #fragments: ~
+    #esi: true
+    #fragments: true
     php_errors:
         log: true
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

This is just an RFC. One question I've gotten routinely over the years is "What is the `~`?" in config. I think it would be more clear if we just used `null` instead. Or, when the "presence" of a key is activating a component, use `true`, which reads a bit more clear.

Any major objections? I would propose making this change across *all* of the config files and making it a best-practice going forward.