### PR TITLE
Add .splitEntryChunks() to webpack.config.js

### DIFF
--- a/symfony/webpack-encore-bundle/1.0/webpack.config.js
+++ b/symfony/webpack-encore-bundle/1.0/webpack.config.js
@@ -21,6 +21,9 @@ Encore
     //.addEntry('page1', './assets/js/page1.js')
     //.addEntry('page2', './assets/js/page2.js')
 
+    // When enabled, Webpack "splits" your files into smaller pieces for greater optimization.
+    .splitEntryChunks()
+
     // will require an extra script tag for runtime.js
     // but, you probably want this, unless you're building a single-page app
     .enableSingleRuntimeChunk()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Don't we need adding .`.splitEntryChunks()` as pointed in docs? See https://github.com/symfony/webpack-encore-bundle#usage
