### PR TITLE
Proposal: Check for CONSOLE_APP_ENV first before APP_ENV in bin/console

### DIFF
--- a/symfony/console/3.3/bin/console
+++ b/symfony/console/3.3/bin/console
@@ -23,7 +23,7 @@ if (!isset($_SERVER['APP_ENV'])) {
 }
 
 $input = new ArgvInput();
-$env = $input->getParameterOption(['--env', '-e'], $_SERVER['APP_ENV'] ?? 'dev', true);
+$env = $input->getParameterOption(['--env', '-e'], $_SERVER['CONSOLE_APP_ENV'] ?? $_SERVER['APP_ENV'] ?? 'dev', true);
 $debug = (bool) ($_SERVER['APP_DEBUG'] ?? ('prod' !== $env)) && !$input->hasParameterOption('--no-debug', true);
 
 if ($debug) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Probably the most elegant alternative solution of both #467 and #461

With these changes we can load websites in any environment using Symfony Web Server having WebServerBundle registered for dev environment only.

For example, with the next command I can load website in `prod` mode:
```bash
CONSOLE_APP_ENV=dev APP_ENV=prod bin/console server:run
```
