### PR TITLE
Described EasyLog Handler activation after install

### DIFF
--- a/easycorp/easy-log-handler/1.0/config/packages/dev/easy_log_handler.yaml
+++ b/easycorp/easy-log-handler/1.0/config/packages/dev/easy_log_handler.yaml
@@ -3,7 +3,6 @@ services:
         public: false
         arguments: ['%kernel.logs_dir%/%kernel.environment%.log']
 
-#// FIXME: How to add this configuration automatically without messing up with the monolog configuration?
 #monolog:
 #    handlers:
 #        buffered:

--- a/easycorp/easy-log-handler/1.0/post-install.txt
+++ b/easycorp/easy-log-handler/1.0/post-install.txt
@@ -1,0 +1,6 @@
+<bg=blue;fg=white>                  </>
+<bg=blue;fg=white> Easy Log Handler </>
+<bg=blue;fg=white>                  </>
+
+  * Uncomment Monolog configuration in <comment>%CONFIG_DIR%/packages/dev/easy_log_handler.yaml</comment>
+    to enable Easy Log Handler.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

I believe this PR improves DX when requiring the `easycorp/easy-log-handler` package (and thus the `debug`symfony pack also).

IMHO, there is no solution which could answer the question asked in the `FIXME` comment of the configuration file:
> How to add this configuration automatically without messing up with the monolog configuration?

The only acceptable solution I see is to NOT automatically add the configuration and provide a quick getting started message which will guide developers.