### PR TITLE
MonologBundle: use excluded_http_codes

### DIFF
--- a/symfony/monolog-bundle/3.3/config/packages/dev/monolog.yaml
+++ b/symfony/monolog-bundle/3.3/config/packages/dev/monolog.yaml
@@ -1,0 +1,19 @@
+monolog:
+    handlers:
+        main:
+            type: stream
+            path: "%kernel.logs_dir%/%kernel.environment%.log"
+            level: debug
+            channels: ["!event"]
+        # uncomment to get logging in your browser
+        # you may have to allow bigger header sizes in your Web server configuration
+        #firephp:
+        #    type: firephp
+        #    level: info
+        #chromephp:
+        #    type: chromephp
+        #    level: info
+        console:
+            type: console
+            process_psr_3_messages: false
+            channels: ["!event", "!doctrine", "!console"]

--- a/symfony/monolog-bundle/3.3/config/packages/prod/monolog.yaml
+++ b/symfony/monolog-bundle/3.3/config/packages/prod/monolog.yaml
@@ -1,0 +1,25 @@
+monolog:
+    handlers:
+        main:
+            type: fingers_crossed
+            action_level: error
+            handler: nested
+            excluded_404s:
+                # regex: exclude all 404 errors from the logs
+                - ^/
+        nested:
+            type: stream
+            path: "%kernel.logs_dir%/%kernel.environment%.log"
+            level: debug
+        console:
+            type: console
+            process_psr_3_messages: false
+            channels: ["!event", "!doctrine"]
+        deprecation:
+            type: stream
+            path: "%kernel.logs_dir%/%kernel.environment%.deprecations.log"
+        deprecation_filter:
+            type: filter
+            handler: deprecation
+            max_level: info
+            channels: ["php"]

--- a/symfony/monolog-bundle/3.3/config/packages/prod/monolog.yaml
+++ b/symfony/monolog-bundle/3.3/config/packages/prod/monolog.yaml
@@ -4,9 +4,7 @@ monolog:
             type: fingers_crossed
             action_level: error
             handler: nested
-            excluded_404s:
-                # regex: exclude all 404 errors from the logs
-                - ^/
+            excluded_http_codes: [404, 405]
         nested:
             type: stream
             path: "%kernel.logs_dir%/%kernel.environment%.log"

--- a/symfony/monolog-bundle/3.3/config/packages/test/monolog.yaml
+++ b/symfony/monolog-bundle/3.3/config/packages/test/monolog.yaml
@@ -1,0 +1,7 @@
+monolog:
+    handlers:
+        main:
+            type: stream
+            path: "%kernel.logs_dir%/%kernel.environment%.log"
+            level: debug
+            channels: ["!event"]

--- a/symfony/monolog-bundle/3.3/manifest.json
+++ b/symfony/monolog-bundle/3.3/manifest.json
@@ -1,0 +1,9 @@
+{
+    "bundles": {
+        "Symfony\\Bundle\\MonologBundle\\MonologBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "aliases": ["log", "logger", "logging", "logs", "monolog"]
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

This uses `excluded_http_codes` instead of `excluded_404s`, which is more flexible (and `excluded_404s` is deprecated in the next, unreleased version of MonologBundle).