### PR TITLE
[Webpack encore] Enable cache only in prod

### DIFF
--- a/symfony/webpack-encore-bundle/1.0/config/packages/prod/webpack_encore.yaml
+++ b/symfony/webpack-encore-bundle/1.0/config/packages/prod/webpack_encore.yaml
@@ -1,0 +1,4 @@
+webpack_encore:
+    # Cache the entrypoints.json (rebuild Symfony's cache when entrypoints.json changes)
+    # Available in version 1.2
+    #cache: true

--- a/symfony/webpack-encore-bundle/1.0/config/packages/prod/webpack_encore.yaml
+++ b/symfony/webpack-encore-bundle/1.0/config/packages/prod/webpack_encore.yaml
@@ -1,4 +1,4 @@
-webpack_encore:
+#webpack_encore:
     # Cache the entrypoints.json (rebuild Symfony's cache when entrypoints.json changes)
     # Available in version 1.2
     #cache: true

--- a/symfony/webpack-encore-bundle/1.0/config/packages/webpack_encore.yaml
+++ b/symfony/webpack-encore-bundle/1.0/config/packages/webpack_encore.yaml
@@ -2,7 +2,3 @@ webpack_encore:
     # The path where Encore is building the assets.
     # This should match Encore.setOutputPath() in webpack.config.js.
     output_path: '%kernel.project_dir%/public/build'
-
-    # Cache the entrypoints.json (rebuild Symfony's cache when entrypoints.json changes)
-    # Available in version 1.2
-    #cache: '%kernel.debug%'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

We made a mistake in #541 

We should only enable cache when `%kernel.debug%` is NOT true. 

#eu-fossa