### PR TITLE
Add "test" and "tests" aliases for the phpunit bridge

### DIFF
--- a/symfony/phpunit-bridge/3.3/manifest.json
+++ b/symfony/phpunit-bridge/3.3/manifest.json
@@ -9,5 +9,5 @@
         ".phpunit",
         "/phpunit.xml"
     ],
-    "aliases": ["phpunit", "simple-phpunit"]
+    "aliases": ["phpunit", "simple-phpunit", "test", "tests"]
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

It feels natural to type `composer require tests` just like we do with `composer require templates`.