### PR TITLE
[cs-fixer] Configure properly the default finder

### DIFF
--- a/friendsofphp/php-cs-fixer/2.2/.php_cs.dist
+++ b/friendsofphp/php-cs-fixer/2.2/.php_cs.dist
@@ -1,8 +1,14 @@
 <?php
 
+$finder = PhpCsFixer\Finder::create()
+    ->in(__DIR__)
+    ->exclude('var')
+;
+
 return PhpCsFixer\Config::create()
     ->setRules([
         '@Symfony' => true,
         'array_syntax' => ['syntax' => 'short'],
     ])
+    ->setFinder($finder)
 ;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Provide a default Finder configuration matching the Flex directory structure. Then PHP-CS-Fixer can be called with `vendor/bin/php-cs-fixer fix` can be called directly.