### PR TITLE
Fix TypeError argument when APP_DEBUG is set

### DIFF
--- a/symfony/console/3.3/bin/console
+++ b/symfony/console/3.3/bin/console
@@ -24,7 +24,7 @@ if (!isset($_SERVER['APP_ENV'])) {
 
 $input = new ArgvInput();
 $env = $input->getParameterOption(['--env', '-e'], $_SERVER['APP_ENV'] ?? 'dev', true);
-$debug = ($_SERVER['APP_DEBUG'] ?? ('prod' !== $env)) && !$input->hasParameterOption('--no-debug', true);
+$debug = (bool) ($_SERVER['APP_DEBUG'] ?? ('prod' !== $env)) && !$input->hasParameterOption('--no-debug', true);
 
 if ($debug) {
     umask(0000);

--- a/symfony/framework-bundle/3.3/public/index.php
+++ b/symfony/framework-bundle/3.3/public/index.php
@@ -16,7 +16,7 @@ if (!isset($_SERVER['APP_ENV'])) {
 }
 
 $env = $_SERVER['APP_ENV'] ?? 'dev';
-$debug = $_SERVER['APP_DEBUG'] ?? ('prod' !== $env);
+$debug = (bool) $_SERVER['APP_DEBUG'] ?? ('prod' !== $env);
 
 if ($debug) {
     umask(0000);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

When you specify APP_DEBUG in the ENV, it is interpreted as a "_string_" which triggers this kind of error:

```
Fatal error: Uncaught TypeError: Argument 2 passed to Symfony\Component\HttpKernel\Kernel::__construct() must be of the type boolean, 
string given, called in /app/public/index.php on line 49 and defined in /app/vendor/symfony/http-kernel/Kernel.php:76
 Stack trace: 
#0 /app/public/index.php(49): Symfony\Component\HttpKernel\Kernel->__construct('prod', '0') 
#1 {main} thrown in /app/vendor/symfony/http-kernel/Kernel.php on line 76
```
This PR aims to solve that issue.

> unless I missed a trick