### PR TITLE
Fixed symfony env variables in phpunit.xml configuration

### DIFF
--- a/symfony/phpunit-bridge/4.1/bin/phpunit
+++ b/symfony/phpunit-bridge/4.1/bin/phpunit
@@ -5,16 +5,6 @@ if (!file_exists(dirname(__DIR__).'/vendor/symfony/phpunit-bridge/bin/simple-php
     echo "Unable to find the `simple-phpunit` script in `vendor/symfony/phpunit-bridge/bin/`.\n";
     exit(1);
 }
-if (false === getenv('SYMFONY_DEPRECATIONS_HELPER')) {
-    // see https://symfony.com/doc/current/components/phpunit_bridge.html#making-tests-fail
-    putenv('SYMFONY_DEPRECATIONS_HELPER=999999');
-}
-if (false === getenv('SYMFONY_PHPUNIT_REMOVE')) {
-    putenv('SYMFONY_PHPUNIT_REMOVE=');
-}
-if (false === getenv('SYMFONY_PHPUNIT_VERSION')) {
-    putenv('SYMFONY_PHPUNIT_VERSION=6.5');
-}
 if (false === getenv('SYMFONY_PHPUNIT_DIR')) {
     putenv('SYMFONY_PHPUNIT_DIR='.__DIR__.'/.phpunit');
 }

--- a/symfony/phpunit-bridge/4.1/phpunit.xml.dist
+++ b/symfony/phpunit-bridge/4.1/phpunit.xml.dist
@@ -14,6 +14,9 @@
         <env name="APP_DEBUG" value="1" />
         <env name="APP_SECRET" value="s$cretf0rt3st" />
         <env name="SHELL_VERBOSITY" value="-1" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="999999" />
+        <env name="SYMFONY_PHPUNIT_REMOVE" value="" />
+        <env name="SYMFONY_PHPUNIT_VERSION" value="6.5" />
         <!-- define your env variables for the test env here -->
     </php>
 

--- a/symfony/phpunit-bridge/4.1/phpunit.xml.dist
+++ b/symfony/phpunit-bridge/4.1/phpunit.xml.dist
@@ -14,6 +14,7 @@
         <env name="APP_DEBUG" value="1" />
         <env name="APP_SECRET" value="s$cretf0rt3st" />
         <env name="SHELL_VERBOSITY" value="-1" />
+        <!-- see https://symfony.com/doc/current/components/phpunit_bridge.html#making-tests-fail -->
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="999999" />
         <env name="SYMFONY_PHPUNIT_REMOVE" value="" />
         <env name="SYMFONY_PHPUNIT_VERSION" value="6.5" />


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

fixes symfony/symfony#28726, symfony/recipes#476

With symfony/symfony#28995 its not longer needed that the env variables are needed to be set in the phpunit script for parallel test runs. Also without the patch this putenv make I think more problems as nobody opens the `bin/phpunit` file and it will ignore the phpunit.xml.dist configuration.