### PR TITLE
Fix disabling not_compromised_password validation

### DIFF
--- a/symfony/validator/4.1/config/packages/test/validator.yaml
+++ b/symfony/validator/4.1/config/packages/test/validator.yaml
@@ -1,4 +1,4 @@
 framework:
     validation:
         # As of Symfony 4.3 you can disable the NotCompromisedPassword Validator
-        # disable_not_compromised_password: true
+        # not_compromised_password: false


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

See https://github.com/symfony/symfony/issues/31756