### PR TITLE
Add project dir to framework bundle

### DIFF
--- a/symfony/framework-bundle/4.2/src/Kernel.php
+++ b/symfony/framework-bundle/4.2/src/Kernel.php
@@ -25,6 +25,11 @@ class Kernel extends BaseKernel
         }
     }
 
+    public function getProjectDir(): string
+    {
+        return \dirname(__DIR__);
+    }
+
     protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader): void
     {
         $container->addResource(new FileResource($this->getProjectDir().'/config/bundles.php'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

References #555 and symfony/symfony#30651

This defines the project directory without looking for the `composer.json`.