### PR TITLE
fix mercure environment variable name in parameters

### DIFF
--- a/symfony/mercure-bundle/0.1/config/packages/mercure.yaml
+++ b/symfony/mercure-bundle/0.1/config/packages/mercure.yaml
@@ -2,4 +2,4 @@ mercure:
     hubs:
         default:
             url: '%env(MERCURE_PUBLISH_URL)%'
-            jwt: '%env(MERCURE_JWT_SECRET)%'
+            jwt: '%env(MERCURE_JWT)%'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

The default environment variable set when installing is `MERCURE_JWT ` not `MERCURE_JWT_SECRET`, It contains the JWT token not the secret of it.
The envvar is correctly set but the parameter used is defined with the wrong one.