### PR TITLE
Remove apostrophes from trusted hosts

### DIFF
--- a/symfony/framework-bundle/3.3/manifest.json
+++ b/symfony/framework-bundle/3.3/manifest.json
@@ -15,7 +15,7 @@
         "APP_ENV": "dev",
         "APP_SECRET": "%generate(secret)%",
         "#TRUSTED_PROXIES": "127.0.0.1,127.0.0.2",
-        "#TRUSTED_HOSTS": "^localhost|example\\.com$"
+        "#TRUSTED_HOSTS": "^localhost|example\.com$"
     },
     "gitignore": [
         "/.env.local",

--- a/symfony/framework-bundle/3.3/manifest.json
+++ b/symfony/framework-bundle/3.3/manifest.json
@@ -15,7 +15,7 @@
         "APP_ENV": "dev",
         "APP_SECRET": "%generate(secret)%",
         "#TRUSTED_PROXIES": "127.0.0.1,127.0.0.2",
-        "#TRUSTED_HOSTS": "'^localhost|example\\.com$'"
+        "#TRUSTED_HOSTS": "^localhost|example\\.com$"
     },
     "gitignore": [
         "/.env.local",

--- a/symfony/framework-bundle/4.2/manifest.json
+++ b/symfony/framework-bundle/4.2/manifest.json
@@ -15,7 +15,7 @@
         "APP_ENV": "dev",
         "APP_SECRET": "%generate(secret)%",
         "#TRUSTED_PROXIES": "127.0.0.1,127.0.0.2",
-        "#TRUSTED_HOSTS": "'^localhost|example\\.com$'"
+        "#TRUSTED_HOSTS": "^localhost|example\.com$"
     },
     "gitignore": [
         "/.env.local",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

When activating the `TRUSTED_PROXIES` in the `.env` the enclosing apostrophes mess up the regex. The `Request::SetTrustedProxies` turns this into `{'^localhost|example\\.com$'}i`. In this form the preg_match can not match the hosts.

On top of that, the double `\` also messes it up because this escapes the backslash itself instead of the dot. Therefore the regex will be matching _any charachter except linebreaks_ in the url, while it should be matching the dot.
