### PR TITLE
[Encore] Make @babel/preset-env use polyfills by default

### DIFF
--- a/symfony/webpack-encore-bundle/1.0/package.json
+++ b/symfony/webpack-encore-bundle/1.0/package.json
@@ -1,6 +1,7 @@
 {
     "devDependencies": {
-        "@symfony/webpack-encore": "^0.22.0",
+        "@symfony/webpack-encore": "^0.26.0",
+        "core-js": "^3.0.0",
         "webpack-notifier": "^1.6.0"
     },
     "license": "UNLICENSED",

--- a/symfony/webpack-encore-bundle/1.0/webpack.config.js
+++ b/symfony/webpack-encore-bundle/1.0/webpack.config.js
@@ -53,6 +53,10 @@ Encore
     // uncomment if you use TypeScript
     //.enableTypeScriptLoader()
 
+    // uncomment to get integrity="..." attributes on your script & link tags
+    // requires WebpackEncoreBundle 1.4 or higher
+    //.enableIntegrityHashes()
+
     // uncomment if you're having problems with a jQuery plugin
     //.autoProvidejQuery()
 

--- a/symfony/webpack-encore-bundle/1.0/webpack.config.js
+++ b/symfony/webpack-encore-bundle/1.0/webpack.config.js
@@ -41,6 +41,12 @@ Encore
     // enables hashed filenames (e.g. app.abc123.css)
     .enableVersioning(Encore.isProduction())
 
+    // enables @babel/preset-env polyfills
+    .configureBabel(() => {}, {
+        useBuiltIns: 'usage',
+        corejs: 3
+    })
+
     // enables Sass/SCSS support
     //.enableSassLoader()
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

This PR is related to https://github.com/symfony/webpack-encore/pull/545 and must not be merged until a new version of Encore is released (0.26.x).

Quick summary: we will soon set the `useBuiltIns` option of `@babel/preset-env` to `false` instead of `entry` by default (which makes it not handle `core-js` polyfills anymore).

This is needed because the other values (`entry` and `usage`) require the users to at least add `core-js` to their projects and specify its version in `@babel/preset-env`'s settings.

With this update the recipe will automatically require `core-js@3` and configure `@babel/preset-env` so polyfills are automatically added when/where they are needed (`useBuiltIns: 'usage'` and `corejs: 3`).

/cc @weaverryan 