### PR TITLE
Always load .env.local even in test environment

### DIFF
--- a/symfony/framework-bundle/3.3/config/bootstrap.php
+++ b/symfony/framework-bundle/3.3/config/bootstrap.php
@@ -31,7 +31,7 @@ if (is_array($env = @include dirname(__DIR__).'/.env.local.php')) {
             $dotenv->populate(array('APP_ENV' => $env = 'dev'));
         }
 
-        if ('test' !== $env && file_exists($p = "$path.local")) {
+        if (file_exists($p = "$path.local")) {
             $dotenv->load($p);
             $env = $_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? $env;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

I'm not sure about the original purpose of this, but does anybody have a good example when it's useful?

Because for me it does not seem useful. For example, I may have some paths to binaries that are different on different systems, so I'd like to overwrite these paths with my `.env.local` that are defaulted in `.env`. And I do want to use those new paths in every environment, not only in `dev`/`prod` skipping `test`. And I don't see a value in duplicating them one more time in `.env.test.local`. Thoughts?