### PR TITLE
prevent yaml lint error

### DIFF
--- a/symfony/monolog-bundle/3.1/config/packages/dev/monolog.yaml
+++ b/symfony/monolog-bundle/3.1/config/packages/dev/monolog.yaml
@@ -14,6 +14,6 @@ monolog:
         #    type: chromephp
         #    level: info
         console:
-            type:   console
+            type: console
             process_psr_3_messages: false
             channels: ["!event", "!doctrine", "!console"]


### PR DESCRIPTION
yamllint: too many spaces after colon (colons)

| Q             | A
| ------------- | ---
| License       | MIT

<!--
Please, carefully read the README before submitting a pull request.
-->
