### PR TITLE
[DoctrineBundle] set auto_generate_proxy_classes to true, false in prod

### DIFF
--- a/doctrine/doctrine-bundle/1.6/config/packages/doctrine.yaml
+++ b/doctrine/doctrine-bundle/1.6/config/packages/doctrine.yaml
@@ -17,7 +17,7 @@ doctrine:
 
         url: '%env(resolve:DATABASE_URL)%'
     orm:
-        auto_generate_proxy_classes: '%kernel.debug%'
+        auto_generate_proxy_classes: true
         naming_strategy: doctrine.orm.naming_strategy.underscore
         auto_mapping: true
         mappings:

--- a/doctrine/doctrine-bundle/1.6/config/packages/prod/doctrine.yaml
+++ b/doctrine/doctrine-bundle/1.6/config/packages/prod/doctrine.yaml
@@ -1,5 +1,6 @@
 doctrine:
     orm:
+        auto_generate_proxy_classes: false
         metadata_cache_driver:
             type: service
             id: doctrine.system_cache_provider


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

This change will allow tests to be more easily run with `debug=false`.

Ref: https://github.com/symfony/recipes/pull/242