### PR TITLE
Promote Alice as an official recipe with an alias

### DIFF
--- a/hautelook/alice-bundle/2.1/config/packages/dev/hautelook_alice.yaml
+++ b/hautelook/alice-bundle/2.1/config/packages/dev/hautelook_alice.yaml
@@ -1,0 +1,2 @@
+hautelook_alice:
+    fixtures_path: fixtures

--- a/hautelook/alice-bundle/2.1/config/packages/test/hautelook_alice.yaml
+++ b/hautelook/alice-bundle/2.1/config/packages/test/hautelook_alice.yaml
@@ -1,0 +1,2 @@
+imports:
+    - { resource: ../dev/hautelook_alice.yaml }

--- a/hautelook/alice-bundle/2.1/manifest.json
+++ b/hautelook/alice-bundle/2.1/manifest.json
@@ -1,0 +1,10 @@
+{
+    "aliases": ["alice"],
+    "bundles": {
+        "Hautelook\\AliceBundle\\HautelookAliceBundle": ["dev", "test"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/",
+        "fixtures/": "fixtures/"
+    }
+}

--- a/hautelook/alice-bundle/2.1/post-install.txt
+++ b/hautelook/alice-bundle/2.1/post-install.txt
@@ -1,0 +1,6 @@
+<bg=blue;fg=white>                       </>
+<bg=blue;fg=white> How to load fixtures? </>
+<bg=blue;fg=white>                       </>
+
+  * <fg=blue>Write</> fixtures files in the <comment>fixtures/</> folder
+  * <fg=blue>Run</> <comment>php bin/console hautelook:fixtures:load</>

--- a/nelmio/alice/3.2/config/packages/dev/nelmio_alice.yaml
+++ b/nelmio/alice/3.2/config/packages/dev/nelmio_alice.yaml
@@ -1,0 +1,3 @@
+nelmio_alice:
+    functions_blacklist:
+        - 'current'

--- a/nelmio/alice/3.2/config/packages/test/nelmio_alice.yaml
+++ b/nelmio/alice/3.2/config/packages/test/nelmio_alice.yaml
@@ -1,0 +1,2 @@
+imports:
+    - { resource: ../dev/nelmio_alice.yaml }

--- a/nelmio/alice/3.2/manifest.json
+++ b/nelmio/alice/3.2/manifest.json
@@ -1,0 +1,8 @@
+{
+    "bundles": {
+        "Nelmio\\Alice\\Bridge\\Symfony\\NelmioAliceBundle": ["dev", "test"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    }
+}

--- a/theofidry/alice-data-fixtures/1.0/manifest.json
+++ b/theofidry/alice-data-fixtures/1.0/manifest.json
@@ -1,0 +1,5 @@
+{
+    "bundles": {
+        "Fidry\\AliceDataFixtures\\Bridge\\Symfony\\FidryAliceDataFixturesBundle": ["dev", "test"]
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

This PR promotes [Alice](https://github.com/nelmio/alice)'s recipes to the official repository, and add an alias, `alice`, to install the corresponding bundle.

By typing `composer require alice`, advanced fixtures and especially [the database testing helpers for Panther and WebTestCase](https://github.com/hautelook/AliceBundle#database-testing) are automatically available.

The next step is to update the documentation.