### PR TITLE
lexik/jwt-auth adds gitignore to manifest

### DIFF
--- a/lexik/jwt-authentication-bundle/2.3/manifest.json
+++ b/lexik/jwt-authentication-bundle/2.3/manifest.json
@@ -11,5 +11,8 @@
         "JWT_PRIVATE_KEY_PATH": "%CONFIG_DIR%/jwt/private.pem",
         "JWT_PUBLIC_KEY_PATH": "%CONFIG_DIR%/jwt/public.pem",
         "JWT_PASSPHRASE": "%generate(secret)%"
+    },
+    "gitignore": {
+    	"/var/jwt"
     }
 }

--- a/lexik/jwt-authentication-bundle/2.3/manifest.json
+++ b/lexik/jwt-authentication-bundle/2.3/manifest.json
@@ -13,6 +13,6 @@
         "JWT_PASSPHRASE": "%generate(secret)%"
     },
     "gitignore": [
-    	"/var/jwt"
+    	"%CONFIG_DIR%/jwt/*.pem"
     ]
 }

--- a/lexik/jwt-authentication-bundle/2.3/manifest.json
+++ b/lexik/jwt-authentication-bundle/2.3/manifest.json
@@ -12,7 +12,7 @@
         "JWT_PUBLIC_KEY_PATH": "%CONFIG_DIR%/jwt/public.pem",
         "JWT_PASSPHRASE": "%generate(secret)%"
     },
-    "gitignore": {
+    "gitignore": [
     	"/var/jwt"
-    }
+    ]
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Adds `/var/jwt/` to gitignore for the lexik/jwt-auth-bundle. This will prevent developers from commiting the certificates, which are placed under `/var/jwt/[private|public].pem`

<!--
Please, carefully read the README before submitting a pull request.
-->
