### PR TITLE
Remove default database URL as it already defined in .env

### DIFF
--- a/doctrine/doctrine-bundle/1.6/config/packages/doctrine.yaml
+++ b/doctrine/doctrine-bundle/1.6/config/packages/doctrine.yaml
@@ -1,10 +1,3 @@
-parameters:
-    # Adds a fallback DATABASE_URL if the env var is not set.
-    # This allows you to run cache:warmup even if your
-    # environment variables are not available yet.
-    # You should not need to change this value.
-    env(DATABASE_URL): ''
-
 doctrine:
     dbal:
         # configure these for your database server


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Following this [discussion](https://github.com/symfony/symfony/issues/31497#issuecomment-492616894) I removed the default database URL in parameters section because a default value is already defined in the `.env`