### PR TITLE
Add container tracking to bundles.php so the container rebuilds when it changes

### DIFF
--- a/symfony/framework-bundle/3.3/src/Kernel.php
+++ b/symfony/framework-bundle/3.3/src/Kernel.php
@@ -36,6 +36,7 @@ class Kernel extends BaseKernel
 
     protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader)
     {
+        $container->addResource(new FileResource($this->getProjectDir().'/config/bundles.php'));
         // Feel free to remove the "container.autowiring.strict_mode" parameter
         // if you are using symfony/dependency-injection 4.0+ as it's the default behavior
         $container->setParameter('container.autowiring.strict_mode', true);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

This is an annoying detail :). If you change the `bundles.php` file by hand (e.g. to add a bundle manually - not common, but I just did it for some internal bundles), the container will not rebuild. I tested this this fixes that issue.
