### PR TITLE
Bumping encore version

### DIFF
--- a/symfony/webpack-encore-bundle/1.0/package.json
+++ b/symfony/webpack-encore-bundle/1.0/package.json
@@ -1,6 +1,6 @@
 {
     "devDependencies": {
-        "@symfony/webpack-encore": "^0.21.0",
+        "@symfony/webpack-encore": "^0.22.0",
         "webpack-notifier": "^1.6.0"
     },
     "license": "UNLICENSED",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Needed so users get the latest version - `^0.21.0` will only allow for `0.21.*`. We ultimately need a stable Encore release to ease needing to always make this change.

Thanks!