### PR TITLE
Force running Symfony Web Server in dev mode

### DIFF
--- a/symfony/console/3.3/bin/console
+++ b/symfony/console/3.3/bin/console
@@ -23,8 +23,14 @@ if (!isset($_SERVER['APP_ENV'])) {
 }
 
 $input = new ArgvInput();
-$env = $input->getParameterOption(['--env', '-e'], $_SERVER['APP_ENV'] ?? 'dev', true);
-$debug = (bool) ($_SERVER['APP_DEBUG'] ?? ('prod' !== $env)) && !$input->hasParameterOption('--no-debug', true);
+// Check if Symfony Web Server should be forced running in dev
+if ($input->hasParameterOption(['--dev'], true)) {
+    $env = 'dev';
+    $debug = true;
+} else {
+    $env = $input->getParameterOption(['--env', '-e'], $_SERVER['APP_ENV'] ?? 'dev', true);
+    $debug = (bool) ($_SERVER['APP_DEBUG'] ?? ('prod' !== $env)) && !$input->hasParameterOption('--no-debug', true);
+}
 
 if ($debug) {
     umask(0000);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

An alternative to #461 solution to avoid BC breaks.

This PR also requires small changes in WebServerBundle, see https://github.com/symfony/symfony/pull/28574

The idea is to make it possible to preview websites in different environments using Symfony Web Server when its bundle registered for `dev` environment only. It will be possible with the next command:

```bash
APP_ENV=prod bin/console server:run --dev
```

Symfony Web Server commands are special because sometimes we do not want to actually start the web server in `prod` environment but we do want to preview the website in `prod` environment. Right now it's possible only if you register Symfony Web Server bundle in `prod` environment, but it makes no sense and may lead to some security risks.

So, this `--dev` option allows ignoring environment variables in `bin/console.php` and force running the webserver in dev mode, though your `public/index.php` will be loaded in a specified environment.

In short, these changes will help developers debugging their websites in different environments having Symfony Web Server bundle registered for `dev` environment only.