### PR TITLE
Improve the console script

### DIFF
--- a/symfony/console/3.3/bin/console
+++ b/symfony/console/3.3/bin/console
@@ -23,8 +23,8 @@ if (!isset($_SERVER['APP_ENV'])) {
 }
 
 $input = new ArgvInput();
-$env = $input->getParameterOption(['--env', '-e'], $_SERVER['APP_ENV'] ?? 'dev');
-$debug = ($_SERVER['APP_DEBUG'] ?? ('prod' !== $env)) && !$input->hasParameterOption(['--no-debug', '']);
+$env = $input->getParameterOption(['--env', '-e'], $_SERVER['APP_ENV'] ?? 'dev', true);
+$debug = ($_SERVER['APP_DEBUG'] ?? ('prod' !== $env)) && !$input->hasParameterOption('--no-debug', true);
 
 if ($debug) {
     umask(0000);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

- look for the `--env` and `--no-debug` only before a `--` separator, to respect the support for `--`
- avoid passing an empty string as parameter option name (which would never match anyway, but causes php warning is some Symfony versions instead of being ignored silently, because of https://github.com/symfony/symfony/issues/26136).
