### PR TITLE
Load routes for specific env first

### DIFF
--- a/symfony/framework-bundle/4.2/src/Kernel.php
+++ b/symfony/framework-bundle/4.2/src/Kernel.php
@@ -41,8 +41,8 @@ class Kernel extends BaseKernel
     {
         $confDir = $this->getProjectDir().'/config';
 
-        $routes->import($confDir.'/{routes}/*'.self::CONFIG_EXTS, '/', 'glob');
         $routes->import($confDir.'/{routes}/'.$this->environment.'/**/*'.self::CONFIG_EXTS, '/', 'glob');
+        $routes->import($confDir.'/{routes}/*'.self::CONFIG_EXTS, '/', 'glob');
         $routes->import($confDir.'/{routes}'.self::CONFIG_EXTS, '/', 'glob');
     }
 }


### PR DESCRIPTION
It's common to add a 'wildcard' route to an application that looks like
a CMS. Usually the route has the following path `/{slug}`.

But with the current routes loading order, the 'dev' routing is loaded
after regular routes. In previous SF versions, dev routing was loaded
first. This PR retores this behavior.


| Q             | A
| ------------- | ---
| License       | MIT