### PR TITLE
RFC: explicitly adding mailer env vars

### DIFF
--- a/symfony/amazon-mailer/4.3/manifest.json
+++ b/symfony/amazon-mailer/4.3/manifest.json
@@ -1,6 +1,8 @@
 {
     "env": {
-        "#1": "MAILER_DSN=smtp://$AWS_ACCESS_KEY:$AWS_SECRET_KEY@ses",
-        "#2": "MAILER_DSN=http://$AWS_ACCESS_KEY:$AWS_SECRET_KEY@ses"
+        "#1": "AWS_ACCESS_KEY=",
+        "#2": "AWS_SECRET_KEY=",
+        "#3": "MAILER_DSN=smtp://$AWS_ACCESS_KEY:$AWS_SECRET_KEY@ses",
+        "#4": "MAILER_DSN=http://$AWS_ACCESS_KEY:$AWS_SECRET_KEY@ses"
     }
 }

--- a/symfony/mailchimp-mailer/4.3/manifest.json
+++ b/symfony/mailchimp-mailer/4.3/manifest.json
@@ -1,6 +1,9 @@
 {
     "env": {
-        "#1": "MAILER_DSN=smtp://$MANDRILL_USERNAME:$MANDRILL_PASSWORD@mandrill",
-        "#2": "MAILER_DSN=http://$MANDRILL_KEY@mandrill"
+        "#1": "MANDRILL_USERNAME=",
+        "#2": "MANDRILL_PASSWORD=",
+        "#3": "MAILER_DSN=smtp://$MANDRILL_USERNAME:$MANDRILL_PASSWORD@mandrill",
+        "#4": "MANDRILL_KEY=",
+        "#5": "MAILER_DSN=http://$MANDRILL_KEY@mandrill"
     }
 }

--- a/symfony/mailgun-mailer/4.3/manifest.json
+++ b/symfony/mailgun-mailer/4.3/manifest.json
@@ -1,6 +1,10 @@
 {
     "env": {
-        "#1": "MAILER_DSN=smtp://$MAILGUN_USERNAME:$MAILGUN_PASSWORD@mailgun",
-        "#2": "MAILER_DSN=http://$MAILGUN_KEY:$MAILGUN_DOMAIN@mailgun"
+        "#1": "MAILGUN_USERNAME=",
+        "#2": "MAILGUN_PASSWORD=",
+        "#3": "MAILER_DSN=smtp://$MAILGUN_USERNAME:$MAILGUN_PASSWORD@mailgun",
+        "#4": "MAILGUN_KEY=",
+        "#5": "MAILGUN_DOMAIN=",
+        "#6": "MAILER_DSN=http://$MAILGUN_KEY:$MAILGUN_DOMAIN@mailgun"
     }
 }

--- a/symfony/postmark-mailer/4.3/manifest.json
+++ b/symfony/postmark-mailer/4.3/manifest.json
@@ -1,5 +1,6 @@
 {
     "env": {
-        "#1": "MAILER_DSN=smtp://$POSTMARK_ID@postmark"
+        "#1": "POSTMARK_ID=",
+        "#2": "MAILER_DSN=smtp://$POSTMARK_ID@postmark"
     }
 }

--- a/symfony/sendgrid-mailer/4.3/manifest.json
+++ b/symfony/sendgrid-mailer/4.3/manifest.json
@@ -1,5 +1,6 @@
 {
     "env": {
-        "#1": "MAILER_DSN=smtp://$SENDGRID_KEY@sendgrid"
+        "#1": "SENDGRID_KEY=",
+        "#2": "MAILER_DSN=smtp://$SENDGRID_KEY@sendgrid"
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

It's cool how all the mailers embed other environment variables inside of them. But actually, I got confused by this - I didn't think about how I could define `SENDGRID_KEY` as its own env var, and then leave `MAILER_DSN` alone. Why not also add the `SENDGRID_KEY` as an env var? If we agree, I'll do the same for all the mailer configs.