### PR TITLE
Add npm and Yarn error logs to .gitignore

### DIFF
--- a/symfony/webpack-encore-pack/1.0/manifest.json
+++ b/symfony/webpack-encore-pack/1.0/manifest.json
@@ -8,7 +8,7 @@
     "gitignore": [
         "/node_modules/",
         "/%PUBLIC_DIR%/build/",
-        "/npm-debug.log",
-        "/yarn-error.log"
+        "npm-debug.log",
+        "yarn-error.log"
     ]
 }

--- a/symfony/webpack-encore-pack/1.0/manifest.json
+++ b/symfony/webpack-encore-pack/1.0/manifest.json
@@ -7,6 +7,8 @@
     "aliases": ["encore", "webpack", "webpack-encore"],
     "gitignore": [
         "/node_modules/",
-        "/%PUBLIC_DIR%/build/"
+        "/%PUBLIC_DIR%/build/",
+        "/npm-debug.log",
+        "/yarn-error.log"
     ]
 }


### PR DESCRIPTION
By default, it is a good idea to add the npm/Yarn error logs to .gitignore when installing the Encore package so they don't accidentally get committed. There are many common situations which cause an error log to be generated, whether through running commands, or installing Node.js packages. In my case, it was because the Encore command exits with a code of 1 when `yarn run encore --help` is run.

| Q             | A
| ------------- | ---
| License       | MIT