### PR TITLE
[webpack-encore-bundle] - update comments in default recipe for new features

### DIFF
--- a/symfony/webpack-encore-bundle/1.0/config/packages/webpack_encore.yaml
+++ b/symfony/webpack-encore-bundle/1.0/config/packages/webpack_encore.yaml
@@ -2,3 +2,12 @@ webpack_encore:
     # The path where Encore is building the assets.
     # This should match Encore.setOutputPath() in webpack.config.js.
     output_path: '%kernel.project_dir%/public/build'
+    # If multiple builds are defined (as shown below), you can disable the default build:
+    # output_path: false	    # output_path: false
+
+    # if using Encore.enableIntegrityHashes() specify the crossorigin attribute value (default: anonymous)
+    # crossorigin: 'use-credentials'
+    
+    # Cache the entrypoints.json (rebuild Symfony's cache when entrypoints.json changes)
+    # Available in version 1.2
+    #cache: '%kernel.debug%'

--- a/symfony/webpack-encore-bundle/1.0/config/packages/webpack_encore.yaml
+++ b/symfony/webpack-encore-bundle/1.0/config/packages/webpack_encore.yaml
@@ -5,8 +5,8 @@ webpack_encore:
     # If multiple builds are defined (as shown below), you can disable the default build:
     # output_path: false
 
-    # if using Encore.enableIntegrityHashes() specify the crossorigin attribute value (default: anonymous)
-    # crossorigin: 'use-credentials'
+    # if using Encore.enableIntegrityHashes() specify the crossorigin attribute value (default: false, or use 'anonymous' or 'use-credentials')
+    # crossorigin: 'anonymous'
     
     # Cache the entrypoints.json (rebuild Symfony's cache when entrypoints.json changes)
     # Available in version 1.2

--- a/symfony/webpack-encore-bundle/1.0/config/packages/webpack_encore.yaml
+++ b/symfony/webpack-encore-bundle/1.0/config/packages/webpack_encore.yaml
@@ -3,7 +3,7 @@ webpack_encore:
     # This should match Encore.setOutputPath() in webpack.config.js.
     output_path: '%kernel.project_dir%/public/build'
     # If multiple builds are defined (as shown below), you can disable the default build:
-    # output_path: false	    # output_path: false
+    # output_path: false
 
     # if using Encore.enableIntegrityHashes() specify the crossorigin attribute value (default: anonymous)
     # crossorigin: 'use-credentials'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

This PR makes two changes

1) update documentation for previous feature allowing output_path to be false

2) update documentation for new feature to set the value fo crossorigin attribute if PR https://github.com/symfony/webpack-encore-bundle/pull/56 is accepted
