### PR TITLE
Update Console Binary

### DIFF
--- a/symfony/console/3.3/bin/console
+++ b/symfony/console/3.3/bin/console
@@ -23,7 +23,7 @@ if (!isset($_SERVER['APP_ENV'])) {
 }
 
 $input = new ArgvInput();
-$env = $input->getParameterOption(['--env', '-e'], $_SERVER['APP_ENV'] ?? 'dev', true);
+$env = $input->getParameterOption(['--env', '-e'], false, true) ?: ($_SERVER['APP_ENV'] ?? 'dev');
 $debug = (bool) ($_SERVER['APP_DEBUG'] ?? ('prod' !== $env)) && !$input->hasParameterOption('--no-debug', true);
 
 if ($debug) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Currently, all commands that include a bare double dash (`--`) without specifying the environment before will pass `bool(false)` to the Kernel as the environment, rather than the default environment `string(3) "dev"`. If `declare(strict_types=1)` has been set, the following error will occur:

```
PHP Fatal error:  Uncaught Symfony\Component\Debug\Exception\FatalThrowableError: Type error: Argument 1 passed to Symfony\Component\HttpKernel\Kernel::__construct() must be of the type string, boolean given, called in ~/symfony-project/bin/console on line 41 in ~/symfony-project/vendor/symfony/http-kernel/Kernel.php:76
Stack trace:
#0 ~/symfony-project/bin/console(41): Symfony\Component\HttpKernel\Kernel->__construct(false, true)
#1 {main}
  thrown in ~/symfony-project/vendor/symfony/http-kernel/Kernel.php on line 76
```

This change ensures that a default environment is always given to the Kernel constructor even when one is not supplied on the command-line.

### Example

The following example can be used to replicate the error:

```bash
$ git clone git://github.com/symfony/skeleton.git ./symfony-project
$ cd symfony-project
$ composer install
# Add "declare(strict_types=1);" to "bin/console".
$ bin/console --ansi -- debug:router
```