### PR TITLE
Remove http&http-client aliases from php-http/httplug-pack

### DIFF
--- a/php-http/httplug-pack/1.0/manifest.json
+++ b/php-http/httplug-pack/1.0/manifest.json
@@ -1,3 +1,3 @@
 {
-    "aliases": ["http", "http-client", "httplug"]
+    "aliases": ["httplug"]
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

symfony/http-client will be the new default for `http-client` (and I don't think we need one for `http`)