### PR TITLE
RFC Create a recipe for Google mailer transport

### DIFF
--- a/symfony/google-mailer/4.3/manifest.json
+++ b/symfony/google-mailer/4.3/manifest.json
@@ -1,0 +1,8 @@
+{
+    "env": {
+        "#1": "Gmail SHOULD NOT be used on production, use it in development only.",
+        "#2": "GMAIL_USERNAME=",
+        "#3": "GMAIL_PASSWORD=",
+        "#4": "MAILER_DSN=smtp://$GMAIL_USERNAME:$GMAIL_PASSWORD@google"
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

It wasn't added in #587 but I think this is a missing piece. If it's not recommended to use Gmail on production, let's add a note about it because not having a recipe for this does not mean devs won't use it on production.
