### PR TITLE
Encore: configure runtime environment if not already configured

### DIFF
--- a/symfony/webpack-encore-bundle/1.0/webpack.config.js
+++ b/symfony/webpack-encore-bundle/1.0/webpack.config.js
@@ -1,5 +1,9 @@
 var Encore = require('@symfony/webpack-encore');
 
+if (!Encore.isRuntimeEnvironmentConfigured()) {
+    Encore.configureRuntimeEnvironment(process.env.NODE_ENV || 'dev');
+}
+
 Encore
     // directory where compiled assets will be stored
     .setOutputPath('public/build/')

--- a/symfony/webpack-encore-bundle/1.0/webpack.config.js
+++ b/symfony/webpack-encore-bundle/1.0/webpack.config.js
@@ -1,5 +1,7 @@
 var Encore = require('@symfony/webpack-encore');
 
+// Manually configure the runtime environment if not already configured yet by the "encore" command.
+// It's useful when you use tools that rely on webpack.config.js file.
 if (!Encore.isRuntimeEnvironmentConfigured()) {
     Encore.configureRuntimeEnvironment(process.env.NODE_ENV || 'dev');
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

With this, we directly fix the error: 
> Encore.setOutputPath() cannot be called yet because the runtime environment
doesn't appear to be configured. Make sure you're using the encore executable
or call Encore.configureRuntimeEnvironment() first if you're purposely not
calling Encore directly.

when using Encore/Webpack without the `encore` command (`npm run encore ...`).

This is useful when:
- using tools that depends of `webpack.config.js`, like ESLint with the import plugin, Karma, ...
- using an IDE with Webpack integration

This doesn't break anything if you use `encore` command, since it already configure the runtime environment.

See:
- https://symfony.com/doc/current/frontend/encore/faq.html#how-do-i-integrate-my-encore-configuration-with-my-ide
- https://github.com/symfony/webpack-encore/pull/500
- https://github.com/symfony/webpack-encore/pull/115

What do you think about it?
Thanks :)