### PR TITLE
Slightly tweak the comment

### DIFF
--- a/symfony/framework-bundle/4.2/public/index.php
+++ b/symfony/framework-bundle/4.2/public/index.php
@@ -7,7 +7,7 @@ use Symfony\Component\HttpFoundation\Request;
 
 require __DIR__.'/../vendor/autoload.php';
 
-// The check is to ensure we don't use .env in production
+// The check is to ensure we don't use .env if APP_ENV is defined
 if (!isset($_SERVER['APP_ENV'])) {
     if (!class_exists(Dotenv::class)) {
         throw new \RuntimeException('APP_ENV environment variable is not defined. You need to define environment variables for configuration or add "symfony/dotenv" as a Composer dependency to load variables from a .env file.');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

The current condition does not guarantee we do not load `.env` in production. We should tweak whether the comment or the condition to `if (!isset($_SERVER['APP_ENV']) || 'prod' === $_SERVER['APP_ENV'])`. Or maybe remove this comment at all? It's pretty obvious.