### PR TITLE
Update lexik/jwt-authentication-bundle gitignore

### DIFF
--- a/lexik/jwt-authentication-bundle/2.3/manifest.json
+++ b/lexik/jwt-authentication-bundle/2.3/manifest.json
@@ -13,6 +13,6 @@
         "JWT_PASSPHRASE": "%generate(secret)%"
     },
     "gitignore": [
-    	"config/jwt/*.pem"
+    	"/config/jwt/*.pem"
     ]
 }

--- a/lexik/jwt-authentication-bundle/2.3/manifest.json
+++ b/lexik/jwt-authentication-bundle/2.3/manifest.json
@@ -13,6 +13,6 @@
         "JWT_PASSPHRASE": "%generate(secret)%"
     },
     "gitignore": [
-    	"%CONFIG_DIR%/jwt/*.pem"
+    	"config/jwt/*.pem"
     ]
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

After installation i literally see

```
###> lexik/jwt-authentication-bundle ###
%CONFIG_DIR%/jwt/*.pem
###< lexik/jwt-authentication-bundle ###
```

in my project's `.gitignore`. Note the `%CONFIG_DIR%` which is an unknown directory.

Curious if the recipe is wrong, or it's a bug in flex (using v1.0.71)