### PR TITLE
Add "jwt" alias for lexik/jwt-authentication-bundle

### DIFF
--- a/lexik/jwt-authentication-bundle/2.3/manifest.json
+++ b/lexik/jwt-authentication-bundle/2.3/manifest.json
@@ -5,7 +5,7 @@
     "copy-from-recipe": {
         "config/": "%CONFIG_DIR%"
     },
-    "aliases": ["jwt-auth"],
+    "aliases": ["jwt", "jwt-auth"],
     "env": {
         "#1": "Key paths should be relative to the project directory",
         "JWT_PRIVATE_KEY_PATH": "%CONFIG_DIR%/jwt/private.pem",

--- a/lexik/jwt-authentication-bundle/2.5/manifest.json
+++ b/lexik/jwt-authentication-bundle/2.5/manifest.json
@@ -5,7 +5,7 @@
     "copy-from-recipe": {
         "config/": "%CONFIG_DIR%"
     },
-    "aliases": ["jwt-auth"],
+    "aliases": ["jwt", "jwt-auth"],
     "env": {
         "JWT_SECRET_KEY": "%kernel.project_dir%/%CONFIG_DIR%/jwt/private.pem",
         "JWT_PUBLIC_KEY": "%kernel.project_dir%/%CONFIG_DIR%/jwt/public.pem",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

As it's the de-facto bundle for JWT authentication.