### PR TITLE
Expose "Link" header in nelmio

### DIFF
--- a/nelmio/cors-bundle/1.5/config/packages/nelmio_cors.yaml
+++ b/nelmio/cors-bundle/1.5/config/packages/nelmio_cors.yaml
@@ -4,6 +4,7 @@ nelmio_cors:
         allow_origin: ['%env(CORS_ALLOW_ORIGIN)%']
         allow_methods: ['GET', 'OPTIONS', 'POST', 'PUT', 'PATCH', 'DELETE']
         allow_headers: ['Content-Type', 'Authorization']
+        expose_headers: ['Link']
         max_age: 3600
     paths:
         '^/': ~


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

It'd be better to expose the `Link` header by default. Indeed, it's a metadata based header and it's mandatory to make https://github.com/api-platform/admin/ work from scratch.