### PR TITLE
Move DoctrineCacheBundle from recipes-contrib to recipes

### DIFF
--- a/doctrine/doctrine-cache-bundle/1.3/config/packages/doctrine_cache.yaml
+++ b/doctrine/doctrine-cache-bundle/1.3/config/packages/doctrine_cache.yaml
@@ -1,0 +1,10 @@
+doctrine_cache:
+    aliases:
+        apc_cache: my_apc_cache
+
+    providers:
+        my_apc_cache:
+            type: apc
+            namespace: my_apc_cache_ns
+            aliases:
+                - apc_cache

--- a/doctrine/doctrine-cache-bundle/1.3/manifest.json
+++ b/doctrine/doctrine-cache-bundle/1.3/manifest.json
@@ -1,0 +1,8 @@
+{
+    "bundles": {
+        "Doctrine\\Bundle\\DoctrineCacheBundle\\DoctrineCacheBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

I think this makes sense since DoctrineCacheBundle is part of the orm-pack.
FYI @xabbuh 

#eu-fossa

See contrib PR: https://github.com/symfony/recipes-contrib/pull/652