### PR TITLE
Using autowire in security_checker.yaml

### DIFF
--- a/sensiolabs/security-checker/4.0/config/packages/security_checker.yaml
+++ b/sensiolabs/security-checker/4.0/config/packages/security_checker.yaml
@@ -1,9 +1,8 @@
 services:
-    SensioLabs\Security\SecurityChecker:
-        public: false
+    _defaults:
+        autowire: true
+        autoconfigure: true
 
-    SensioLabs\Security\Command\SecurityCheckerCommand:
-        arguments: ['@SensioLabs\Security\SecurityChecker']
-        public: false
-        tags:
-            - { name: console.command, command: 'security:check' }
+    SensioLabs\Security\SecurityChecker: ~
+
+    SensioLabs\Security\Command\SecurityCheckerCommand: ~


### PR DESCRIPTION
Using autowire & autoconfigure in `security_checker.yaml`

This made for consistency with main `config/services.yaml` style and following the latest trends.

Moved from https://github.com/symfony/demo/pull/898

| Q             | A
| ------------- | ---
| License       | MIT
