### PR TITLE
Add project path to app Kernel instanciation

### DIFF
--- a/symfony/console/3.3/bin/console
+++ b/symfony/console/3.3/bin/console
@@ -33,6 +33,6 @@ if ($_SERVER['APP_DEBUG']) {
     }
 }
 
-$kernel = new Kernel($_SERVER['APP_ENV'], (bool) $_SERVER['APP_DEBUG']);
+$kernel = new Kernel($_SERVER['APP_ENV'], (bool) $_SERVER['APP_DEBUG'], dirname(__DIR__));
 $application = new Application($kernel);
 $application->run($input);

--- a/symfony/framework-bundle/4.2/public/index.php
+++ b/symfony/framework-bundle/4.2/public/index.php
@@ -20,7 +20,7 @@ if ($trustedHosts = $_SERVER['TRUSTED_HOSTS'] ?? $_ENV['TRUSTED_HOSTS'] ?? false
     Request::setTrustedHosts([$trustedHosts]);
 }
 
-$kernel = new Kernel($_SERVER['APP_ENV'], (bool) $_SERVER['APP_DEBUG']);
+$kernel = new Kernel($_SERVER['APP_ENV'], (bool) $_SERVER['APP_DEBUG'], dirname(__DIR__));
 $request = Request::createFromGlobals();
 $response = $kernel->handle($request);
 $response->send();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Changed invocation of the Kernel according to the feature from symfony/symfony#30651.
This removes the need for a `composer.json` to define the project folder when using the framework bundle.
