### PR TITLE
Move more platform-dependent options to the DSN

### DIFF
--- a/doctrine/doctrine-bundle/1.6/config/packages/doctrine.yaml
+++ b/doctrine/doctrine-bundle/1.6/config/packages/doctrine.yaml
@@ -8,8 +8,6 @@ parameters:
 doctrine:
     dbal:
         # configure these for your database server
-        driver: 'pdo_mysql'
-        server_version: '5.7'
         charset: utf8mb4
         default_table_options:
             charset: utf8mb4

--- a/doctrine/doctrine-bundle/1.6/manifest.json
+++ b/doctrine/doctrine-bundle/1.6/manifest.json
@@ -9,7 +9,6 @@
     "env": {
         "#1": "Format described at http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url",
         "#2": "For an SQLite database, use: \"sqlite:///%kernel.project_dir%/var/data.db\"",
-        "#3": "Configure your db driver and server_version in config/packages/doctrine.yaml",
-        "DATABASE_URL": "mysql://db_user:db_password@127.0.0.1:3306/db_name"
+        "DATABASE_URL": "mysql://db_user:db_password@127.0.0.1:3306/db_name?server_version=5.7"
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

https://github.com/doctrine/dbal/blob/a2cdd8a5b6f507e7f0c509fb9b0134561db357c8/lib/Doctrine/DBAL/DriverManager.php#L215-L272

IIUC this code, doctrine/dbal already supports parsing extra options from DSN query string.

I suggest move platform-dependent options to the DSN by default, making it easier, i.e to switch on sqlite for testing just switching the DSN without leaving confusing 5.7 version and driver setting behinf
