### PR TITLE
minor tweak - if APP_ENV is an empty string, this defaults it back to dev

### DIFF
--- a/symfony/framework-bundle/3.3/config/bootstrap.php
+++ b/symfony/framework-bundle/3.3/config/bootstrap.php
@@ -46,6 +46,6 @@ if (is_array($env = @include dirname(__DIR__).'/.env.local.php')) {
     }
 }
 
-$_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = $_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? 'dev';
+$_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = ($_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? null) ?: 'dev';
 $_SERVER['APP_DEBUG'] = $_SERVER['APP_DEBUG'] ?? $_ENV['APP_DEBUG'] ?? 'prod' !== $_SERVER['APP_ENV'];
 $_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = (int) $_SERVER['APP_DEBUG'] || filter_var($_SERVER['APP_DEBUG'], FILTER_VALIDATE_BOOLEAN) ? '1' : '0';

--- a/symfony/framework-bundle/4.2/config/bootstrap.php
+++ b/symfony/framework-bundle/4.2/config/bootstrap.php
@@ -16,6 +16,6 @@ if (is_array($env = @include dirname(__DIR__).'/.env.local.php')) {
     (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 }
 
-$_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = $_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? 'dev';
+$_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = ($_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? null) ?: 'dev';
 $_SERVER['APP_DEBUG'] = $_SERVER['APP_DEBUG'] ?? $_ENV['APP_DEBUG'] ?? 'prod' !== $_SERVER['APP_ENV'];
 $_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = (int) $_SERVER['APP_DEBUG'] || filter_var($_SERVER['APP_DEBUG'], FILTER_VALIDATE_BOOLEAN) ? '1' : '0';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

One more tweak after #513 

It's an edge-case, but when APP_ENV is set to an empty string

```
APP_ENV='' php bin/console
```

Before `$_SERVER['APP_ENV']` would be an empty string, after it would be `dev`. 

Or, maybe we decide that the current behavior IS the correct behavior. It's an edge-case either way.