### PR TITLE
adjust recipe configuration

### DIFF
--- a/php-http/httplug-bundle/1.6/config/packages/httplug.yaml
+++ b/php-http/httplug-bundle/1.6/config/packages/httplug.yaml
@@ -1,7 +1,7 @@
 httplug:
     plugins:
-        redirect:
-            preserve_header: true
+        retry:
+            retry: 1
 
     discovery:
         client: 'auto'
@@ -12,3 +12,7 @@ httplug:
             plugins:
                 - 'httplug.plugin.content_length'
                 - 'httplug.plugin.redirect'
+                - header_defaults:
+                    headers:
+                        "X-Httplug": "This is just an example".
+                - 'httplug.plugin.retry'

--- a/php-http/httplug-bundle/1.6/config/packages/httplug.yaml
+++ b/php-http/httplug-bundle/1.6/config/packages/httplug.yaml
@@ -14,5 +14,5 @@ httplug:
                 - 'httplug.plugin.redirect'
                 - header_defaults:
                     headers:
-                        "X-Httplug": "This is just an example".
+                        "X-Httplug": "This is just an example"
                 - 'httplug.plugin.retry'


### PR DESCRIPTION
preserving headers on redirects includes a potential security risk because on redirect to a different domain credential headers would be leaked.

| Q             | A
| ------------- | ---
| License       | MIT
