### PR TITLE
Adding access_control examples and small warning

### DIFF
--- a/symfony/security-bundle/3.3/config/packages/security.yaml
+++ b/symfony/security-bundle/3.3/config/packages/security.yaml
@@ -16,3 +16,9 @@ security:
 
             # form_login: ~
             # https://symfony.com/doc/current/security/form_login_setup.html
+
+    # easy way to control access for large sections of your site
+    # note: only the *first* access control that matches will be used
+    access_control:
+        # - { path: ^/admin, roles: ROLE_ADMIN }
+        # - { path: ^/profile, roles: ROLE_USER }

--- a/symfony/security-bundle/3.3/config/packages/security.yaml
+++ b/symfony/security-bundle/3.3/config/packages/security.yaml
@@ -17,8 +17,8 @@ security:
             # form_login: ~
             # https://symfony.com/doc/current/security/form_login_setup.html
 
-    # easy way to control access for large sections of your site
-    # note: only the *first* access control that matches will be used
+    # Easy way to control access for large sections of your site
+    # Note: Only the *first* access control that matches will be used
     access_control:
         # - { path: ^/admin, roles: ROLE_ADMIN }
         # - { path: ^/profile, roles: ROLE_USER }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Hi guys!

A friend of mine made a mistake in his `access_control` because he didn't realize that only the *first* access control that matches is used. I thought the best way to make this easier would be to add a few examples and some very small docs.

I've checked that leaving `access_control` empty like this is "ok" - the configuration system just treats it like an empty array.