### PR TITLE
Fix injection of SecurityChecker with Crawler

### DIFF
--- a/sensiolabs/security-checker/4.2/config/packages/security_checker.yaml
+++ b/sensiolabs/security-checker/4.2/config/packages/security_checker.yaml
@@ -1,0 +1,13 @@
+services:
+    SensioLabs\Security\Crawler:
+        public: false
+
+    SensioLabs\Security\SecurityChecker:
+        arguments: ['@SensioLabs\Security\Crawler']
+        public: false
+
+    SensioLabs\Security\Command\SecurityCheckerCommand:
+        arguments: ['@SensioLabs\Security\SecurityChecker']
+        public: false
+        tags:
+            - { name: console.command, command: 'security:check' }

--- a/sensiolabs/security-checker/4.2/manifest.json
+++ b/sensiolabs/security-checker/4.2/manifest.json
@@ -1,0 +1,9 @@
+{
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "composer-scripts": {
+        "security-checker security:check": "script"
+    },
+    "aliases": ["security-check", "security-checker", "sec-checker", "sec-check", "sec-checks"]
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Fix the instantiation error of [SecurityChecker](https://github.com/sensiolabs/security-checker/blob/master/SensioLabs/Security/SecurityChecker.php) in the next release.

```
Too few arguments to function SensioLabs\Security\SecurityChecker::__construct(), 0 passed in /Users/mhe/www/perso/my-api/var/cache/dev/ContainerYAbmEjX/getSecurityCheckerCommandService.php on line 13 and exactly 1 expected 
```
