### PR TITLE
Documenting the WebpackEncoreBundle caching option

### DIFF
--- a/symfony/webpack-encore-bundle/1.0/config/packages/webpack_encore.yaml
+++ b/symfony/webpack-encore-bundle/1.0/config/packages/webpack_encore.yaml
@@ -2,3 +2,7 @@ webpack_encore:
     # The path where Encore is building the assets.
     # This should match Encore.setOutputPath() in webpack.config.js.
     output_path: '%kernel.project_dir%/public/build'
+
+    # Cache the entrypoints.json (rebuild Symfony's cache when entrypoints.json changes)
+    # Available in version 1.2
+    #cache: '%kernel.debug%'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

See symfony/webpack-encore-bundle#12

This is only available in 1.2, but I don't see a good reason to duplicate the recipe - it's an opt-in feature (so it will always be commented-out by default) and even if you, somehow, installed an older version today, you will now be aware of this feature.

Thanks!