### PR TITLE
[DebugBundle] Enable the VarDumper server dumper by default on dev

### DIFF
--- a/symfony/debug-bundle/4.1/config/packages/dev/debug.yaml
+++ b/symfony/debug-bundle/4.1/config/packages/dev/debug.yaml
@@ -1,0 +1,4 @@
+debug:
+    # Forwards VarDumper Data clones to a centralized server allowing to inspect dumps on CLI or in your browser.
+    # See the "server:dump" command to start a new server.
+    dump_destination: "tcp://%env(VAR_DUMPER_SERVER)%"

--- a/symfony/debug-bundle/4.1/manifest.json
+++ b/symfony/debug-bundle/4.1/manifest.json
@@ -1,0 +1,8 @@
+{
+    "bundles": {
+        "Symfony\\Bundle\\DebugBundle\\DebugBundle": ["dev", "test"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

<!--
Please, carefully read the README before submitting a pull request.
-->

See https://github.com/symfony/symfony/pull/23831 regarding the feature.

Always enabling it on dev mode should be safe, as the server dumper fallbacks on the original dumper if the server isn't listening. So everything should work as usual.
