### PR TITLE
Simplifying links to authentication in security.yaml

### DIFF
--- a/symfony/security-bundle/3.3/config/packages/security.yaml
+++ b/symfony/security-bundle/3.3/config/packages/security.yaml
@@ -10,12 +10,10 @@ security:
             anonymous: true
 
             # activate different ways to authenticate
+            # https://symfony.com/doc/current/security.html#firewalls-authentication
 
-            # http_basic: true
-            # https://symfony.com/doc/current/security.html#a-configuring-how-your-users-will-authenticate
-
-            # form_login: true
-            # https://symfony.com/doc/current/security/form_login_setup.html
+            # https://symfony.com/doc/current/security/impersonating_user.html
+            # switch_user: true
 
     # Easy way to control access for large sections of your site
     # Note: Only the *first* access control that matches will be used


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

I think it's better to link to the authentication system, than give a few examples here. form_login is especially not useful, as we recommend using Guard instead of this and *simply* uncommenting this is not nearly enough to get it working anyways.

Cheers!
