### PR TITLE
Optimize Encore Init

### DIFF
--- a/symfony/webpack-encore-bundle/1.0/assets/js/app.js
+++ b/symfony/webpack-encore-bundle/1.0/assets/js/app.js
@@ -9,6 +9,6 @@
 require('../css/app.css');
 
 // Need jQuery? Install it with "yarn add jquery", then uncomment to require it.
-// var $ = require('jquery');
+// let $ = require('jquery');
 
 console.log('Hello Webpack Encore! Edit me in assets/js/app.js');

--- a/symfony/webpack-encore-bundle/1.0/assets/js/app.js
+++ b/symfony/webpack-encore-bundle/1.0/assets/js/app.js
@@ -9,6 +9,6 @@
 require('../css/app.css');
 
 // Need jQuery? Install it with "yarn add jquery", then uncomment to require it.
-// let $ = require('jquery');
+// const $ = require('jquery');
 
 console.log('Hello Webpack Encore! Edit me in assets/js/app.js');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Some optimization when we init encore with Flex. We can use ```let``` instruction because webpack transpile that. I think that gitignore is not needed because css and js folder exists at creation. If the developer change that folder, it's his responsability to create this file.