### PR TITLE
Always load vars defined in .env files, providing .env.local.php for prod

### DIFF
--- a/symfony/console/3.3/bin/console
+++ b/symfony/console/3.3/bin/console
@@ -15,10 +15,8 @@ if (!class_exists(Application::class)) {
 }
 
 $input = new ArgvInput();
-if (null !== $_ENV['APP_ENV'] = $input->getParameterOption(['--env', '-e'], null, true)) {
-    putenv('APP_ENV='.$_ENV['APP_ENV']);
-    // force loading .env files when --env is defined
-    $_SERVER['APP_ENV'] = null;
+if (null !== $env = $input->getParameterOption(['--env', '-e'], null, true)) {
+    putenv('APP_ENV='.$_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = $env);
 }
 
 if ($input->hasParameterOption('--no-debug', true)) {

--- a/symfony/flex/1.0/.env
+++ b/symfony/flex/1.0/.env
@@ -1,5 +1,14 @@
-# This file defines all environment variables that the application needs.
-# DO NOT DEFINE PRODUCTION SECRETS IN THIS FILE.
-# Use ".env.local" for local overrides during development.
-# Use real environment variables when deploying to production.
+# In all environments, the following files are loaded if they exist,
+# the later taking precedence over the former:
+#
+#  * .env                contains default values for the environment variables needed by the app
+#  * .env.local          uncommitted file with local overrides
+#  * .env.$APP_ENV       committed environment-specific defaults
+#  * .env.$APP_ENV.local uncommitted environment-specific overrides
+#
+# Real environment variables win over .env files.
+#
+# DO NOT DEFINE PRODUCTION SECRETS IN THIS FILE NOR IN ANY OTHER COMMITTED FILES.
+#
+# Run "composer dump-env prod" to compile .env files for production use (requires symfony/flex >=1.2).
 # https://symfony.com/doc/current/best_practices/configuration.html#infrastructure-related-configuration

--- a/symfony/framework-bundle/3.3/config/bootstrap.php
+++ b/symfony/framework-bundle/3.3/config/bootstrap.php
@@ -4,18 +4,18 @@ use Symfony\Component\Dotenv\Dotenv;
 
 require dirname(__DIR__).'/vendor/autoload.php';
 
-if (!array_key_exists('APP_ENV', $_SERVER)) {
-    $_SERVER['APP_ENV'] = $_ENV['APP_ENV'] ?? null;
-}
-
-if ('prod' !== $_SERVER['APP_ENV']) {
-    if (!class_exists(Dotenv::class)) {
-        throw new RuntimeException('The "APP_ENV" environment variable is not set to "prod". Please run "composer require symfony/dotenv" to load the ".env" files configuring the application.');
-    }
-
+// Load cached env vars if the .env.local.php file exists
+// Run "composer dump-env prod" to create it (requires symfony/flex >=1.2)
+if (is_array($env = @include dirname(__DIR__).'/.env.local.php')) {
+    $_SERVER += $env;
+    $_ENV += $env;
+} elseif (!class_exists(Dotenv::class)) {
+    throw new RuntimeException('Please run "composer require symfony/dotenv" to load the ".env" files configuring the application.');
+} else {
     $path = dirname(__DIR__).'/.env';
     $dotenv = new Dotenv();
 
+    // load all the .env files
     if (method_exists($dotenv, 'loadEnv')) {
         $dotenv->loadEnv($path);
     } else {

--- a/symfony/framework-bundle/3.3/manifest.json
+++ b/symfony/framework-bundle/3.3/manifest.json
@@ -19,6 +19,7 @@
     },
     "gitignore": [
         "/.env.local",
+        "/.env.local.php",
         "/.env.*.local",
         "/%PUBLIC_DIR%/bundles/",
         "/%VAR_DIR%/",

--- a/symfony/framework-bundle/4.2/config/bootstrap.php
+++ b/symfony/framework-bundle/4.2/config/bootstrap.php
@@ -4,15 +4,15 @@ use Symfony\Component\Dotenv\Dotenv;
 
 require dirname(__DIR__).'/vendor/autoload.php';
 
-if (!array_key_exists('APP_ENV', $_SERVER)) {
-    $_SERVER['APP_ENV'] = $_ENV['APP_ENV'] ?? null;
-}
-
-if ('prod' !== $_SERVER['APP_ENV']) {
-    if (!class_exists(Dotenv::class)) {
-        throw new RuntimeException('The "APP_ENV" environment variable is not set to "prod". Please run "composer require symfony/dotenv" to load the ".env" files configuring the application.');
-    }
-
+// Load cached env vars if the .env.local.php file exists
+// Run "composer dump-env prod" to create it (requires symfony/flex >=1.2)
+if (is_array($env = @include dirname(__DIR__).'/.env.local.php')) {
+    $_SERVER += $env;
+    $_ENV += $env;
+} elseif (!class_exists(Dotenv::class)) {
+    throw new RuntimeException('Please run "composer require symfony/dotenv" to load the ".env" files configuring the application.');
+} else {
+    // load all the .env files
     (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 }
 

--- a/symfony/framework-bundle/4.2/manifest.json
+++ b/symfony/framework-bundle/4.2/manifest.json
@@ -19,6 +19,7 @@
     },
     "gitignore": [
         "/.env.local",
+        "/.env.local.php",
         "/.env.*.local",
         "/%PUBLIC_DIR%/bundles/",
         "/%VAR_DIR%/",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

This PR provides a nice experience where `.env` files are "always" loaded.
That means their purpose is easy to reason about: the committed files define the defaults (`.env` especially) - and `.env.local` defines local overrides.

A new `.env.local.php` is provided for prod, so that performance is not affected.
When `.env.local.php` is found, other .env files are ignored.

On the deployement side, this means it should be much easier to deal with `.env` files for people that can't easilly deal with real env vars:
- if you use real env vars they always win
- logically, `.env` files are always loaded (to define defaults)
- on prod, one can dump a `.env.local.php` file for max performance

The plan is to add a new flex command to create this file and ease deployments:
`composer dump-env prod`