### PR TITLE
Revert quotes: breaks database in phpunit.xml.dist

### DIFF
--- a/doctrine/doctrine-bundle/1.6/manifest.json
+++ b/doctrine/doctrine-bundle/1.6/manifest.json
@@ -10,6 +10,6 @@
         "#1": "Format described at http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url",
         "#2": "For an SQLite database, use: \"sqlite:///%kernel.project_dir%/var/data.db\"",
         "#3": "Configure your db driver and server_version in config/packages/doctrine.yaml",
-        "DATABASE_URL": "'mysql://db_user:db_password@127.0.0.1:3306/db_name'"
+        "DATABASE_URL": "mysql://db_user:db_password@127.0.0.1:3306/db_name"
     }
 }


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| License       | MIT

This reverts sha:ba7fcf10ccb0cc84f16e029dc0bf6a6509680f3b - #361.

That originally was meant to solve: https://github.com/symfony/symfony/issues/26056

The problem is that the change breaks the database in `phpunit.xml.dist`. It ends up like this:

```
<env name="DATABASE_URL" value="'mysql://root:@127.0.0.1:3306/test_maker'"/>
```

And so, because the string starts with a `'`, it seems to parse this as the database name - I get>

> Unknown database 'mysql://root:@127.0.0.1:3306/test_maker''
