### PR TITLE
Fix creating of prod matching environments

### DIFF
--- a/symfony/framework-bundle/3.3/config/bootstrap.php
+++ b/symfony/framework-bundle/3.3/config/bootstrap.php
@@ -47,5 +47,5 @@ if (is_array($env = @include dirname(__DIR__).'/.env.local.php')) {
 }
 
 $_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = ($_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? null) ?: 'dev';
-$_SERVER['APP_DEBUG'] = $_SERVER['APP_DEBUG'] ?? $_ENV['APP_DEBUG'] ?? 'prod' !== $_SERVER['APP_ENV'];
+$_SERVER['APP_DEBUG'] = $_SERVER['APP_DEBUG'] ?? $_ENV['APP_DEBUG'] ?? 'dev' === $_SERVER['APP_ENV'];
 $_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = (int) $_SERVER['APP_DEBUG'] || filter_var($_SERVER['APP_DEBUG'], FILTER_VALIDATE_BOOLEAN) ? '1' : '0';

--- a/symfony/framework-bundle/4.2/config/bootstrap.php
+++ b/symfony/framework-bundle/4.2/config/bootstrap.php
@@ -17,5 +17,5 @@ if (is_array($env = @include dirname(__DIR__).'/.env.local.php')) {
 }
 
 $_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = ($_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? null) ?: 'dev';
-$_SERVER['APP_DEBUG'] = $_SERVER['APP_DEBUG'] ?? $_ENV['APP_DEBUG'] ?? 'prod' !== $_SERVER['APP_ENV'];
+$_SERVER['APP_DEBUG'] = $_SERVER['APP_DEBUG'] ?? $_ENV['APP_DEBUG'] ?? 'dev' === $_SERVER['APP_ENV'];
 $_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = (int) $_SERVER['APP_DEBUG'] || filter_var($_SERVER['APP_DEBUG'], FILTER_VALIDATE_BOOLEAN) ? '1' : '0';

--- a/symfony/phpunit-bridge/3.3/.env.test
+++ b/symfony/phpunit-bridge/3.3/.env.test
@@ -1,4 +1,5 @@
 # define your env variables for the test env here
 KERNEL_CLASS='App\Kernel'
 APP_SECRET='s$cretf0rt3st'
+APP_DEBUG='true'
 SYMFONY_DEPRECATIONS_HELPER=999999

--- a/symfony/phpunit-bridge/4.1/.env.test
+++ b/symfony/phpunit-bridge/4.1/.env.test
@@ -1,4 +1,5 @@
 # define your env variables for the test env here
 KERNEL_CLASS='App\Kernel'
+APP_DEBUG='true'
 APP_SECRET='s$cretf0rt3st'
 SYMFONY_DEPRECATIONS_HELPER=999999


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Based on the [documentation](https://symfony.com/doc/current/configuration/environments.html#creating-a-new-environment) there should be not more be needed to create a `prod` similiar environment:

```yaml
imports:
    - { resource: '../prod/' }
```

but thats because of `APP_DEBUG` not true. With this change the new environment will match 100% to the prod env.

