### PR TITLE
[webpack-encore] use versioned assets

### DIFF
--- a/symfony/webpack-encore-pack/1.0/config/packages/assets.yaml
+++ b/symfony/webpack-encore-pack/1.0/config/packages/assets.yaml
@@ -1,0 +1,3 @@
+framework:
+    assets:
+        json_manifest_path: '%kernel.project_dir%/public/build/manifest.json'

--- a/symfony/webpack-encore-pack/1.0/manifest.json
+++ b/symfony/webpack-encore-pack/1.0/manifest.json
@@ -1,6 +1,7 @@
 {
     "copy-from-recipe": {
         "assets/": "assets/",
+        "config/": "%CONFIG_DIR%/",
         "package.json": "package.json",
         "webpack.config.js": "webpack.config.js"
     },

--- a/symfony/webpack-encore-pack/1.0/webpack.config.js
+++ b/symfony/webpack-encore-pack/1.0/webpack.config.js
@@ -5,7 +5,7 @@ Encore
     .setOutputPath('public/build/')
     // the public path used by the web server to access the previous directory
     .setPublicPath('/build')
-    // the path inside the Symfony app, as given to the asset() function
+    // the public path you will use in Symfony's asset() function - e.g. asset('build/some_file.js')
     .setManifestKeyPrefix('build/')
 
     .cleanupOutputBeforeBuild()

--- a/symfony/webpack-encore-pack/1.0/webpack.config.js
+++ b/symfony/webpack-encore-pack/1.0/webpack.config.js
@@ -5,20 +5,27 @@ Encore
     .setOutputPath('public/build/')
     // the public path used by the web server to access the previous directory
     .setPublicPath('/build')
+    // the path inside the Symfony app, as given to the asset() function
+    .setManifestKeyPrefix('build/')
+
     .cleanupOutputBeforeBuild()
     .enableSourceMaps(!Encore.isProduction())
-    // uncomment to create hashed filenames (e.g. app.abc123.css)
-    // .enableVersioning(Encore.isProduction())
+
+    // the following line enables hashed filenames (e.g. app.abc123.css)
+    .enableVersioning(Encore.isProduction())
 
     // uncomment to define the assets of the project
-    // .addEntry('js/app', './assets/js/app.js')
-    // .addStyleEntry('css/app', './assets/css/app.scss')
+    //.addEntry('js/app', './assets/js/app.js')
+    //.addStyleEntry('css/app', './assets/css/app.scss')
+
+    // uncomment if you use TypeScript
+    //.enableTypeScriptLoader()
 
     // uncomment if you use Sass/SCSS files
-    // .enableSassLoader()
+    //.enableSassLoader()
 
     // uncomment for legacy applications that require $/jQuery as a global variable
-    // .autoProvidejQuery()
+    //.autoProvidejQuery()
 ;
 
 module.exports = Encore.getWebpackConfig();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Let's enable versioned assets by default?
Related to https://github.com/symfony/webpack-encore-pack/pull/1