### PR TITLE
Use API scheme instead of SMTP by default for SendGrid

### DIFF
--- a/symfony/sendgrid-mailer/4.3/manifest.json
+++ b/symfony/sendgrid-mailer/4.3/manifest.json
@@ -1,5 +1,5 @@
 {
     "env": {
-        "#1": "MAILER_DSN=smtp://$SENDGRID_KEY@sendgrid"
+        "#1": "MAILER_DSN=api://$SENDGRID_KEY@sendgrid"
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

SendGrid recommends using API instead of SMTP:

<img width="940" alt="Screen Shot 2019-05-27 at 18 52 28" src="https://user-images.githubusercontent.com/3317635/58430191-07352180-80b1-11e9-871c-aeea1f242d9a.png">

Probably it makes sense to tweak this recipe?