### PR TITLE
Add a CLI guard to the bin/console

### DIFF
--- a/symfony/console/3.3/bin/console
+++ b/symfony/console/3.3/bin/console
@@ -1,8 +1,6 @@
 #!/usr/bin/env php
 <?php
 
-namespace Bin;
-
 use App\Kernel;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;

--- a/symfony/console/3.3/bin/console
+++ b/symfony/console/3.3/bin/console
@@ -1,10 +1,16 @@
 #!/usr/bin/env php
 <?php
 
+namespace Bin;
+
 use App\Kernel;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Debug\Debug;
+
+if (false === in_array(\PHP_SAPI, ['cli', 'phpdbg', 'embed'], true)) {
+    echo 'Warning: The console should be invoked via the CLI version of PHP, not the '.\PHP_SAPI.' SAPI'.\PHP_EOL;
+}
 
 set_time_limit(0);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Add a CLI guard in `bin/console`. This file is not meant to be executed in another context than CLI, as such it may be a good idea to bail out early when it's not the case. I don't think it's a necessity, but it can be seen as an inexpensive additional guard like done in most CLI applications including Composer.