### PR TITLE
Re-adding doc root to the web server command

### DIFF
--- a/symfony/framework-bundle/3.3/post-install.txt
+++ b/symfony/framework-bundle/3.3/post-install.txt
@@ -4,7 +4,7 @@
 
   * <fg=blue>Run</> your application:
     1. Change to the project directory
-    2. Execute the <comment>php -S 127.0.0.1:8000 public/index.php</> command;
+    2. Execute the <comment>php -S 127.0.0.1:8000 -t public</> command;
     3. Browse to the <comment>http://localhost:8000/</> URL.
 
        Quit the server with CTRL-C.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

See: https://github.com/symfony/recipes/pull/353#discussion_r165009263

I thought we could just change it to `php -S 127.0.0.1:8000 -t public index.php`. But when I do this, it ALWAYS loads `index.php` - it *never* loads an asset. I don't think we can pass a router argument at all, unless it's smart enough (like `router.php` is in WebServerBundle) to serve the static file if it exists:

https://github.com/symfony/symfony/blob/f74bda51ebd5c66c20dac455d119f407901ad364/src/Symfony/Bundle/WebServerBundle/Resources/router.php#L30

Of course this reverts a fix for this bug: https://github.com/symfony/symfony/issues/25911

I just don't think the built-in web server can work in all cases without our custom router. We can only make it work "quite good" I think. And I think this patch (where assets work) is better than the other. But I'm far from an expert on the built-in web server :).

Cheers!
