### PR TITLE
[phpunit-bridge] default to not failing on deprecations

### DIFF
--- a/symfony/phpunit-bridge/3.3/bin/phpunit
+++ b/symfony/phpunit-bridge/3.3/bin/phpunit
@@ -5,6 +5,10 @@ if (!file_exists(dirname(__DIR__).'/vendor/symfony/phpunit-bridge/bin/simple-php
     echo "Unable to find the `simple-phpunit` script in `vendor/symfony/phpunit-bridge/bin/`.\n";
     exit(1);
 }
+if (false === getenv('SYMFONY_DEPRECATIONS_HELPER')) {
+    // see https://symfony.com/doc/current/components/phpunit_bridge.html#making-tests-fail
+    putenv('SYMFONY_DEPRECATIONS_HELPER=999999');
+}
 if (false === getenv('SYMFONY_PHPUNIT_REMOVE')) {
     putenv('SYMFONY_PHPUNIT_REMOVE=symfony/yaml');
 }

--- a/symfony/phpunit-bridge/4.1/bin/phpunit
+++ b/symfony/phpunit-bridge/4.1/bin/phpunit
@@ -5,6 +5,10 @@ if (!file_exists(dirname(__DIR__).'/vendor/symfony/phpunit-bridge/bin/simple-php
     echo "Unable to find the `simple-phpunit` script in `vendor/symfony/phpunit-bridge/bin/`.\n";
     exit(1);
 }
+if (false === getenv('SYMFONY_DEPRECATIONS_HELPER')) {
+    // see https://symfony.com/doc/current/components/phpunit_bridge.html#making-tests-fail
+    putenv('SYMFONY_DEPRECATIONS_HELPER=999999');
+}
 if (false === getenv('SYMFONY_PHPUNIT_REMOVE')) {
     putenv('SYMFONY_PHPUNIT_REMOVE=');
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Until now, I've been advocating that peoples' CI should fail whenever a deprecation is reported.
But when a vendor throws a deprecation, sometime, it's not your fault and you can't do anything about it (except contributing back to the project, which is good for OSS!)

Talking on Slack, @greg0ire convinced me we can do this change: by setting `SYMFONY_DEPRECATIONS_HELPER` to `999999` by default, we make ppls' CI green (when they don't raise more than 1M deprecations.)
And it still makes the deprecation report visible on the tests' output so that ppl still have some incentive to fix them.

Fixes https://github.com/symfony/symfony/issues/27936