### PR TITLE
Moved the EasyAdmin recipe to its new vendor

### DIFF
--- a/easycorp/easyadmin-bundle/1.17/config/packages/easy_admin.yaml
+++ b/easycorp/easyadmin-bundle/1.17/config/packages/easy_admin.yaml
@@ -1,0 +1,6 @@
+#easy_admin:
+#    entities:
+#        # List the entity class name you want to manage
+#        - App\Entity\Product
+#        - App\Entity\Category
+#        - App\Entity\User

--- a/easycorp/easyadmin-bundle/1.17/config/routes/easy_admin.yaml
+++ b/easycorp/easyadmin-bundle/1.17/config/routes/easy_admin.yaml
@@ -1,0 +1,4 @@
+easy_admin_bundle:
+    resource: '@EasyAdminBundle/Controller/AdminController.php'
+    prefix: /admin
+    type: annotation

--- a/easycorp/easyadmin-bundle/1.17/manifest.json
+++ b/easycorp/easyadmin-bundle/1.17/manifest.json
@@ -4,5 +4,6 @@
     },
     "copy-from-recipe": {
         "config/": "%CONFIG_DIR%/"
-    }
+    },
+    "aliases": ["admin-gen", "admin-generator", "admin"]
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

We've moved the Composer package from `javiereguiluz/easyadmin-bundle` to `easycorp/easyadmin-bundle` ... so I guess we need to update the recipes too. I don't know if I must also delete the entire `javiereguiluz/` directory.