### PR TITLE
Allowing APP_ENV to be an empty index

### DIFF
--- a/symfony/framework-bundle/3.3/config/bootstrap.php
+++ b/symfony/framework-bundle/3.3/config/bootstrap.php
@@ -46,6 +46,6 @@ if (is_array($env = @include dirname(__DIR__).'/.env.local.php')) {
     }
 }
 
-$_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = $_SERVER['APP_ENV'] ?: $_ENV['APP_ENV'] ?: 'dev';
+$_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = $_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? 'dev';
 $_SERVER['APP_DEBUG'] = $_SERVER['APP_DEBUG'] ?? $_ENV['APP_DEBUG'] ?? 'prod' !== $_SERVER['APP_ENV'];
 $_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = (int) $_SERVER['APP_DEBUG'] || filter_var($_SERVER['APP_DEBUG'], FILTER_VALIDATE_BOOLEAN) ? '1' : '0';

--- a/symfony/framework-bundle/4.2/config/bootstrap.php
+++ b/symfony/framework-bundle/4.2/config/bootstrap.php
@@ -16,6 +16,6 @@ if (is_array($env = @include dirname(__DIR__).'/.env.local.php')) {
     (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 }
 
-$_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = $_SERVER['APP_ENV'] ?: $_ENV['APP_ENV'] ?: 'dev';
+$_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = $_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? 'dev';
 $_SERVER['APP_DEBUG'] = $_SERVER['APP_DEBUG'] ?? $_ENV['APP_DEBUG'] ?? 'prod' !== $_SERVER['APP_ENV'];
 $_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = (int) $_SERVER['APP_DEBUG'] || filter_var($_SERVER['APP_DEBUG'], FILTER_VALIDATE_BOOLEAN) ? '1' : '0';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Hi people!

Fixes #512 

This happened after #501 was merged. Previously, code at the top of `bootstrap.php` guaranteed that the `$_SERVER['APP_ENV']` key always existed. After that was removed, the code at the bottom needed to be updated to account for this.

I tested that this does fix the undefined index problem when using phpunit.

Cheers!