### PR TITLE
[WebpackEncoreBundle] Don't use kernel.debug for the cache parameter

### DIFF
--- a/symfony/webpack-encore-bundle/1.0/config/packages/webpack_encore.yaml
+++ b/symfony/webpack-encore-bundle/1.0/config/packages/webpack_encore.yaml
@@ -10,4 +10,4 @@ webpack_encore:
     
     # Cache the entrypoints.json (rebuild Symfony's cache when entrypoints.json changes)
     # Available in version 1.2
-    #cache: '%kernel.debug%'
+    #cache: 'false'

--- a/symfony/webpack-encore-bundle/1.0/config/packages/webpack_encore.yaml
+++ b/symfony/webpack-encore-bundle/1.0/config/packages/webpack_encore.yaml
@@ -8,6 +8,7 @@ webpack_encore:
     # if using Encore.enableIntegrityHashes() specify the crossorigin attribute value (default: false, or use 'anonymous' or 'use-credentials')
     # crossorigin: 'anonymous'
     
-    # Cache the entrypoints.json (rebuild Symfony's cache when entrypoints.json changes)
+    # Cache the entrypoints.json (rebuild Symfony's cache when entrypoints.json changes).
+    # To enable caching for the production environment, creating a webpack_encore.yaml in the config/packages/prod directory with this value set to true
     # Available in version 1.2
     #cache: 'false'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

When using the `%kernel.debug%` value for the `cache` parameter means the entrypoints will be cached when debug is true, where actually it should be the reverse. This currently causes issues in development mode, especially when using integrity hashes, since the integrity hash is cached with the entrypoints and it won't match the content of the assets if they changed. So I think this value should by default be set to `false`, where the developer can then decide if they want to enable it in production (an alternative option is to create another config file in the `prod` folder where this value defaults to `true`)