### PR TITLE
fix php built-in server command in what's next

### DIFF
--- a/symfony/framework-bundle/4.2/post-install.txt
+++ b/symfony/framework-bundle/4.2/post-install.txt
@@ -5,7 +5,7 @@
   * <fg=blue>Run</> your application:
     1. Change to the project directory
     2. Create your code repository with the <comment>git init</comment> command
-    3. Execute the <comment>php -S 127.0.0.1:8000 -t public</> command
+    3. Execute the <comment>php -S 127.0.0.1:8000 -t public public/index.php</> command
     4. Browse to the <comment>http://localhost:8000/</> URL.
 
        Quit the server with CTRL-C.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

<!--
Please, carefully read the README before submitting a pull request.
-->
Fix php built-in server command in **what's next** when creating a new symfony project .
Issues Ticket in Symfony Repo [#28781](https://github.com/symfony/symfony/issues/28781)

When someone run php built-in server with the old command and in the routing parameters must add dot '.', the server don't redirect the request to front controller index.php.

> for example: /page/{name} => /page/one.pl

the server will search for a file named  page/one and with extension .pl in the public folder.

adding public/index.php to the command fix that bug and all requests will passed by index.php
