### PR TITLE
[PHPUnit] Forces test envs overriding

### DIFF
--- a/phpunit/phpunit/4.7/phpunit.xml.dist
+++ b/phpunit/phpunit/4.7/phpunit.xml.dist
@@ -9,7 +9,7 @@
 >
     <php>
         <ini name="error_reporting" value="-1" />
-        <env name="APP_ENV" value="test" />
+        <env name="APP_ENV" value="test" force="true" />
         <env name="SHELL_VERBOSITY" value="-1" />
     </php>
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Type           | Fix

When I run this test:

```php
class EnvTest extends TestCase
{
    public function testEnv(): void
    {
        self::assertEquals('test', getenv('APP_ENV'));
    }
}
```

from docker-compose with specified `APP_ENV: dev` I see:

```php
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'test'
+'dev'
```

because PHPUnit does not override existing envs in non-forcing lazy mode and  `getenv('APP_ENV')` still returns `dev` instead of `test`.

In `force="true"` mode the test successfully passes.
