### PR TITLE
[symfony/twig-bundle] remove "paths", thats already the default

### DIFF
--- a/symfony/twig-bundle/3.3/config/packages/twig.yaml
+++ b/symfony/twig-bundle/3.3/config/packages/twig.yaml
@@ -1,4 +1,3 @@
 twig:
-    paths: ['%kernel.project_dir%/templates']
     debug: '%kernel.debug%'
     strict_variables: '%kernel.debug%'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

since 3.4 at least, but 3.3 is EOLed.