### PR TITLE
[lexik_jwt_authentication] Add recipe for v2.5

### DIFF
--- a/lexik/jwt-authentication-bundle/2.5/config/packages/lexik_jwt_authentication.yaml
+++ b/lexik/jwt-authentication-bundle/2.5/config/packages/lexik_jwt_authentication.yaml
@@ -1,0 +1,4 @@
+lexik_jwt_authentication:
+    secret_key: '%env(resolve:JWT_SECRET_KEY)%'
+    public_key: '%env(resolve:JWT_PUBLIC_KEY)%'
+    pass_phrase: '%env(JWT_PASSPHRASE)%'

--- a/lexik/jwt-authentication-bundle/2.5/manifest.json
+++ b/lexik/jwt-authentication-bundle/2.5/manifest.json
@@ -1,0 +1,17 @@
+{
+    "bundles": {
+        "Lexik\\Bundle\\JWTAuthenticationBundle\\LexikJWTAuthenticationBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%"
+    },
+    "aliases": ["jwt-auth"],
+    "env": {
+        "JWT_SECRET_KEY": "%kernel.project_dir%/%CONFIG_DIR%/jwt/private.pem",
+        "JWT_PUBLIC_KEY": "%kernel.project_dir%/%CONFIG_DIR%/jwt/public.pem",
+        "JWT_PASSPHRASE": "%generate(secret)%"
+    },
+    "gitignore": [
+        "/%CONFIG_DIR%/jwt/*.pem"
+    ]
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

The change requiring a new version of the recipe is that the `public_key_path` and `private_key_path` have been renamed to `public_key` and `secret_key`.

Motivation for this naming change is that they now both accept a raw key as value, which allows storing the raw key itself as an env var and configure the bundle like `secret_key: %env(JWT_PRIVATE_KEY)%` or use whatever custom env var processor to resolve the raw key (I need some feedbacks before using this for the recipe config). Additionally HMAC support was added, which requires only `secret_key` to be set with a raw secret string.
Lastly, only one of the key is required by the config tree (think SSO, server needs the secret key and clients need the public one, no side require to hold both, clients must not know about the secret key).