### PR TITLE
Bootstrap environment 

### DIFF
--- a/phpunit/phpunit/4.7/phpunit.xml.dist
+++ b/phpunit/phpunit/4.7/phpunit.xml.dist
@@ -5,16 +5,16 @@
          xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.1/phpunit.xsd"
          backupGlobals="false"
          colors="true"
-         bootstrap="vendor/autoload.php"
+         bootstrap="tests/bootstrap.php"
 >
     <php>
         <ini name="error_reporting" value="-1" />
         <env name="KERNEL_CLASS" value="App\Kernel" />
+        <env name="SHELL_VERBOSITY" value="-1" />
+
+        <!-- override or set env variables for the test env here -->
         <env name="APP_ENV" value="test" />
         <env name="APP_DEBUG" value="1" />
-        <env name="APP_SECRET" value="s$cretf0rt3st" />
-        <env name="SHELL_VERBOSITY" value="-1" />
-        <!-- define your env variables for the test env here -->
     </php>
 
     <testsuites>

--- a/phpunit/phpunit/4.7/phpunit.xml.dist
+++ b/phpunit/phpunit/4.7/phpunit.xml.dist
@@ -14,7 +14,6 @@
 
         <!-- override or set env variables for the test env here -->
         <env name="APP_ENV" value="test" />
-        <env name="APP_DEBUG" value="1" />
     </php>
 
     <testsuites>

--- a/phpunit/phpunit/4.7/tests/bootstrap.php
+++ b/phpunit/phpunit/4.7/tests/bootstrap.php
@@ -9,7 +9,7 @@ use App\Kernel;
  * Those variables will override any defined in .env.
  */
 
-Kernel::bootstrapEnvironment();
+Kernel::bootstrapEnvironment($_ENV['APP_ENV'] ?? null);
 
 $debug = $_SERVER['APP_DEBUG'] ?? true;
 

--- a/phpunit/phpunit/4.7/tests/bootstrap.php
+++ b/phpunit/phpunit/4.7/tests/bootstrap.php
@@ -1,0 +1,18 @@
+<?php
+
+require __DIR__.'/../vendor/autoload.php';
+
+use App\Kernel;
+
+/*
+ * Environment variables can also be specified in phpunit.xml.dist.
+ * Those variables will override any defined in .env.
+ */
+
+Kernel::bootstrapEnvironment();
+
+$debug = $_SERVER['APP_DEBUG'] ?? true;
+
+if ($debug) {
+    umask(0000);
+}

--- a/symfony/console/3.3/bin/console
+++ b/symfony/console/3.3/bin/console
@@ -5,7 +5,6 @@ use App\Kernel;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Debug\Debug;
-use Symfony\Component\Dotenv\Dotenv;
 
 set_time_limit(0);
 

--- a/symfony/console/3.3/bin/console
+++ b/symfony/console/3.3/bin/console
@@ -15,7 +15,7 @@ if (!class_exists(Application::class)) {
 }
 
 $input = new ArgvInput();
-$env = $input->getParameterOption(['--env', '-e'], $_SERVER['APP_ENV'] ?? 'dev', true);
+$env = $input->getParameterOption(['--env', '-e'], null, true);
 
 Kernel::bootstrapEnvironment($env);
 

--- a/symfony/console/3.3/bin/console
+++ b/symfony/console/3.3/bin/console
@@ -15,15 +15,11 @@ if (!class_exists(Application::class)) {
     throw new \RuntimeException('You need to add "symfony/framework-bundle" as a Composer dependency.');
 }
 
-if (!isset($_SERVER['APP_ENV'])) {
-    if (!class_exists(Dotenv::class)) {
-        throw new \RuntimeException('APP_ENV environment variable is not defined. You need to define environment variables for configuration or add "symfony/dotenv" as a Composer dependency to load variables from a .env file.');
-    }
-    (new Dotenv())->load(__DIR__.'/../.env');
-}
-
 $input = new ArgvInput();
 $env = $input->getParameterOption(['--env', '-e'], $_SERVER['APP_ENV'] ?? 'dev', true);
+
+Kernel::bootstrapEnvironment($env);
+
 $debug = (bool) ($_SERVER['APP_DEBUG'] ?? ('prod' !== $env)) && !$input->hasParameterOption('--no-debug', true);
 
 if ($debug) {

--- a/symfony/framework-bundle/3.3/public/index.php
+++ b/symfony/framework-bundle/3.3/public/index.php
@@ -2,18 +2,11 @@
 
 use App\Kernel;
 use Symfony\Component\Debug\Debug;
-use Symfony\Component\Dotenv\Dotenv;
 use Symfony\Component\HttpFoundation\Request;
 
 require __DIR__.'/../vendor/autoload.php';
 
-// The check is to ensure we don't use .env in production
-if (!isset($_SERVER['APP_ENV'])) {
-    if (!class_exists(Dotenv::class)) {
-        throw new \RuntimeException('APP_ENV environment variable is not defined. You need to define environment variables for configuration or add "symfony/dotenv" as a Composer dependency to load variables from a .env file.');
-    }
-    (new Dotenv())->load(__DIR__.'/../.env');
-}
+Kernel::bootstrapEnvironment();
 
 $env = $_SERVER['APP_ENV'] ?? 'dev';
 $debug = (bool) ($_SERVER['APP_DEBUG'] ?? ('prod' !== $env));

--- a/symfony/framework-bundle/3.3/src/Kernel.php
+++ b/symfony/framework-bundle/3.3/src/Kernel.php
@@ -6,6 +6,7 @@ use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Dotenv\Dotenv;
 use Symfony\Component\HttpKernel\Kernel as BaseKernel;
 use Symfony\Component\Routing\RouteCollectionBuilder;
 
@@ -33,6 +34,27 @@ class Kernel extends BaseKernel
                 yield new $class();
             }
         }
+    }
+
+    public static function bootstrapEnvironment(string $env = null)
+    {
+        $env = $env ?? $_SERVER['APP_ENV'] ?? null;
+        $projectDir = __DIR__.'/..';
+        if (!$env && !class_exists(Dotenv::class)) {
+            throw new \RuntimeException('Environment not defined. You need to define environment variables for configuration or add "symfony/dotenv" as a Composer dependency to load variables from a .env file.');
+        }
+
+        // Dotenv is not installed or generic env file is not present
+        // Assume envs are already defined
+        if (!class_exists(Dotenv::class) || !file_exists($projectDir.'/.env')) {
+            return;
+        }
+
+        $envFiles = ["$projectDir/.env"];
+        if (file_exists($file = "$projectDir/.env.$env")) {
+            $envFiles[] = $file;
+        }
+        (new Dotenv())->load(...$envFiles);
     }
 
     protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader)

--- a/symfony/phpunit-bridge/3.3/phpunit.xml.dist
+++ b/symfony/phpunit-bridge/3.3/phpunit.xml.dist
@@ -5,16 +5,16 @@
          xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.1/phpunit.xsd"
          backupGlobals="false"
          colors="true"
-         bootstrap="vendor/autoload.php"
+         bootstrap="tests/bootstrap.php"
 >
     <php>
         <ini name="error_reporting" value="-1" />
         <env name="KERNEL_CLASS" value="App\Kernel" />
+        <env name="SHELL_VERBOSITY" value="-1" />
+
+        <!-- override or set env variables for the test env here -->
         <env name="APP_ENV" value="test" />
         <env name="APP_DEBUG" value="1" />
-        <env name="APP_SECRET" value="s$cretf0rt3st" />
-        <env name="SHELL_VERBOSITY" value="-1" />
-        <!-- define your env variables for the test env here -->
     </php>
 
     <testsuites>

--- a/symfony/phpunit-bridge/3.3/tests/bootstrap.php
+++ b/symfony/phpunit-bridge/3.3/tests/bootstrap.php
@@ -9,7 +9,7 @@ use App\Kernel;
  * Those variables will override any defined in .env.
  */
 
-Kernel::bootstrapEnvironment();
+Kernel::bootstrapEnvironment($_ENV['APP_ENV'] ?? null);
 
 $debug = $_SERVER['APP_DEBUG'] ?? true;
 

--- a/symfony/phpunit-bridge/3.3/tests/bootstrap.php
+++ b/symfony/phpunit-bridge/3.3/tests/bootstrap.php
@@ -1,0 +1,18 @@
+<?php
+
+require __DIR__.'/../vendor/autoload.php';
+
+use App\Kernel;
+
+/*
+ * Environment variables can also be specified in phpunit.xml.dist.
+ * Those variables will override any defined in .env.
+ */
+
+Kernel::bootstrapEnvironment();
+
+$debug = $_SERVER['APP_DEBUG'] ?? true;
+
+if ($debug) {
+    umask(0000);
+}


### PR DESCRIPTION
Picking up one of @weaverryan branches and helping out glue everything together having in consideration the discussion on his PR #366 and the DotEnvLoad from @ogizanagi.

Below is the copy of that PR.

| Q             | A
| ------------- | ---
| License       | MIT

Fixes https://github.com/symfony/flex/issues/251

WIP
====

Needs to be reviewed and need tests? 

Problem
======

The problem is that currently, environment variables must be completely duplicated between .env and phpunit.xml.dist

Solution
=======

Extend the Kernel to allow different env to be loaded, falling back to the old behaviour ($_SERVER['APP_ENV']). The env files are overwritten, so we always load `.env` and `.env.test` values will override `.env` ones and so on.

.env is read in the same way as bin/console and public/index.php
Environment variables in phpunit.xml.dist WIN over .env.
