### PR TITLE
[monolog-bundle] log deprecations by default, in a dedicated log file

### DIFF
--- a/symfony/monolog-bundle/3.1/config/packages/prod/monolog.yaml
+++ b/symfony/monolog-bundle/3.1/config/packages/prod/monolog.yaml
@@ -15,3 +15,11 @@ monolog:
             type: console
             process_psr_3_messages: false
             channels: ["!event", "!doctrine"]
+        deprecation:
+            type: stream
+            path: "%kernel.logs_dir%/%kernel.environment%.deprecations.log"
+        deprecation_filter:
+            type: filter
+            handler: deprecation
+            max_level: info
+            channels: ["php"]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Only deprecations are logged at "INFO" level on the "php" channel.
Let's write them down by default in prod, since deprecations that happen in prod may be seen only there (typically when you don't have 100% test coverage, do you?)