### PR TITLE
Allow to override .env files per env

### DIFF
--- a/behat/symfony2-extension/2.1/features/bootstrap/bootstrap.php
+++ b/behat/symfony2-extension/2.1/features/bootstrap/bootstrap.php
@@ -1,11 +1,3 @@
 <?php
 
-use Symfony\Component\Dotenv\Dotenv;
-
-// The check is to ensure we don't use .env in production
-if (!isset($_SERVER['APP_ENV'])) {
-    if (!class_exists(Dotenv::class)) {
-        throw new \RuntimeException('APP_ENV environment variable is not defined. You need to define environment variables for configuration or add "symfony/dotenv" as a Composer dependency to load variables from a .env file.');
-    }
-    (new Dotenv())->load(__DIR__.'/../../.env');
-}
+App\Kernel::bootstrapEnv('test');

--- a/phpunit/phpunit/4.7/.env.test
+++ b/phpunit/phpunit/4.7/.env.test
@@ -1,0 +1,4 @@
+# define your env variables for the test env here
+KERNEL_CLASS=App\\Kernel
+APP_SECRET='s$cretf0rt3st'
+SHELL_VERBOSITY=-1

--- a/phpunit/phpunit/4.7/manifest.json
+++ b/phpunit/phpunit/4.7/manifest.json
@@ -1,5 +1,6 @@
 {
     "copy-from-recipe": {
+        ".env.test": ".env.test",
         "phpunit.xml.dist": "phpunit.xml.dist",
         "tests/": "tests/"
     },

--- a/phpunit/phpunit/4.7/phpunit.xml.dist
+++ b/phpunit/phpunit/4.7/phpunit.xml.dist
@@ -2,19 +2,13 @@
 
 <!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.1/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.7/phpunit.xsd"
          backupGlobals="false"
          colors="true"
-         bootstrap="vendor/autoload.php"
+         bootstrap="tests/bootstrap.php"
 >
     <php>
         <ini name="error_reporting" value="-1" />
-        <env name="KERNEL_CLASS" value="App\Kernel" />
-        <env name="APP_ENV" value="test" />
-        <env name="APP_DEBUG" value="1" />
-        <env name="APP_SECRET" value="s$cretf0rt3st" />
-        <env name="SHELL_VERBOSITY" value="-1" />
-        <!-- define your env variables for the test env here -->
     </php>
 
     <testsuites>

--- a/phpunit/phpunit/4.7/tests/bootstrap.php
+++ b/phpunit/phpunit/4.7/tests/bootstrap.php
@@ -1,0 +1,5 @@
+<?php
+
+require dirname(__DIR__).'/vendor/autoload.php';
+
+App\Kernel::bootstrapEnv('test');

--- a/symfony/console/3.3/bin/console
+++ b/symfony/console/3.3/bin/console
@@ -3,30 +3,20 @@
 
 use App\Kernel;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
-use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Debug\Debug;
-use Symfony\Component\Dotenv\Dotenv;
 
 set_time_limit(0);
 
-require __DIR__.'/../vendor/autoload.php';
+require dirname(__DIR__).'/vendor/autoload.php';
 
 if (!class_exists(Application::class)) {
     throw new \RuntimeException('You need to add "symfony/framework-bundle" as a Composer dependency.');
 }
 
-if (!isset($_SERVER['APP_ENV'])) {
-    if (!class_exists(Dotenv::class)) {
-        throw new \RuntimeException('APP_ENV environment variable is not defined. You need to define environment variables for configuration or add "symfony/dotenv" as a Composer dependency to load variables from a .env file.');
-    }
-    (new Dotenv())->load(__DIR__.'/../.env');
-}
+Kernel::bootstrapCli($_SERVER['argv']);
+Kernel::bootstrapEnv();
 
-$input = new ArgvInput();
-$env = $input->getParameterOption(['--env', '-e'], $_SERVER['APP_ENV'] ?? 'dev', true);
-$debug = (bool) ($_SERVER['APP_DEBUG'] ?? ('prod' !== $env)) && !$input->hasParameterOption('--no-debug', true);
-
-if ($debug) {
+if ($_SERVER['APP_DEBUG']) {
     umask(0000);
 
     if (class_exists(Debug::class)) {
@@ -34,6 +24,6 @@ if ($debug) {
     }
 }
 
-$kernel = new Kernel($env, $debug);
+$kernel = new Kernel($_SERVER['APP_ENV'], $_SERVER['APP_DEBUG']);
 $application = new Application($kernel);
-$application->run($input);
+$application->run();

--- a/symfony/flex/1.0/.env
+++ b/symfony/flex/1.0/.env
@@ -1,3 +1,3 @@
 # This file is a "template" of which env vars need to be defined for your application
-# Copy this file to .env file for development, create environment variables when deploying to production
+# Override the variables you want in .env.local for development, create environment variables when deploying to production
 # https://symfony.com/doc/current/best_practices/configuration.html#infrastructure-related-configuration

--- a/symfony/flex/1.0/manifest.json
+++ b/symfony/flex/1.0/manifest.json
@@ -1,5 +1,5 @@
 {
     "copy-from-recipe": {
-        ".env.dist": ".env.dist"
+        ".env": ".env"
     }
 }

--- a/symfony/framework-bundle/3.3/public/index.php
+++ b/symfony/framework-bundle/3.3/public/index.php
@@ -2,23 +2,13 @@
 
 use App\Kernel;
 use Symfony\Component\Debug\Debug;
-use Symfony\Component\Dotenv\Dotenv;
 use Symfony\Component\HttpFoundation\Request;
 
-require __DIR__.'/../vendor/autoload.php';
+require dirname(__DIR__).'/vendor/autoload.php';
 
-// The check is to ensure we don't use .env in production
-if (!isset($_SERVER['APP_ENV']) && !isset($_ENV['APP_ENV'])) {
-    if (!class_exists(Dotenv::class)) {
-        throw new \RuntimeException('APP_ENV environment variable is not defined. You need to define environment variables for configuration or add "symfony/dotenv" as a Composer dependency to load variables from a .env file.');
-    }
-    (new Dotenv())->load(__DIR__.'/../.env');
-}
+Kernel::bootstrapEnv();
 
-$env = $_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? 'dev';
-$debug = (bool) ($_SERVER['APP_DEBUG'] ?? $_ENV['APP_DEBUG'] ?? ('prod' !== $env));
-
-if ($debug) {
+if ($_SERVER['APP_DEBUG']) {
     umask(0000);
 
     Debug::enable();
@@ -32,7 +22,7 @@ if ($trustedHosts = $_SERVER['TRUSTED_HOSTS'] ?? $_ENV['TRUSTED_HOSTS'] ?? false
     Request::setTrustedHosts(explode(',', $trustedHosts));
 }
 
-$kernel = new Kernel($env, $debug);
+$kernel = new Kernel($_SERVER['APP_ENV'], $_SERVER['APP_DEBUG']);
 $request = Request::createFromGlobals();
 $response = $kernel->handle($request);
 $response->send();

--- a/symfony/framework-bundle/3.3/src/Kernel.php
+++ b/symfony/framework-bundle/3.3/src/Kernel.php
@@ -6,6 +6,7 @@ use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Dotenv\Dotenv;
 use Symfony\Component\HttpKernel\Kernel as BaseKernel;
 use Symfony\Component\Routing\RouteCollectionBuilder;
 
@@ -57,5 +58,79 @@ class Kernel extends BaseKernel
         $routes->import($confDir.'/{routes}/*'.self::CONFIG_EXTS, '/', 'glob');
         $routes->import($confDir.'/{routes}/'.$this->environment.'/**/*'.self::CONFIG_EXTS, '/', 'glob');
         $routes->import($confDir.'/{routes}'.self::CONFIG_EXTS, '/', 'glob');
+    }
+
+    public static function bootstrapCli(array &$argv)
+    {
+        // consume --env and --no-debug from the command line
+
+        // when using symfony/console v4.2 or higher, this should
+        // be replaced by a call to Application::bootstrapEnv()
+
+        for ($i = 0; $i < \count($argv) && '--' !== $v = $argv[$i]; ++$i) {
+            if ('--no-debug' === $v) {
+                putenv('APP_DEBUG='.$_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = '0');
+                $argvUnset[$i] = true;
+                break;
+            }
+        }
+
+        for ($i = 0; $i < \count($argv) && '--' !== $v = $argv[$i]; ++$i) {
+            if (!$v || '-' !== $v[0] || !preg_match('/^-(?:-env(?:=|$)|e=?)(.*)$/D', $v, $v)) {
+                continue;
+            }
+            if (!empty($v[1]) || !empty($argv[1 + $i])) {
+                putenv('APP_ENV='.$_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = empty($v[1]) ? $argv[1 + $i] : $v[1]);
+                $argvUnset[$i] = $argvUnset[$i + empty($v[1])] = true;
+            }
+            break;
+        }
+
+        if (!empty($argvUnset)) {
+            $argv = array_values(array_diff_key($argv, $argvUnset));
+        }
+    }
+
+    public static function bootstrapEnv($env = null)
+    {
+        if (null !== $env) {
+            putenv('APP_ENV='.$_SERVER['APP_ENV'] = $env);
+        }
+
+        if ('prod' !== $_SERVER['APP_ENV'] = isset($_SERVER['APP_ENV']) ? $_SERVER['APP_ENV'] : (isset($_ENV['APP_ENV']) ? $_ENV['APP_ENV'] : null)) {
+            if (!class_exists(Dotenv::class)) {
+                throw new \RuntimeException('The "APP_ENV" environment variable is not defined. You need to set it or run "composer require symfony/dotenv" to load it from a ".env" file.');
+            }
+
+            // when using symfony/dotenv v4.2 or higher, this call and the related methods
+            // below should be replaced by a call to the new Dotenv::loadEnv() method
+            self::loadEnv(new Dotenv(), \dirname(__DIR__).'/.env');
+        }
+
+        $_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = isset($_SERVER['APP_ENV']) ? $_SERVER['APP_ENV'] : 'dev';
+        $_SERVER['APP_DEBUG'] = isset($_SERVER['APP_DEBUG']) ? $_SERVER['APP_DEBUG'] : (isset($_ENV['APP_DEBUG']) ? $_ENV['APP_DEBUG'] : 'prod' !== $_SERVER['APP_ENV']);
+        $_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = (int) $_SERVER['APP_DEBUG'] || filter_var($_SERVER['APP_DEBUG'], FILTER_VALIDATE_BOOLEAN) ? '1' : '0';
+    }
+
+    private static function loadEnv(Dotenv $dotenv, $path)
+    {
+        $dotenv->load($path);
+
+        if (null === $env = isset($_SERVER['APP_ENV']) ? $_SERVER['APP_ENV'] : (isset($_ENV['APP_ENV']) ? $_ENV['APP_ENV'] : null)) {
+            $dotenv->populate(array('APP_ENV' => $env = 'dev'));
+        }
+
+        if ('test' !== $env && file_exists($p = "$path.local")) {
+            $dotenv->load($p);
+            $env = isset($_SERVER['APP_ENV']) ? $_SERVER['APP_ENV'] : (isset($_ENV['APP_ENV']) ? $_ENV['APP_ENV'] : $env);
+        }
+
+        if (file_exists($p = "$path.$env")) {
+            $dotenv->load($p);
+        }
+
+        if (file_exists($p = "$path.$env.local")) {
+            $dotenv->load($p);
+        }
     }
 }

--- a/symfony/framework-bundle/4.2/manifest.json
+++ b/symfony/framework-bundle/4.2/manifest.json
@@ -18,7 +18,8 @@
         "#TRUSTED_HOSTS": "localhost,example.com"
     },
     "gitignore": [
-        "/.env",
+        "/.env.local",
+        "/.env.*.local",
         "/%PUBLIC_DIR%/bundles/",
         "/%VAR_DIR%/",
         "/vendor/"

--- a/symfony/framework-bundle/4.2/public/index.php
+++ b/symfony/framework-bundle/4.2/public/index.php
@@ -2,23 +2,13 @@
 
 use App\Kernel;
 use Symfony\Component\Debug\Debug;
-use Symfony\Component\Dotenv\Dotenv;
 use Symfony\Component\HttpFoundation\Request;
 
-require __DIR__.'/../vendor/autoload.php';
+require dirname(__DIR__).'/vendor/autoload.php';
 
-// The check is to ensure we don't use .env if APP_ENV is defined
-if (!isset($_SERVER['APP_ENV']) && !isset($_ENV['APP_ENV'])) {
-    if (!class_exists(Dotenv::class)) {
-        throw new \RuntimeException('APP_ENV environment variable is not defined. You need to define environment variables for configuration or add "symfony/dotenv" as a Composer dependency to load variables from a .env file.');
-    }
-    (new Dotenv())->load(__DIR__.'/../.env');
-}
+Kernel::bootstrapEnv();
 
-$env = $_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? 'dev';
-$debug = (bool) ($_SERVER['APP_DEBUG'] ?? $_ENV['APP_DEBUG'] ?? ('prod' !== $env));
-
-if ($debug) {
+if ($_SERVER['APP_DEBUG']) {
     umask(0000);
 
     Debug::enable();
@@ -32,7 +22,7 @@ if ($trustedHosts = $_SERVER['TRUSTED_HOSTS'] ?? $_ENV['TRUSTED_HOSTS'] ?? false
     Request::setTrustedHosts(explode(',', $trustedHosts));
 }
 
-$kernel = new Kernel($env, $debug);
+$kernel = new Kernel($_SERVER['APP_ENV'], $_SERVER['APP_DEBUG']);
 $request = Request::createFromGlobals();
 $response = $kernel->handle($request);
 $response->send();

--- a/symfony/framework-bundle/4.2/src/Kernel.php
+++ b/symfony/framework-bundle/4.2/src/Kernel.php
@@ -5,7 +5,9 @@ namespace App;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Config\Resource\FileResource;
+use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Dotenv\Dotenv;
 use Symfony\Component\HttpKernel\Kernel as BaseKernel;
 use Symfony\Component\Routing\RouteCollectionBuilder;
 
@@ -57,5 +59,30 @@ class Kernel extends BaseKernel
         $routes->import($confDir.'/{routes}/*'.self::CONFIG_EXTS, '/', 'glob');
         $routes->import($confDir.'/{routes}/'.$this->environment.'/**/*'.self::CONFIG_EXTS, '/', 'glob');
         $routes->import($confDir.'/{routes}'.self::CONFIG_EXTS, '/', 'glob');
+    }
+
+    public static function bootstrapCli(array &$argv)
+    {
+        // consume --env and --no-debug from the command line
+        Application::bootstrapEnv($argv);
+    }
+
+    public static function bootstrapEnv(string $env = null)
+    {
+        if (null !== $env) {
+            putenv('APP_ENV='.$_SERVER['APP_ENV'] = $env);
+        }
+
+        if ('prod' !== $_SERVER['APP_ENV'] = $_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? null) {
+            if (!class_exists(Dotenv::class)) {
+                throw new \RuntimeException('The "APP_ENV" environment variable is not defined. You need to set it or run "composer require symfony/dotenv" to load it from a ".env" file.');
+            }
+
+            (new Dotenv())->loadEnv(\dirname(__DIR__).'/.env');
+        }
+
+        $_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = $_SERVER['APP_ENV'] ?? $_SERVER['APP_ENV'] ?? 'dev';
+        $_SERVER['APP_DEBUG'] = $_SERVER['APP_DEBUG'] ?? $_ENV['APP_DEBUG'] ?? 'prod' !== $_SERVER['APP_ENV'];
+        $_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = (int) $_SERVER['APP_DEBUG'] || filter_var($_SERVER['APP_DEBUG'], FILTER_VALIDATE_BOOLEAN) ? '1' : '0';
     }
 }

--- a/symfony/phpunit-bridge/3.3/.env.test
+++ b/symfony/phpunit-bridge/3.3/.env.test
@@ -1,0 +1,6 @@
+# define your env variables for the test env here
+KERNEL_CLASS=App\\Kernel
+APP_SECRET='s$cretf0rt3st'
+SHELL_VERBOSITY=-1
+SYMFONY_DEPRECATIONS_HELPER=999999
+SYMFONY_PHPUNIT_VERSION=6.5

--- a/symfony/phpunit-bridge/3.3/bin/phpunit
+++ b/symfony/phpunit-bridge/3.3/bin/phpunit
@@ -5,15 +5,13 @@ if (!file_exists(dirname(__DIR__).'/vendor/symfony/phpunit-bridge/bin/simple-php
     echo "Unable to find the `simple-phpunit` script in `vendor/symfony/phpunit-bridge/bin/`.\n";
     exit(1);
 }
-if (false === getenv('SYMFONY_DEPRECATIONS_HELPER')) {
-    // see https://symfony.com/doc/current/components/phpunit_bridge.html#making-tests-fail
-    putenv('SYMFONY_DEPRECATIONS_HELPER=999999');
-}
+
+$classLoader = require dirname(__DIR__).'/vendor/autoload.php';
+App\Kernel::bootstrapEnv('test');
+$classLoader->unregister();
+
 if (false === getenv('SYMFONY_PHPUNIT_REMOVE')) {
     putenv('SYMFONY_PHPUNIT_REMOVE=symfony/yaml');
-}
-if (false === getenv('SYMFONY_PHPUNIT_VERSION')) {
-    putenv('SYMFONY_PHPUNIT_VERSION=6.5');
 }
 if (false === getenv('SYMFONY_PHPUNIT_DIR')) {
     putenv('SYMFONY_PHPUNIT_DIR='.__DIR__.'/.phpunit');

--- a/symfony/phpunit-bridge/3.3/manifest.json
+++ b/symfony/phpunit-bridge/3.3/manifest.json
@@ -1,5 +1,6 @@
 {
     "copy-from-recipe": {
+        ".env.test": ".env.test",
         "bin/": "%BIN_DIR%/",
         "config/": "%CONFIG_DIR%/",
         "phpunit.xml.dist": "phpunit.xml.dist",

--- a/symfony/phpunit-bridge/3.3/phpunit.xml.dist
+++ b/symfony/phpunit-bridge/3.3/phpunit.xml.dist
@@ -9,12 +9,6 @@
 >
     <php>
         <ini name="error_reporting" value="-1" />
-        <env name="KERNEL_CLASS" value="App\Kernel" />
-        <env name="APP_ENV" value="test" />
-        <env name="APP_DEBUG" value="1" />
-        <env name="APP_SECRET" value="s$cretf0rt3st" />
-        <env name="SHELL_VERBOSITY" value="-1" />
-        <!-- define your env variables for the test env here -->
     </php>
 
     <testsuites>

--- a/symfony/phpunit-bridge/4.1/.env.test
+++ b/symfony/phpunit-bridge/4.1/.env.test
@@ -1,0 +1,6 @@
+# define your env variables for the test env here
+KERNEL_CLASS=App\\Kernel
+APP_SECRET='s$cretf0rt3st'
+SHELL_VERBOSITY=-1
+SYMFONY_DEPRECATIONS_HELPER=999999
+SYMFONY_PHPUNIT_VERSION=6.5

--- a/symfony/phpunit-bridge/4.1/bin/phpunit
+++ b/symfony/phpunit-bridge/4.1/bin/phpunit
@@ -5,15 +5,13 @@ if (!file_exists(dirname(__DIR__).'/vendor/symfony/phpunit-bridge/bin/simple-php
     echo "Unable to find the `simple-phpunit` script in `vendor/symfony/phpunit-bridge/bin/`.\n";
     exit(1);
 }
-if (false === getenv('SYMFONY_DEPRECATIONS_HELPER')) {
-    // see https://symfony.com/doc/current/components/phpunit_bridge.html#making-tests-fail
-    putenv('SYMFONY_DEPRECATIONS_HELPER=999999');
-}
+
+$classLoader = require dirname(__DIR__).'/vendor/autoload.php';
+App\Kernel::bootstrapEnv('test');
+$classLoader->unregister();
+
 if (false === getenv('SYMFONY_PHPUNIT_REMOVE')) {
     putenv('SYMFONY_PHPUNIT_REMOVE=');
-}
-if (false === getenv('SYMFONY_PHPUNIT_VERSION')) {
-    putenv('SYMFONY_PHPUNIT_VERSION=6.5');
 }
 if (false === getenv('SYMFONY_PHPUNIT_DIR')) {
     putenv('SYMFONY_PHPUNIT_DIR='.__DIR__.'/.phpunit');

--- a/symfony/phpunit-bridge/4.1/manifest.json
+++ b/symfony/phpunit-bridge/4.1/manifest.json
@@ -1,5 +1,6 @@
 {
     "copy-from-recipe": {
+        ".env.test": ".env.test",
         "bin/": "%BIN_DIR%/",
         "phpunit.xml.dist": "phpunit.xml.dist",
         "tests/": "tests/"

--- a/symfony/phpunit-bridge/4.1/phpunit.xml.dist
+++ b/symfony/phpunit-bridge/4.1/phpunit.xml.dist
@@ -9,12 +9,6 @@
 >
     <php>
         <ini name="error_reporting" value="-1" />
-        <env name="KERNEL_CLASS" value="App\Kernel" />
-        <env name="APP_ENV" value="test" />
-        <env name="APP_DEBUG" value="1" />
-        <env name="APP_SECRET" value="s$cretf0rt3st" />
-        <env name="SHELL_VERBOSITY" value="-1" />
-        <!-- define your env variables for the test env here -->
     </php>
 
     <testsuites>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

This PR is an alternative to #466 and replaces #479.
It needs https://github.com/symfony/symfony/pull/29129 to work with 4.2.

What we have here:
- Dotenv is configured to load `.env` < `.env.local` < `.env.$env` < `.env.$env.local` (only the 1st is required, see PR linked above)
- this works starting with Symfony 3.4 and uses an optimized code starting with 4.2 (removing the doc-split hell)
- the loading logic is factorized in a new static `Kernel::bootstrapEnv()` method
- the CLI accepts and *consumes* `--env` & `--no-debug` (see `Kernel::bootstrapCliEnv()`, fixes https://github.com/symfony/symfony/issues/23343)
- `.env` files are loaded for tests (fixes https://github.com/symfony/flex/issues/317, https://github.com/symfony/symfony/issues/28895 and https://github.com/symfony/symfony/issues/28726)
- config for the test env is moved from `phpunit.xml.dist` to `.env.test`
- `.env.dist` is not created anymore (commit `.env` instead and use `.env.local` for local overrides)
- `.gitignore` is updated accordingly

Regarding flex integration:
- this PR doesn't change anything for existing projects - they won't notice
- when flex sees a `.env.test` file, it should skip updating `phpunit.xml` files
- that's it - all the rest should remain identical, isn't it?
- (people that still want to use `.env.dist` just need to create the file and flex will populate it as it does today)