### PR TITLE
base.html.twig: remove optional tags

### DIFF
--- a/symfony/twig-bundle/3.3/templates/base.html.twig
+++ b/symfony/twig-bundle/3.3/templates/base.html.twig
@@ -1,12 +1,6 @@
 <!DOCTYPE html>
-<html>
-    <head>
-        <meta charset="UTF-8">
-        <title>{% block title %}Welcome!{% endblock %}</title>
-        {% block stylesheets %}{% endblock %}
-    </head>
-    <body>
-        {% block body %}{% endblock %}
-        {% block javascripts %}{% endblock %}
-    </body>
-</html>
+<meta charset="UTF-8">
+<title>{% block title %}Welcome!{% endblock %}</title>
+{% block stylesheets %}{% endblock %}
+{% block body %}<p>Welcome to Symfony{% endblock %}
+{% block javascripts %}{% endblock %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Remove optional tags according to [Google Best Practices](https://google.github.io/styleguide/htmlcssguide.html#Optional_Tags) and [the HTML5 spec](https://html.spec.whatwg.org/multipage/syntax.html#syntax-tag-omission).

Having a minimalist starting file is more in the spirit of Flex.