### PR TITLE
Fix recipe: make consistent with symfony/flex 1.0 new env handling

### DIFF
--- a/symfony/flex/1.0/.env.dist
+++ b/symfony/flex/1.0/.env.dist
@@ -1,0 +1,3 @@
+# This file is a "template" of which env vars need to be defined for your application
+# Copy this file to .env file for development, create environment variables when deploying to production
+# https://symfony.com/doc/current/best_practices/configuration.html#infrastructure-related-configuration

--- a/symfony/framework-bundle/3.3/manifest.json
+++ b/symfony/framework-bundle/3.3/manifest.json
@@ -18,7 +18,8 @@
         "#TRUSTED_HOSTS": "localhost,example.com"
     },
     "gitignore": [
-        "/.env",
+        "/.env.local",
+        "/.env.*.local",
         "/%PUBLIC_DIR%/bundles/",
         "/%VAR_DIR%/",
         "/vendor/"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

In #481, the symfony/flex 1.0 recipe was changed so that the user gets a `.env` file and NOT a `.env.dist`. The gitignore recipe for FWBundle 4.2 was updated, but not 3.3.

Cheers!