### PR TITLE
(WIP) Make tests faster by default

### DIFF
--- a/symfony/phpunit-bridge/3.3/phpunit.xml.dist
+++ b/symfony/phpunit-bridge/3.3/phpunit.xml.dist
@@ -10,6 +10,7 @@
     <php>
         <ini name="error_reporting" value="-1" />
         <env name="APP_ENV" value="test" />
+        <env name="APP_DEBUG" value="false" />
         <env name="SHELL_VERBOSITY" value="-1" />
     </php>
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

As explained by @stof in [this comment](https://github.com/symfony/symfony/issues/30290#issuecomment-464846550) most of the times you can run tests in the (much faster) "debug = false" mode.

This PR is incomplete! We need to see how to implement the clearing of the test cache when needed. @stof do you suggest to use something similar to what you showed in this gist? https://gist.github.com/stof/fb45ca5940159b2741081e1cb2dae3b0

Thanks.