### PR TITLE
PHPUnit: use a .env file

### DIFF
--- a/symfony/phpunit-bridge/4.1/.env.test
+++ b/symfony/phpunit-bridge/4.1/.env.test
@@ -1,0 +1,2 @@
+APP_ENV=test
+APP_SECRET=s$cretf0rt3st

--- a/symfony/phpunit-bridge/4.1/manifest.json
+++ b/symfony/phpunit-bridge/4.1/manifest.json
@@ -2,7 +2,8 @@
     "copy-from-recipe": {
         "bin/": "%BIN_DIR%/",
         "phpunit.xml.dist": "phpunit.xml.dist",
-        "tests/": "tests/"
+        "tests/": "tests/",
+        ".env.test": ".env.test"
     },
     "gitignore": [
         ".phpunit",

--- a/symfony/phpunit-bridge/4.1/phpunit.xml.dist
+++ b/symfony/phpunit-bridge/4.1/phpunit.xml.dist
@@ -5,16 +5,12 @@
          xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
-         bootstrap="vendor/autoload.php"
+         bootstrap="tests/bootstrap.php"
 >
     <php>
         <ini name="error_reporting" value="-1" />
         <env name="KERNEL_CLASS" value="App\Kernel" />
-        <env name="APP_ENV" value="test" />
-        <env name="APP_DEBUG" value="1" />
-        <env name="APP_SECRET" value="s$cretf0rt3st" />
         <env name="SHELL_VERBOSITY" value="-1" />
-        <!-- define your env variables for the test env here -->
     </php>
 
     <testsuites>

--- a/symfony/phpunit-bridge/4.1/tests/bootstrap.php
+++ b/symfony/phpunit-bridge/4.1/tests/bootstrap.php
@@ -1,0 +1,7 @@
+<?php
+
+require __DIR__.'/../vendor/autoload.php';
+
+use Symfony\Component\Dotenv\Dotenv;
+
+(new Dotenv())->load(__DIR__.'/../.env', __DIR__.'/../.env.test');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Having to modify both `.env` and and `phpunit.xml.dist` when adding an environment variable is tedious and error prone.
Storing env vars in different formats (XML and `.env`) also leads to weird bugs such as #317.

With this PR, in test mode `.env` and `.env.test` files are always loaded. `.env.test` allows to override env vars for this env.

Not related with this PR: I don't really understand why we need both `.env` and `.env.dist`. As `.env` file must not be used in production anyway, can't we have only a (versioned) `.env` file and get rid of the `.dist` one?
For people not using Docker/Vagrant/etc, we may allow to override the values of the `.env` file in a `.env.local` file (that will not be versioned).
Even if we want to keep the `.dist` file, cannot we always load it along with `.env`? Then we'll be able to only use `.env` to override some vars (the secrets) instead of having to copy the full content in both. wdyt?