### PR TITLE
[FrameworkBundle] Load packages configuration after services configuration

### DIFF
--- a/symfony/framework-bundle/4.2/src/Kernel.php
+++ b/symfony/framework-bundle/4.2/src/Kernel.php
@@ -36,10 +36,10 @@ class Kernel extends BaseKernel
         $container->setParameter('container.dumper.inline_class_loader', true);
         $confDir = $this->getProjectDir().'/config';
 
-        $loader->load($confDir.'/{packages}/*'.self::CONFIG_EXTS, 'glob');
-        $loader->load($confDir.'/{packages}/'.$this->environment.'/**/*'.self::CONFIG_EXTS, 'glob');
         $loader->load($confDir.'/{services}'.self::CONFIG_EXTS, 'glob');
         $loader->load($confDir.'/{services}_'.$this->environment.self::CONFIG_EXTS, 'glob');
+        $loader->load($confDir.'/{packages}/*'.self::CONFIG_EXTS, 'glob');
+        $loader->load($confDir.'/{packages}/'.$this->environment.'/**/*'.self::CONFIG_EXTS, 'glob');
     }
 
     protected function configureRoutes(RouteCollectionBuilder $routes): void


### PR DESCRIPTION
Some people tends to declare some services in `/config/package/foobar.yaml`.
More over, some recipies does that [too](https://github.com/symfony/recipes/tree/master/sensiolabs/security-checker/4.0/config/packages)

But with the default configuration, services are overriden in
`services.yaml` (auto-discovery) and so the services does not work.

This patch made the packages directory prioritary overy the services
files


| Q             | A
| ------------- | ---
| License       | MIT

---

I found this "issue" by helping someone on slack.