### PR TITLE
Allow installation of latest encore version

### DIFF
--- a/symfony/webpack-encore-pack/1.0/package.json
+++ b/symfony/webpack-encore-pack/1.0/package.json
@@ -1,6 +1,6 @@
 {
     "devDependencies": {
-        "@symfony/webpack-encore": "^0.19.0",
+        "@symfony/webpack-encore": "^0.20.0",
         "webpack-notifier": "^1.6.0"
     },
     "license": "UNLICENSED",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Under yarn/npm versioning rules, the new `0.20.*` versions  weren't installable by default,  see also: 
https://docs.npmjs.com/misc/semver#caret-ranges-123-025-004

Its pretty much the same as composer versioning, as in it wont bump minor versions in pre `1.0.0` versioning.
