### PR TITLE
Fixed not imported FQCN in Framework recipe

### DIFF
--- a/symfony/framework-bundle/3.3/src/Kernel.php
+++ b/symfony/framework-bundle/3.3/src/Kernel.php
@@ -4,6 +4,7 @@ namespace App;
 
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel as BaseKernel;
 use Symfony\Component\Routing\RouteCollectionBuilder;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

https://github.com/symfony/recipes/pull/379 introduced a major bug (making all commands/controllers unusable) by not importing this FQCN. As a result, fresh installations get this error:

 > Fatal error: Uncaught Symfony\Component\Debug\Exception\ClassNotFoundException: Attempted to load class "FileResource" from namespace "App".

Reported by `@AO` on Symfony Slack. Thanks!