### PR TITLE
explode trustedHosts to array

### DIFF
--- a/symfony/framework-bundle/4.2/public/index.php
+++ b/symfony/framework-bundle/4.2/public/index.php
@@ -17,7 +17,7 @@ if ($trustedProxies = $_SERVER['TRUSTED_PROXIES'] ?? $_ENV['TRUSTED_PROXIES'] ??
 }
 
 if ($trustedHosts = $_SERVER['TRUSTED_HOSTS'] ?? $_ENV['TRUSTED_HOSTS'] ?? false) {
-    Request::setTrustedHosts([$trustedHosts]);
+    Request::setTrustedHosts(explode(',', $trustedHosts));
 }
 
 $kernel = new Kernel($_SERVER['APP_ENV'], (bool) $_SERVER['APP_DEBUG']);


### PR DESCRIPTION
This fixes problem when multiple trusted hosts are separated by comma in .env file and not being matched in Symfony\Component\HttpFoundation\Request::getHost method, causing SuspiciousOperationException exception.

Found when upgrading to new .env 

https://symfony.com/doc/current/configuration/dot-env-changes.html
> Update your public/index.php (index.php diff) file to load the new config/bootstrap.php file.
>  If you've customized this file, make sure to keep those changes (but use the rest of the changes).


| Q             | A
| ------------- | ---
| License       | MIT

<!--
Please, carefully read the README before submitting a pull request.
-->