### PR TITLE
disable route annotations with SensioFrameworkExtraBundle 5.2

### DIFF
--- a/sensio/framework-extra-bundle/5.2/config/packages/sensio_framework_extra.yaml
+++ b/sensio/framework-extra-bundle/5.2/config/packages/sensio_framework_extra.yaml
@@ -1,0 +1,3 @@
+sensio_framework_extra:
+    router:
+        annotations: false

--- a/sensio/framework-extra-bundle/5.2/manifest.json
+++ b/sensio/framework-extra-bundle/5.2/manifest.json
@@ -1,0 +1,9 @@
+{
+    "bundles": {
+        "Sensio\\Bundle\\FrameworkExtraBundle\\SensioFrameworkExtraBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "aliases": ["annotations", "annotation", "annot", "annots"]
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

see sensiolabs/SensioFrameworkExtraBundle#562

Credits go to @mehranhadidi who made me aware of this in the Symfony Slack.