### PR TITLE
Fix loading the autoloader in tests

### DIFF
--- a/symfony/phpunit-bridge/3.3/bin/phpunit
+++ b/symfony/phpunit-bridge/3.3/bin/phpunit
@@ -6,9 +6,9 @@ if (!file_exists(dirname(__DIR__).'/vendor/symfony/phpunit-bridge/bin/simple-php
     exit(1);
 }
 
-$classLoader = require dirname(__DIR__).'/vendor/autoload.php';
+require dirname(__DIR__).'/vendor/autoload.php';
+
 App\Kernel::bootstrapEnv('test');
-$classLoader->unregister();
 
 if (false === getenv('SYMFONY_PHPUNIT_REMOVE')) {
     putenv('SYMFONY_PHPUNIT_REMOVE=symfony/yaml');

--- a/symfony/phpunit-bridge/4.1/bin/phpunit
+++ b/symfony/phpunit-bridge/4.1/bin/phpunit
@@ -6,9 +6,9 @@ if (!file_exists(dirname(__DIR__).'/vendor/symfony/phpunit-bridge/bin/simple-php
     exit(1);
 }
 
-$classLoader = require dirname(__DIR__).'/vendor/autoload.php';
+require dirname(__DIR__).'/vendor/autoload.php';
+
 App\Kernel::bootstrapEnv('test');
-$classLoader->unregister();
 
 if (false === getenv('SYMFONY_PHPUNIT_REMOVE')) {
     putenv('SYMFONY_PHPUNIT_REMOVE=');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

As reported in https://github.com/symfony/recipes/commit/95bb54353eb404a22e365fef62e937a371833af9#r31264986
phpunit uses `include_once` so referencing `vendor/autoload.php` is a no-op.

Let's forget about the potential autoload stack reordering issue, it shouldn't have any effect in practice.