### PR TITLE
Use default_path instead of paths for Twig and Translator config

### DIFF
--- a/symfony/translation/3.3/config/packages/translation.yaml
+++ b/symfony/translation/3.3/config/packages/translation.yaml
@@ -1,7 +1,6 @@
 framework:
     default_locale: '%locale%'
     translator:
-        paths:
-            - '%kernel.project_dir%/translations'
+        default_path: '%kernel.project_dir%/translations'
         fallbacks:
             - '%locale%'

--- a/symfony/twig-bundle/3.3/config/packages/twig.yaml
+++ b/symfony/twig-bundle/3.3/config/packages/twig.yaml
@@ -1,6 +1,4 @@
 twig:
     default_path: '%kernel.project_dir%/templates'
-    # additional template paths
-    #paths: []
     debug: '%kernel.debug%'
     strict_variables: '%kernel.debug%'

--- a/symfony/twig-bundle/3.3/config/packages/twig.yaml
+++ b/symfony/twig-bundle/3.3/config/packages/twig.yaml
@@ -1,4 +1,4 @@
 twig:
-    paths: ['%kernel.project_dir%/templates']
+    default_path: '%kernel.project_dir%/templates'
     debug: '%kernel.debug%'
     strict_variables: '%kernel.debug%'

--- a/symfony/twig-bundle/3.3/config/packages/twig.yaml
+++ b/symfony/twig-bundle/3.3/config/packages/twig.yaml
@@ -1,4 +1,6 @@
 twig:
     default_path: '%kernel.project_dir%/templates'
+    # additional template paths
+    #paths: []
     debug: '%kernel.debug%'
     strict_variables: '%kernel.debug%'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Fix https://github.com/symfony/recipes/pull/416#issuecomment-404230767
