### PR TITLE
Fixing validator option name - not_compromised_password

### DIFF
--- a/symfony/validator/4.3/config/packages/test/validator.yaml
+++ b/symfony/validator/4.3/config/packages/test/validator.yaml
@@ -1,3 +1,3 @@
 framework:
     validation:
-        disable_not_compromised_password: true
+        not_compromised_password: false


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

This was renamed https://github.com/symfony/symfony/commit/ecfccc6ef011b20390a9ae9a70d5c7e8e2ddf83e#diff-5e7347edce37c5886ec67b7ba02f3a9c

Caught by the MakerBundle test suite
