### PR TITLE
[DX] Set default_table_options to match default utf8mb4 charset

### DIFF
--- a/doctrine/doctrine-bundle/1.6/config/packages/doctrine.yaml
+++ b/doctrine/doctrine-bundle/1.6/config/packages/doctrine.yaml
@@ -11,6 +11,9 @@ doctrine:
         driver: 'pdo_mysql'
         server_version: '5.7'
         charset: utf8mb4
+        default_table_options:
+            charset: utf8mb4
+            collate: utf8mb4_unicode_ci
 
         # With Symfony 3.3, remove the `resolve:` prefix
         url: '%env(resolve:DATABASE_URL)%'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

The `default_table_options` options should match the default charset `utf8mb4` so the migrations will generate each table with `utf8mb4` + `utf8mb4_unicode_ci` instead of `utf8` + `utf8_unicode_ci`, so users don't have to specify the `table_options` for each entity.