### PR TITLE
Moving the AMQP exchange from env var to config

### DIFF
--- a/symfony/messenger/4.3/config/packages/messenger.yaml
+++ b/symfony/messenger/4.3/config/packages/messenger.yaml
@@ -5,7 +5,7 @@ framework:
 
         transports:
             # https://symfony.com/doc/current/messenger.html#transports
-            # async: '%env(MESSENGER_TRANSPORT_DSN)%'
+            # async: '%env(MESSENGER_TRANSPORT_DSN)%/messages_exchange'
             # failed: 'doctrine://default?queue_name=failed'
             # sync: 'sync://'
 

--- a/symfony/messenger/4.3/manifest.json
+++ b/symfony/messenger/4.3/manifest.json
@@ -4,7 +4,7 @@
     },
     "env": {
         "#1": "Choose one of the transports below",
-        "#2": "MESSENGER_TRANSPORT_DSN=amqp://guest:guest@localhost:5672/%2f/messages",
+        "#2": "MESSENGER_TRANSPORT_DSN=amqp://guest:guest@localhost:5672/%2f",
         "#3": "MESSENGER_TRANSPORT_DSN=doctrine://default",
         "#4": "MESSENGER_TRANSPORT_DSN=redis://localhost:6379/messages"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

This should make it easier (more obvious how) to specify multiple transports using the same
AMQP connection config, but with different exchanges. Using a different exchange for each transport is the "main" way of supporting multiple transports (you can also use 1 exchange with multiple queues, but then it's up to you to change the exchange type to direct and manage binding and routing keys).

Docs issue: https://github.com/symfony/symfony-docs/issues/11713

From Twitter convo: https://twitter.com/webdevilopers/status/1136177625406332928?s=21

Cheers!
