### PR TITLE
Tweaking doctrine post message to look good in context of others

### DIFF
--- a/doctrine/doctrine-bundle/1.6/post-install.txt
+++ b/doctrine/doctrine-bundle/1.6/post-install.txt
@@ -1,6 +1,6 @@
-<bg=blue;fg=white>                     </>
-<bg=blue;fg=white> Next: Configuration </>
-<bg=blue;fg=white>                     </>
+<bg=blue;fg=white>                        </>
+<bg=blue;fg=white> Database Configuration </>
+<bg=blue;fg=white>                        </>
 
   * Modify your DATABASE_URL config in <fg=green>.env</>
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

If you use `symfony/website-skeleton`, you get this craziness :)

<img width="540" alt="screen shot 2018-02-09 at 7 51 08 pm" src="https://user-images.githubusercontent.com/121003/36056545-35d4b00c-0dd3-11e8-87cd-2abe8433f640.png">

We just need to be careful that each post-install (other than FWBundle) has some context about it, so we don't have 3 "Next:" headers. I added the DoctrineBundle message, so shame on me :).

Cheers!