### PR TITLE
[symfony/google-mailer] Fix gmail DSN host code key.

### DIFF
--- a/symfony/google-mailer/4.3/manifest.json
+++ b/symfony/google-mailer/4.3/manifest.json
@@ -3,6 +3,6 @@
         "#1": "Gmail SHOULD NOT be used on production, use it in development only.",
         "#2": "GMAIL_USERNAME=",
         "#3": "GMAIL_PASSWORD=",
-        "#4": "MAILER_DSN=smtp://$GMAIL_USERNAME:$GMAIL_PASSWORD@google"
+        "#4": "MAILER_DSN=smtp://$GMAIL_USERNAME:$GMAIL_PASSWORD@gmail"
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Fixed `MAILER_DSN` value for google-mailer. I changed `google` DSN host code key by `gmail` as specified in `Symfony\Component\Mailer\Transport` class.