### PR TITLE
Check for the dev environment instead of prod

### DIFF
--- a/symfony/framework-bundle/4.2/config/bootstrap.php
+++ b/symfony/framework-bundle/4.2/config/bootstrap.php
@@ -17,5 +17,5 @@ if (is_array($env = @include dirname(__DIR__).'/.env.local.php')) {
 }
 
 $_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = ($_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? null) ?: 'dev';
-$_SERVER['APP_DEBUG'] = $_SERVER['APP_DEBUG'] ?? $_ENV['APP_DEBUG'] ?? 'dev' === $_SERVER['APP_ENV'];
+$_SERVER['APP_DEBUG'] = $_SERVER['APP_DEBUG'] ?? $_ENV['APP_DEBUG'] ?? 'dev' === $_SERVER['APP_ENV'] || 'test' === $_SERVER['APP_ENV'];
 $_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = (int) $_SERVER['APP_DEBUG'] || filter_var($_SERVER['APP_DEBUG'], FILTER_VALIDATE_BOOLEAN) ? '1' : '0';

--- a/symfony/framework-bundle/4.2/config/bootstrap.php
+++ b/symfony/framework-bundle/4.2/config/bootstrap.php
@@ -17,5 +17,5 @@ if (is_array($env = @include dirname(__DIR__).'/.env.local.php')) {
 }
 
 $_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = ($_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? null) ?: 'dev';
-$_SERVER['APP_DEBUG'] = $_SERVER['APP_DEBUG'] ?? $_ENV['APP_DEBUG'] ?? 'prod' !== $_SERVER['APP_ENV'];
+$_SERVER['APP_DEBUG'] = $_SERVER['APP_DEBUG'] ?? $_ENV['APP_DEBUG'] ?? 'dev' === $_SERVER['APP_ENV'];
 $_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = (int) $_SERVER['APP_DEBUG'] || filter_var($_SERVER['APP_DEBUG'], FILTER_VALIDATE_BOOLEAN) ? '1' : '0';


### PR DESCRIPTION
It feels dangerous that we're checking whether the environment !== 'prod'.

I think APP_DEBUG should only default to true if the environment is specifically "dev".

In a real example I have created a "staging" environment and it is showing debug information. I now need to specifically create a env var to stop this. Unless users are aware of this (or there is human error in creating this env var), the server could reveal too much information creating security issues.

| Q             | A
| ------------- | ---
| License       | MIT
