### PR TITLE
removing the Symfony 3.3 warning, because that version is no longer supported

### DIFF
--- a/doctrine/doctrine-bundle/1.6/config/packages/doctrine.yaml
+++ b/doctrine/doctrine-bundle/1.6/config/packages/doctrine.yaml
@@ -15,7 +15,6 @@ doctrine:
             charset: utf8mb4
             collate: utf8mb4_unicode_ci
 
-        # With Symfony 3.3, remove the `resolve:` prefix
         url: '%env(resolve:DATABASE_URL)%'
     orm:
         auto_generate_proxy_classes: '%kernel.debug%'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Simple: Symfony 3.3 is no longer supported. So, no need for this message anymore.
