### PR TITLE
Add a recipe for API Platform Admin

### DIFF
--- a/api-platform/admin-pack/1.0/assets/js/admin.js
+++ b/api-platform/admin-pack/1.0/assets/js/admin.js
@@ -1,0 +1,7 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { HydraAdmin } from '@api-platform/admin';
+
+const entrypoint = document.getElementById('api-entrypoint').innerText;
+
+ReactDOM.render(<HydraAdmin entrypoint={entrypoint}/>, document.getElementById('api-platform-admin'));

--- a/api-platform/admin-pack/1.0/config/routes/api_platform_admin.yaml
+++ b/api-platform/admin-pack/1.0/config/routes/api_platform_admin.yaml
@@ -1,0 +1,5 @@
+admin:
+    path: /admin
+    controller: Symfony\Bundle\FrameworkBundle\Controller\TemplateController
+    defaults:
+        template: admin.html.twig

--- a/api-platform/admin-pack/1.0/manifest.json
+++ b/api-platform/admin-pack/1.0/manifest.json
@@ -1,0 +1,8 @@
+{
+    "copy-from-recipe": {
+        "assets/": "assets/",
+        "config/": "%CONFIG_DIR%/",
+        "templates/": "templates/"
+    },
+    "aliases": ["api-admin", "api-platform-admin", "react-admin"]
+}

--- a/api-platform/admin-pack/1.0/post-install.txt
+++ b/api-platform/admin-pack/1.0/post-install.txt
@@ -4,13 +4,13 @@
 
   * Your admin is almost ready:
     1. Install the JavaScript dependencies by running <comment>yarn add @api-platform/admin</comment>
-    2. Go in <comment>webpack.config.js</comment> and <info>uncomment</info> the following lines:
+    2. Edit <comment>webpack.config.js</comment> and <info>uncomment</info> the following lines:
 
         Encore
             // ...
             .enableReactPreset()
             .addEntry('admin', './assets/js/admin.js')
 
-  * Mark any entity with the <comment>@ApiResource</comment> annotation, it appears in the admin!
+  * Mark entities you want in the admin with the <comment>@ApiResource</comment> annotation, it appears in the admin!
 
   * Using MakerBundle? Try <info>php bin/console make:entity --api-resource</info>

--- a/api-platform/admin-pack/1.0/post-install.txt
+++ b/api-platform/admin-pack/1.0/post-install.txt
@@ -1,0 +1,16 @@
+<bg=blue;fg=white>                       </>
+<bg=blue;fg=white> To finish the install </>
+<bg=blue;fg=white>                       </>
+
+  * Your admin is almost ready:
+    1. Install the JavaScript dependencies by running <comment>yarn add @api-platform/admin</comment>
+    2. Go in <comment>webpack.config.js</comment> and <info>uncomment</info> the following lines:
+
+        Encore
+            // ...
+            .enableReactPreset()
+            .addEntry('admin', './assets/js/admin.js')
+
+  * Mark any entity with the <comment>@ApiResource</comment> annotation, it appears in the admin!
+
+  * Using MakerBundle? Try <info>php bin/console make:entity --api-resource</info>

--- a/api-platform/admin-pack/1.0/post-install.txt
+++ b/api-platform/admin-pack/1.0/post-install.txt
@@ -3,7 +3,7 @@
 <bg=blue;fg=white>                       </>
 
   * Your admin is almost ready:
-    1. Install the JavaScript dependencies by running <comment>yarn add @api-platform/admin</comment>
+    1. Install the JavaScript dependencies by running <comment>yarn add @api-platform/admin @babel/preset-react</comment>
     2. Edit <comment>webpack.config.js</comment> and <info>uncomment</info> the following lines:
 
         Encore

--- a/api-platform/admin-pack/1.0/templates/admin.html.twig
+++ b/api-platform/admin-pack/1.0/templates/admin.html.twig
@@ -1,0 +1,10 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}API Platform Admin{% endblock %}
+
+{% block body %}<div id="api-platform-admin"></div>{% endblock %}
+
+{% block javascripts %}
+    <script type="text/plain" id="api-entrypoint">{{ path('api_entrypoint') }}</script>
+    {{ encore_entry_script_tags('admin') }}
+{% endblock %}

--- a/symfony/webpack-encore-bundle/1.0/webpack.config.js
+++ b/symfony/webpack-encore-bundle/1.0/webpack.config.js
@@ -46,6 +46,10 @@ Encore
 
     // uncomment if you're having problems with a jQuery plugin
     //.autoProvidejQuery()
+
+    // uncomment if you use API Platform Admin (composer req api-admin)
+    //.enableReactPreset()
+    //.addEntry('admin', './assets/js/admin.js')
 ;
 
 module.exports = Encore.getWebpackConfig();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

![admin-demo-97cd2738071d63989db0bbcb6ba85a25](https://user-images.githubusercontent.com/57224/49690669-13461a80-fb35-11e8-875b-1ca46a4d23fc.gif)

This PR makes it easy to use [API Platform Admin](https://api-platform.com/docs/admin) in a traditional Symfony app (an app using Twig).

The recipe installs Webpack Encore and API Platform (using their respective packs) and generate a Twig template, a route and the appropriate code to load the admin in a standard Symfony page. 

It works in a different way than in the "official" distribution of API Platform:

* in API Platform, the admin is a standalone Progressive Web App that must be hosted as a static website (using GitHub Page, Netlify or similar solutions)
* when using this recipe, the React component is loaded directly inside the existing Symfony application, through a Twig template (so it is not installable as a PWA, but doesn't require to setup a different server, CORS headers...).