### PR TITLE
Bumping Encore deps for 0.27.0

### DIFF
--- a/symfony/webpack-encore-bundle/1.0/package.json
+++ b/symfony/webpack-encore-bundle/1.0/package.json
@@ -1,6 +1,6 @@
 {
     "devDependencies": {
-        "@symfony/webpack-encore": "^0.26.0",
+        "@symfony/webpack-encore": "^0.27.0",
         "core-js": "^3.0.0",
         "webpack-notifier": "^1.6.0"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Btw, we *are* looking at a proper, stable of Encore (which would allow us to avoid needing to do this) when Webpack 5 is released.

Cheers!