### PR TITLE
prevent yaml lint error

### DIFF
--- a/symfony/monolog-bundle/3.1/config/packages/prod/monolog.yaml
+++ b/symfony/monolog-bundle/3.1/config/packages/prod/monolog.yaml
@@ -12,6 +12,6 @@ monolog:
             path: "%kernel.logs_dir%/%kernel.environment%.log"
             level: debug
         console:
-            type:   console
+            type: console
             process_psr_3_messages: false
             channels: ["!event", "!doctrine"]


### PR DESCRIPTION
yamllint: too many spaces after colon (colons)

| Q             | A
| ------------- | ---
| License       | MIT

Same like #436, but for the `prod` env.
Sorry for creating 2 Pull-Requests, but used the WYSIWYG-Editor on github.com for this...
