### PR TITLE
[symfony/translation] Remove confusing commented value

### DIFF
--- a/symfony/framework-bundle/3.3/config/packages/framework.yaml
+++ b/symfony/framework-bundle/3.3/config/packages/framework.yaml
@@ -1,6 +1,5 @@
 framework:
     secret: '%env(APP_SECRET)%'
-    #default_locale: en
     #csrf_protection: true
     #http_method_override: true
 

--- a/symfony/framework-bundle/4.2/config/packages/framework.yaml
+++ b/symfony/framework-bundle/4.2/config/packages/framework.yaml
@@ -1,6 +1,5 @@
 framework:
     secret: '%env(APP_SECRET)%'
-    #default_locale: en
     #csrf_protection: true
     #http_method_override: true
 

--- a/symfony/translation/3.3/config/packages/translation.yaml
+++ b/symfony/translation/3.3/config/packages/translation.yaml
@@ -1,6 +1,6 @@
 framework:
-    default_locale: '%locale%'
+    default_locale: en
     translator:
         default_path: '%kernel.project_dir%/translations'
         fallbacks:
-            - '%locale%'
+            - en

--- a/symfony/translation/3.3/manifest.json
+++ b/symfony/translation/3.3/manifest.json
@@ -3,8 +3,5 @@
         "config/": "%CONFIG_DIR%/",
         "translations/": "translations/"
     },
-    "container": {
-        "locale": "en"
-    },
     "aliases": ["translator", "translations"]
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | n/a

`default_locale` shouldn't be set both in `framework.yaml` and in translation. And the parameter is useless.