### PR TITLE
 [FrameworkBundle] New `parameters.yaml` file + Remove `parameters` key from `services.yaml`

### DIFF
--- a/symfony/framework-bundle/3.3/config/parameters.yaml
+++ b/symfony/framework-bundle/3.3/config/parameters.yaml
@@ -1,0 +1,3 @@
+# Put parameters here that don't need to change on each machine where the app is deployed
+# https://symfony.com/doc/current/best_practices/configuration.html#application-related-configuration
+parameters:

--- a/symfony/framework-bundle/3.3/config/services.yaml
+++ b/symfony/framework-bundle/3.3/config/services.yaml
@@ -1,10 +1,6 @@
 # This file is the entry point to configure your own services.
 # Files in the packages/ subdirectory configure your dependencies.
 
-# Put parameters here that don't need to change on each machine where the app is deployed
-# https://symfony.com/doc/current/best_practices/configuration.html#application-related-configuration
-parameters:
-
 services:
     # default configuration for services in *this* file
     _defaults:

--- a/symfony/framework-bundle/3.3/src/Kernel.php
+++ b/symfony/framework-bundle/3.3/src/Kernel.php
@@ -44,6 +44,7 @@ class Kernel extends BaseKernel
         $container->setParameter('container.dumper.inline_class_loader', true);
         $confDir = $this->getProjectDir().'/config';
 
+        $loader->load($confDir.'/{parameters}'.self::CONFIG_EXTS, 'glob');
         $loader->load($confDir.'/{packages}/*'.self::CONFIG_EXTS, 'glob');
         $loader->load($confDir.'/{packages}/'.$this->environment.'/**/*'.self::CONFIG_EXTS, 'glob');
         $loader->load($confDir.'/{services}'.self::CONFIG_EXTS, 'glob');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

What this PR hopes to accomplish, is remove the `parameters` key from `services.yaml`, it's a bit counter intuitive for the parameters to be in the `services.yaml` file.  
  
Also the parameters could get quite many, also the services, so the separation would make the files more clear as to what they should do.  
  
Another advantage this has, because the `parameters.yaml` file gets loaded before other configs, an environment could overwrite a parameter (for whatever reason) by providing a `parameters.yaml` file in the `packages/{env}` folder. This is intuitive, you would think that by placing this file in an environment folder it would overwrite the parameters that you set in it.
