### PR TITLE
Remove the no longer needed getCacheDir and getLogDir methods.

### DIFF
--- a/symfony/framework-bundle/4.2/src/Kernel.php
+++ b/symfony/framework-bundle/4.2/src/Kernel.php
@@ -15,16 +15,6 @@ class Kernel extends BaseKernel
 
     const CONFIG_EXTS = '.{php,xml,yaml,yml}';
 
-    public function getCacheDir()
-    {
-        return $this->getProjectDir().'/var/cache/'.$this->environment;
-    }
-
-    public function getLogDir()
-    {
-        return $this->getProjectDir().'/var/log';
-    }
-
     public function registerBundles()
     {
         $contents = require $this->getProjectDir().'/config/bundles.php';


### PR DESCRIPTION
Since Symfony v4.2 the methods of the parent class are the same.

| Q             | A
| ------------- | ---
| License       | MIT
