### PR TITLE
Configure bundles with true/false values instead of NULL/anything else values

### DIFF
--- a/symfony/framework-bundle/3.3/src/Kernel.php
+++ b/symfony/framework-bundle/3.3/src/Kernel.php
@@ -28,7 +28,7 @@ class Kernel extends BaseKernel
     {
         $contents = require $this->getProjectDir().'/config/bundles.php';
         foreach ($contents as $class => $envs) {
-            if (isset($envs['all']) || isset($envs[$this->environment])) {
+            if ((isset($envs['all']) && $envs['all']) || (isset($envs[$this->environment]) && $envs[$this->environment])) {
                 yield new $class();
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Ensures that the Kernel only initializes bundles that have a true value associated with the the environment. At the moment if the value is true/false it will be enable and only "NULL" will not enable the bundle, however it is clearer/simpler to have a NULL/false not enabling the bundle and only true values to enable it.