### PR TITLE
Allow to override .env files for specific environments

### DIFF
--- a/symfony/console/4.2/bin/console
+++ b/symfony/console/4.2/bin/console
@@ -1,0 +1,41 @@
+#!/usr/bin/env php
+<?php
+
+use App\Kernel;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Debug\Debug;
+use Symfony\Component\Dotenv\Dotenv;
+
+set_time_limit(0);
+
+require __DIR__.'/../vendor/autoload.php';
+
+if (!class_exists(Application::class)) {
+    throw new \RuntimeException('You need to add "symfony/framework-bundle" as a Composer dependency.');
+}
+
+$input = new ArgvInput();
+$env = $input->getParameterOption(['--env', '-e'], null, true);
+
+if (!isset($_SERVER['APP_ENV'])) {
+    if (!class_exists(Dotenv::class)) {
+        throw new \RuntimeException('APP_ENV environment variable is not defined. You need to define environment variables for configuration or add "symfony/dotenv" as a Composer dependency to load variables from a .env file.');
+    }
+    (new Dotenv())->loadForEnv($env ?? 'dev', __DIR__.'/../.env');
+}
+
+$env = $env ?? $_SERVER['APP_ENV'] ?? 'dev';
+$debug = (bool) ($_SERVER['APP_DEBUG'] ?? ('prod' !== $env)) && !$input->hasParameterOption('--no-debug', true);
+
+if ($debug) {
+    umask(0000);
+
+    if (class_exists(Debug::class)) {
+        Debug::enable();
+    }
+}
+
+$kernel = new Kernel($env, $debug);
+$application = new Application($kernel);
+$application->run($input);

--- a/symfony/console/4.2/bin/console
+++ b/symfony/console/4.2/bin/console
@@ -3,22 +3,14 @@
 
 use App\Kernel;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
-use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Debug\Debug;
-use Symfony\Component\Dotenv\Dotenv;
 
 set_time_limit(0);
 
-require __DIR__.'/../vendor/autoload.php';
+require __DIR__.'/../src/bootstrap.php';
 
 if (!class_exists(Application::class)) {
     throw new \RuntimeException('You need to add "symfony/framework-bundle" as a Composer dependency.');
-}
-
-if (class_exists(Dotenv::class)) {
-    (new Dotenv())->loadForEnv($_SERVER['APP_ENV'] ?? 'dev', __DIR__.'/../.env');
-} elseif (!isset($_SERVER['APP_ENV']) && !isset($_ENV['APP_ENV'])) {
-    throw new \RuntimeException('APP_ENV environment variable is not defined. You need to define environment variables for configuration or add "symfony/dotenv" as a Composer dependency to load variables from a .env file.');
 }
 
 $env = $_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? 'dev';

--- a/symfony/console/4.2/bin/console
+++ b/symfony/console/4.2/bin/console
@@ -7,14 +7,11 @@ use Symfony\Component\Debug\Debug;
 
 set_time_limit(0);
 
-require __DIR__.'/../src/bootstrap.php';
+[$env, $debug] = require __DIR__.'/../src/bootstrap.php';
 
 if (!class_exists(Application::class)) {
     throw new \RuntimeException('You need to add "symfony/framework-bundle" as a Composer dependency.');
 }
-
-$env = $_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? 'dev';
-$debug = (bool) ($_SERVER['APP_DEBUG'] ?? $_ENV['APP_DEBUG'] ?? ('prod' !== $env)) && !$input->hasParameterOption('--no-debug', true);
 
 if ($debug) {
     umask(0000);

--- a/symfony/console/4.2/bin/console
+++ b/symfony/console/4.2/bin/console
@@ -15,18 +15,14 @@ if (!class_exists(Application::class)) {
     throw new \RuntimeException('You need to add "symfony/framework-bundle" as a Composer dependency.');
 }
 
-$input = new ArgvInput();
-$env = $input->getParameterOption(['--env', '-e'], null, true);
-
-if (!isset($_SERVER['APP_ENV'])) {
-    if (!class_exists(Dotenv::class)) {
-        throw new \RuntimeException('APP_ENV environment variable is not defined. You need to define environment variables for configuration or add "symfony/dotenv" as a Composer dependency to load variables from a .env file.');
-    }
-    (new Dotenv())->loadForEnv($env ?? 'dev', __DIR__.'/../.env');
+if (class_exists(Dotenv::class)) {
+    (new Dotenv())->loadForEnv($_SERVER['APP_ENV'] ?? 'dev', __DIR__.'/../.env');
+} elseif (!isset($_SERVER['APP_ENV']) && !isset($_ENV['APP_ENV'])) {
+    throw new \RuntimeException('APP_ENV environment variable is not defined. You need to define environment variables for configuration or add "symfony/dotenv" as a Composer dependency to load variables from a .env file.');
 }
 
-$env = $env ?? $_SERVER['APP_ENV'] ?? 'dev';
-$debug = (bool) ($_SERVER['APP_DEBUG'] ?? ('prod' !== $env)) && !$input->hasParameterOption('--no-debug', true);
+$env = $_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? 'dev';
+$debug = (bool) ($_SERVER['APP_DEBUG'] ?? $_ENV['APP_DEBUG'] ?? ('prod' !== $env)) && !$input->hasParameterOption('--no-debug', true);
 
 if ($debug) {
     umask(0000);

--- a/symfony/console/4.2/bin/console
+++ b/symfony/console/4.2/bin/console
@@ -1,26 +1,14 @@
 #!/usr/bin/env php
 <?php
 
-use App\Kernel;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
-use Symfony\Component\Debug\Debug;
-
-set_time_limit(0);
-
-[$env, $debug] = require __DIR__.'/../src/bootstrap.php';
 
 if (!class_exists(Application::class)) {
     throw new \RuntimeException('You need to add "symfony/framework-bundle" as a Composer dependency.');
 }
 
-if ($debug) {
-    umask(0000);
+set_time_limit(0);
 
-    if (class_exists(Debug::class)) {
-        Debug::enable();
-    }
-}
-
-$kernel = new Kernel($env, $debug);
+$kernel = require __DIR__.'/../src/bootstrap.php';
 $application = new Application($kernel);
 $application->run($input);

--- a/symfony/console/4.2/manifest.json
+++ b/symfony/console/4.2/manifest.json
@@ -1,0 +1,6 @@
+{
+    "copy-from-recipe": {
+        "bin/": "%BIN_DIR%/"
+    },
+    "aliases": ["cli"]
+}

--- a/symfony/flex/1.0/.env
+++ b/symfony/flex/1.0/.env
@@ -1,3 +1,3 @@
 # This file is a "template" of which env vars need to be defined for your application
-# Override the variabled you want in .env.local for development, create environment variables when deploying to production
+# Override the variables you want in .env.local for development, create environment variables when deploying to production
 # https://symfony.com/doc/current/best_practices/configuration.html#infrastructure-related-configuration

--- a/symfony/flex/1.0/.env
+++ b/symfony/flex/1.0/.env
@@ -1,3 +1,3 @@
 # This file is a "template" of which env vars need to be defined for your application
-# Copy this file to .env file for development, create environment variables when deploying to production
+# Override the variabled you want in .env.local for development, create environment variables when deploying to production
 # https://symfony.com/doc/current/best_practices/configuration.html#infrastructure-related-configuration

--- a/symfony/flex/1.0/manifest.json
+++ b/symfony/flex/1.0/manifest.json
@@ -1,5 +1,5 @@
 {
     "copy-from-recipe": {
-        ".env.dist": ".env.dist"
+        ".env": ".env"
     }
 }

--- a/symfony/framework-bundle/4.2/manifest.json
+++ b/symfony/framework-bundle/4.2/manifest.json
@@ -18,7 +18,8 @@
         "#TRUSTED_HOSTS": "localhost,example.com"
     },
     "gitignore": [
-        "/.env.*",
+        "/.env.local",
+        "/.env.*.local",
         "/%PUBLIC_DIR%/bundles/",
         "/%VAR_DIR%/",
         "/vendor/"

--- a/symfony/framework-bundle/4.2/manifest.json
+++ b/symfony/framework-bundle/4.2/manifest.json
@@ -18,7 +18,7 @@
         "#TRUSTED_HOSTS": "localhost,example.com"
     },
     "gitignore": [
-        "/.env",
+        "/.env.*",
         "/%PUBLIC_DIR%/bundles/",
         "/%VAR_DIR%/",
         "/vendor/"

--- a/symfony/framework-bundle/4.2/public/index.php
+++ b/symfony/framework-bundle/4.2/public/index.php
@@ -12,7 +12,7 @@ if (!isset($_SERVER['APP_ENV']) && !isset($_ENV['APP_ENV'])) {
     if (!class_exists(Dotenv::class)) {
         throw new \RuntimeException('APP_ENV environment variable is not defined. You need to define environment variables for configuration or add "symfony/dotenv" as a Composer dependency to load variables from a .env file.');
     }
-    (new Dotenv())->load(__DIR__.'/../.env');
+    (new Dotenv())->loadForEnv('dev', __DIR__.'/../.env');
 }
 
 $env = $_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? 'dev';

--- a/symfony/framework-bundle/4.2/public/index.php
+++ b/symfony/framework-bundle/4.2/public/index.php
@@ -4,10 +4,7 @@ use App\Kernel;
 use Symfony\Component\Debug\Debug;
 use Symfony\Component\HttpFoundation\Request;
 
-require __DIR__.'/../src/bootstrap.php';
-
-$env = $_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? 'dev';
-$debug = (bool) ($_SERVER['APP_DEBUG'] ?? $_ENV['APP_DEBUG'] ?? ('prod' !== $env));
+[$env, $debug] = require __DIR__.'/../src/bootstrap.php';
 
 if ($debug) {
     umask(0000);

--- a/symfony/framework-bundle/4.2/public/index.php
+++ b/symfony/framework-bundle/4.2/public/index.php
@@ -2,18 +2,9 @@
 
 use App\Kernel;
 use Symfony\Component\Debug\Debug;
-use Symfony\Component\Dotenv\Dotenv;
 use Symfony\Component\HttpFoundation\Request;
 
-require __DIR__.'/../vendor/autoload.php';
-
-// The check is to ensure we don't use .env if APP_ENV is defined
-if (!isset($_SERVER['APP_ENV']) && !isset($_ENV['APP_ENV'])) {
-    if (!class_exists(Dotenv::class)) {
-        throw new \RuntimeException('APP_ENV environment variable is not defined. You need to define environment variables for configuration or add "symfony/dotenv" as a Composer dependency to load variables from a .env file.');
-    }
-    (new Dotenv())->loadForEnv('dev', __DIR__.'/../.env');
-}
+require __DIR__.'/../src/bootstrap.php';
 
 $env = $_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? 'dev';
 $debug = (bool) ($_SERVER['APP_DEBUG'] ?? $_ENV['APP_DEBUG'] ?? ('prod' !== $env));

--- a/symfony/framework-bundle/4.2/public/index.php
+++ b/symfony/framework-bundle/4.2/public/index.php
@@ -1,27 +1,17 @@
 <?php
 
-use App\Kernel;
-use Symfony\Component\Debug\Debug;
 use Symfony\Component\HttpFoundation\Request;
 
-[$env, $debug] = require __DIR__.'/../src/bootstrap.php';
-
-if ($debug) {
-    umask(0000);
-
-    Debug::enable();
-}
+$kernel = require __DIR__.'/../src/bootstrap.php';
 
 if ($trustedProxies = $_SERVER['TRUSTED_PROXIES'] ?? $_ENV['TRUSTED_PROXIES'] ?? false) {
     Request::setTrustedProxies(explode(',', $trustedProxies), Request::HEADER_X_FORWARDED_ALL ^ Request::HEADER_X_FORWARDED_HOST);
 }
-
 if ($trustedHosts = $_SERVER['TRUSTED_HOSTS'] ?? $_ENV['TRUSTED_HOSTS'] ?? false) {
     Request::setTrustedHosts(explode(',', $trustedHosts));
 }
-
-$kernel = new Kernel($env, $debug);
 $request = Request::createFromGlobals();
+
 $response = $kernel->handle($request);
 $response->send();
 $kernel->terminate($request, $response);

--- a/symfony/framework-bundle/4.2/src/bootstrap.php
+++ b/symfony/framework-bundle/4.2/src/bootstrap.php
@@ -4,8 +4,14 @@ require __DIR__.'/../vendor/autoload.php';
 
 use Symfony\Component\Dotenv\Dotenv;
 
-if (class_exists(Dotenv::class)) {
-    (new Dotenv())->loadForEnv($_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? 'dev', __DIR__.'/../.env');
-} elseif (!isset($_SERVER['APP_ENV']) && !isset($_ENV['APP_ENV'])) {
+$envFromEnv = $_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? null;
+$env = $envFromEnv ?? 'dev';
+$prod = 'prod' === $env;
+
+if (!$prod && class_exists(Dotenv::class)) {
+    (new Dotenv())->loadForEnv($env, __DIR__.'/../.env');
+} elseif (null === $envFromEnv) {
     throw new \RuntimeException('APP_ENV environment variable is not defined. You need to define environment variables for configuration or add "symfony/dotenv" as a Composer dependency to load variables from a .env file.');
 }
+
+return [$env, (bool) ($_SERVER['APP_DEBUG'] ?? $_ENV['APP_DEBUG'] ?? !$prod)];

--- a/symfony/framework-bundle/4.2/src/bootstrap.php
+++ b/symfony/framework-bundle/4.2/src/bootstrap.php
@@ -12,6 +12,7 @@ $prod = 'prod' === $env;
 
 if (!$prod && class_exists(Dotenv::class)) {
     (new Dotenv())->loadForEnv($env, __DIR__.'/../.env');
+    $env = $_SERVER['APP_ENV'] ?? $env;
 } elseif (null === $envFromEnv) {
     throw new \RuntimeException('APP_ENV environment variable is not defined. You need to define environment variables for configuration or add "symfony/dotenv" as a Composer dependency to load variables from a .env file.');
 }

--- a/symfony/framework-bundle/4.2/src/bootstrap.php
+++ b/symfony/framework-bundle/4.2/src/bootstrap.php
@@ -5,7 +5,7 @@ require __DIR__.'/../vendor/autoload.php';
 use Symfony\Component\Dotenv\Dotenv;
 
 if (class_exists(Dotenv::class)) {
-    (new Dotenv())->loadForEnv($_SERVER['APP_ENV'] ?? 'test', __DIR__.'/../.env');
+    (new Dotenv())->loadForEnv($_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? 'test', __DIR__.'/../.env');
 } elseif (!isset($_SERVER['APP_ENV']) && !isset($_ENV['APP_ENV'])) {
     throw new \RuntimeException('APP_ENV environment variable is not defined. You need to define environment variables for configuration or add "symfony/dotenv" as a Composer dependency to load variables from a .env file.');
 }

--- a/symfony/framework-bundle/4.2/src/bootstrap.php
+++ b/symfony/framework-bundle/4.2/src/bootstrap.php
@@ -2,6 +2,8 @@
 
 require __DIR__.'/../vendor/autoload.php';
 
+use App\Kernel;
+use Symfony\Component\Debug\Debug;
 use Symfony\Component\Dotenv\Dotenv;
 
 $envFromEnv = $_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? null;
@@ -14,4 +16,13 @@ if (!$prod && class_exists(Dotenv::class)) {
     throw new \RuntimeException('APP_ENV environment variable is not defined. You need to define environment variables for configuration or add "symfony/dotenv" as a Composer dependency to load variables from a .env file.');
 }
 
-return [$env, (bool) ($_SERVER['APP_DEBUG'] ?? $_ENV['APP_DEBUG'] ?? !$prod)];
+$debug = (bool) ($_SERVER['APP_DEBUG'] ?? $_ENV['APP_DEBUG'] ?? !$prod);
+if ($debug) {
+    umask(0000);
+
+    if (class_exists(Debug::class)) {
+        Debug::enable();
+    }
+}
+
+return new Kernel($env, $debug);

--- a/symfony/framework-bundle/4.2/src/bootstrap.php
+++ b/symfony/framework-bundle/4.2/src/bootstrap.php
@@ -5,7 +5,7 @@ require __DIR__.'/../vendor/autoload.php';
 use Symfony\Component\Dotenv\Dotenv;
 
 if (class_exists(Dotenv::class)) {
-    (new Dotenv())->loadForEnv($_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? 'test', __DIR__.'/../.env');
+    (new Dotenv())->loadForEnv($_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? 'dev', __DIR__.'/../.env');
 } elseif (!isset($_SERVER['APP_ENV']) && !isset($_ENV['APP_ENV'])) {
     throw new \RuntimeException('APP_ENV environment variable is not defined. You need to define environment variables for configuration or add "symfony/dotenv" as a Composer dependency to load variables from a .env file.');
 }

--- a/symfony/phpunit-bridge/4.2/.env.test
+++ b/symfony/phpunit-bridge/4.2/.env.test
@@ -1,0 +1,3 @@
+# define your env variables for the test env here
+APP_ENV=test
+APP_SECRET=s$cretf0rt3st

--- a/symfony/phpunit-bridge/4.2/bin/phpunit
+++ b/symfony/phpunit-bridge/4.2/bin/phpunit
@@ -1,0 +1,22 @@
+#!/usr/bin/env php
+<?php
+
+if (!file_exists(dirname(__DIR__).'/vendor/symfony/phpunit-bridge/bin/simple-phpunit')) {
+    echo "Unable to find the `simple-phpunit` script in `vendor/symfony/phpunit-bridge/bin/`.\n";
+    exit(1);
+}
+if (false === getenv('SYMFONY_DEPRECATIONS_HELPER')) {
+    // see https://symfony.com/doc/current/components/phpunit_bridge.html#making-tests-fail
+    putenv('SYMFONY_DEPRECATIONS_HELPER=999999');
+}
+if (false === getenv('SYMFONY_PHPUNIT_REMOVE')) {
+    putenv('SYMFONY_PHPUNIT_REMOVE=');
+}
+if (false === getenv('SYMFONY_PHPUNIT_VERSION')) {
+    putenv('SYMFONY_PHPUNIT_VERSION=6.5');
+}
+if (false === getenv('SYMFONY_PHPUNIT_DIR')) {
+    putenv('SYMFONY_PHPUNIT_DIR='.__DIR__.'/.phpunit');
+}
+
+require dirname(__DIR__).'/vendor/symfony/phpunit-bridge/bin/simple-phpunit';

--- a/symfony/phpunit-bridge/4.2/manifest.json
+++ b/symfony/phpunit-bridge/4.2/manifest.json
@@ -1,0 +1,13 @@
+{
+    "copy-from-recipe": {
+        "bin/": "%BIN_DIR%/",
+        "phpunit.xml.dist": "phpunit.xml.dist",
+        "tests/": "tests/",
+        ".env.test": ".env.test"
+    },
+    "gitignore": [
+        ".phpunit",
+        "/phpunit.xml"
+    ],
+    "aliases": ["simple-phpunit"]
+}

--- a/symfony/phpunit-bridge/4.2/phpunit.xml.dist
+++ b/symfony/phpunit-bridge/4.2/phpunit.xml.dist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.5/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="tests/bootstrap.php"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+        <env name="KERNEL_CLASS" value="App\Kernel" />
+        <env name="SHELL_VERBOSITY" value="-1" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Project Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>src</directory>
+        </whitelist>
+    </filter>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
+</phpunit>

--- a/symfony/phpunit-bridge/4.2/phpunit.xml.dist
+++ b/symfony/phpunit-bridge/4.2/phpunit.xml.dist
@@ -5,7 +5,7 @@
          xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
-         bootstrap="tests/bootstrap.php"
+         bootstrap="src/bootstrap.php"
 >
     <php>
         <ini name="error_reporting" value="-1" />

--- a/symfony/phpunit-bridge/4.2/phpunit.xml.dist
+++ b/symfony/phpunit-bridge/4.2/phpunit.xml.dist
@@ -9,6 +9,7 @@
 >
     <php>
         <ini name="error_reporting" value="-1" />
+        <env name="APP_ENV" value="test" />
         <env name="KERNEL_CLASS" value="App\Kernel" />
         <env name="SHELL_VERBOSITY" value="-1" />
     </php>

--- a/symfony/phpunit-bridge/4.2/post-install.txt
+++ b/symfony/phpunit-bridge/4.2/post-install.txt
@@ -1,0 +1,6 @@
+<bg=blue;fg=white>              </>
+<bg=blue;fg=white> How to test? </>
+<bg=blue;fg=white>              </>
+
+  * <fg=blue>Write</> test cases in the <comment>tests/</> folder
+  * <fg=blue>Run</> <comment>php bin/phpunit</>

--- a/symfony/phpunit-bridge/4.2/tests/bootstrap.php
+++ b/symfony/phpunit-bridge/4.2/tests/bootstrap.php
@@ -1,0 +1,13 @@
+<?php
+
+require __DIR__.'/../vendor/autoload.php';
+
+use Symfony\Component\Dotenv\Dotenv;
+
+// The check is to ensure we don't use .env if APP_ENV is defined
+if (!isset($_SERVER['APP_ENV'])) {
+    if (!class_exists(Dotenv::class)) {
+        throw new \RuntimeException('APP_ENV environment variable is not defined. You need to define environment variables for configuration or add "symfony/dotenv" as a Composer dependency to load variables from a .env file.');
+    }
+    (new Dotenv())->loadForEnv('test', __DIR__.'/../.env');
+}

--- a/symfony/phpunit-bridge/4.2/tests/bootstrap.php
+++ b/symfony/phpunit-bridge/4.2/tests/bootstrap.php
@@ -4,10 +4,8 @@ require __DIR__.'/../vendor/autoload.php';
 
 use Symfony\Component\Dotenv\Dotenv;
 
-// The check is to ensure we don't use .env if APP_ENV is defined
-if (!isset($_SERVER['APP_ENV'])) {
-    if (!class_exists(Dotenv::class)) {
-        throw new \RuntimeException('APP_ENV environment variable is not defined. You need to define environment variables for configuration or add "symfony/dotenv" as a Composer dependency to load variables from a .env file.');
-    }
-    (new Dotenv())->loadForEnv('test', __DIR__.'/../.env');
+if (class_exists(Dotenv::class)) {
+    (new Dotenv())->loadForEnv($_SERVER['APP_ENV'] ?? 'test', __DIR__.'/../.env');
+} elseif (!isset($_SERVER['APP_ENV']) && !isset($_ENV['APP_ENV'])) {
+    throw new \RuntimeException('APP_ENV environment variable is not defined. You need to define environment variables for configuration or add "symfony/dotenv" as a Composer dependency to load variables from a .env file.');
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

As discussed in #465 and symfony/symfony#28533, this PR makes Symfony behaving like Create React App, Rails or Sinatra: the following files, starting from the bottom. The first value set (or those already defined in the environment) take precedence:

- `.env` - The Original®
- `.env.dev`, `.env.test`, `.env.prod`... - Environment-specific settings.
- `.env.local` - Local overrides. This file is loaded for all environments _except_ `test`.
- `.env.dev.local`, `.env.test.local`, `.env.prod.local`... - Local overrides of environment-specific settings.

The default envs are `env` and `test`.

It also fixes https://github.com/symfony/recipes/pull/366#issuecomment-364778024: when running `bin/console -e=prod`, the `.env.prod` file will be loaded (if `APP_ENV` is not already defined).

Needs:

- symfony/symfony#28533
- symfony/flex#423

Closes #465, #366, #408.