### PR TITLE
nelmio/cors-bundle: update CORS_ALLOW_ORIGIN

### DIFF
--- a/nelmio/cors-bundle/1.5/manifest.json
+++ b/nelmio/cors-bundle/1.5/manifest.json
@@ -6,7 +6,7 @@
         "config/": "%CONFIG_DIR%/"
     },
     "env": {
-        "CORS_ALLOW_ORIGIN": "^https?://localhost(:[0-9]+)?$"
+        "CORS_ALLOW_ORIGIN": "^https?://localhost\(:[0-9]+\)?$"
     },
     "aliases": ["cors"]
 }

--- a/nelmio/cors-bundle/1.5/manifest.json
+++ b/nelmio/cors-bundle/1.5/manifest.json
@@ -6,7 +6,7 @@
         "config/": "%CONFIG_DIR%/"
     },
     "env": {
-        "CORS_ALLOW_ORIGIN": "^https?://localhost\\\(:[0-9]+\\\)?$"
+        "CORS_ALLOW_ORIGIN": "^https?://localhost\\\\(:[0-9]+\\\\)?$"
     },
     "aliases": ["cors"]
 }

--- a/nelmio/cors-bundle/1.5/manifest.json
+++ b/nelmio/cors-bundle/1.5/manifest.json
@@ -6,7 +6,7 @@
         "config/": "%CONFIG_DIR%/"
     },
     "env": {
-        "CORS_ALLOW_ORIGIN": "^https?://localhost\\(:[0-9]+\\)?$"
+        "CORS_ALLOW_ORIGIN": "^https?://localhost\\\(:[0-9]+\\\)?$"
     },
     "aliases": ["cors"]
 }

--- a/nelmio/cors-bundle/1.5/manifest.json
+++ b/nelmio/cors-bundle/1.5/manifest.json
@@ -6,7 +6,7 @@
         "config/": "%CONFIG_DIR%/"
     },
     "env": {
-        "CORS_ALLOW_ORIGIN": "^https?://localhost\(:[0-9]+\)?$"
+        "CORS_ALLOW_ORIGIN": "^https?://localhost\\(:[0-9]+\\)?$"
     },
     "aliases": ["cors"]
 }

--- a/nelmio/cors-bundle/1.5/manifest.json
+++ b/nelmio/cors-bundle/1.5/manifest.json
@@ -6,7 +6,7 @@
         "config/": "%CONFIG_DIR%/"
     },
     "env": {
-        "CORS_ALLOW_ORIGIN": "^https?://localhost\\\\(:[0-9]+\\\\)?$"
+        "CORS_ALLOW_ORIGIN": "'^https?://localhost(:[0-9]+)?$'"
     },
     "aliases": ["cors"]
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

fixes

```
.env: line 48: syntax error near unexpected token `('
.env: line 48: `CORS_ALLOW_ORIGIN=^https?://localhost(:[0-9]+)?$'
```

with `source .env` 

after

```
echo $CORS_ALLOW_ORIGIN
^https?://localhost(:[0-9]+)?$
```

let me know if im missing something :thinking: 