### PR TITLE
Adding test bootstrap.php file so .env vars are read

### DIFF
--- a/phpunit/phpunit/4.7/phpunit.xml.dist
+++ b/phpunit/phpunit/4.7/phpunit.xml.dist
@@ -5,16 +5,16 @@
          xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.1/phpunit.xsd"
          backupGlobals="false"
          colors="true"
-         bootstrap="vendor/autoload.php"
+         bootstrap="tests/bootstrap.php"
 >
     <php>
         <ini name="error_reporting" value="-1" />
         <env name="KERNEL_CLASS" value="App\Kernel" />
+        <env name="SHELL_VERBOSITY" value="-1" />
+
+        <!-- override or set env variables for the test env here -->
         <env name="APP_ENV" value="test" />
         <env name="APP_DEBUG" value="1" />
-        <env name="APP_SECRET" value="s$cretf0rt3st" />
-        <env name="SHELL_VERBOSITY" value="-1" />
-        <!-- define your env variables for the test env here -->
     </php>
 
     <testsuites>

--- a/phpunit/phpunit/4.7/tests/bootstrap.php
+++ b/phpunit/phpunit/4.7/tests/bootstrap.php
@@ -1,0 +1,22 @@
+<?php
+
+require __DIR__.'/../vendor/autoload.php';
+
+use Symfony\Component\Dotenv\Dotenv;
+
+/*
+ * Environment variables can also be specified in phpunit.xml.dist.
+ * Those variables will override any defined in .env.
+ */
+if (!isset($_SERVER['APP_ENV'])) {
+    if (!class_exists(Dotenv::class)) {
+        throw new \RuntimeException('APP_ENV environment variable is not defined. You need to define environment variables for configuration or add "symfony/dotenv" as a Composer dependency to load variables from a .env file.');
+    }
+    (new Dotenv())->load(__DIR__.'/../.env');
+}
+
+$debug = $_SERVER['APP_DEBUG'] ?? true;
+
+if ($debug) {
+    umask(0000);
+}

--- a/symfony/phpunit-bridge/3.3/phpunit.xml.dist
+++ b/symfony/phpunit-bridge/3.3/phpunit.xml.dist
@@ -5,16 +5,16 @@
          xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.1/phpunit.xsd"
          backupGlobals="false"
          colors="true"
-         bootstrap="vendor/autoload.php"
+         bootstrap="tests/bootstrap.php"
 >
     <php>
         <ini name="error_reporting" value="-1" />
         <env name="KERNEL_CLASS" value="App\Kernel" />
+        <env name="SHELL_VERBOSITY" value="-1" />
+
+        <!-- override or set env variables for the test env here -->
         <env name="APP_ENV" value="test" />
         <env name="APP_DEBUG" value="1" />
-        <env name="APP_SECRET" value="s$cretf0rt3st" />
-        <env name="SHELL_VERBOSITY" value="-1" />
-        <!-- define your env variables for the test env here -->
     </php>
 
     <testsuites>

--- a/symfony/phpunit-bridge/3.3/tests/bootstrap.php
+++ b/symfony/phpunit-bridge/3.3/tests/bootstrap.php
@@ -1,0 +1,22 @@
+<?php
+
+require __DIR__.'/../vendor/autoload.php';
+
+use Symfony\Component\Dotenv\Dotenv;
+
+/*
+ * Environment variables can also be specified in phpunit.xml.dist.
+ * Those variables will override any defined in .env.
+ */
+if (!isset($_SERVER['APP_ENV'])) {
+    if (!class_exists(Dotenv::class)) {
+        throw new \RuntimeException('APP_ENV environment variable is not defined. You need to define environment variables for configuration or add "symfony/dotenv" as a Composer dependency to load variables from a .env file.');
+    }
+    (new Dotenv())->load(__DIR__.'/../.env');
+}
+
+$debug = $_SERVER['APP_DEBUG'] ?? true;
+
+if ($debug) {
+    umask(0000);
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Fixes symfony/flex#251

The problem is that currently, environment variables must be completely duplicated between `.env` and `phpunit.xml.dist`. That's just unacceptable DX to put in the user... which includes me - I don't want to do that :).

This is an easy win:

* `.env` is read in the same way as `bin/console` and `public/index.php`
* Environment variables in `phpunit.xml.dist` WIN over `.env`. This is used to set the environment to `test`.
