### PR TITLE
Set framework.router.strict_requirements to true in test env by default

### DIFF
--- a/symfony/routing/3.3/config/packages/test/routing.yaml
+++ b/symfony/routing/3.3/config/packages/test/routing.yaml
@@ -1,0 +1,3 @@
+framework:
+    router:
+        strict_requirements: true

--- a/symfony/routing/4.0/config/packages/test/routing.yaml
+++ b/symfony/routing/4.0/config/packages/test/routing.yaml
@@ -1,0 +1,3 @@
+framework:
+    router:
+        strict_requirements: true

--- a/symfony/routing/4.2/config/packages/test/routing.yaml
+++ b/symfony/routing/4.2/config/packages/test/routing.yaml
@@ -1,0 +1,3 @@
+framework:
+    router:
+        strict_requirements: true


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Related issue https://github.com/symfony/recipes/issues/454