### PR TITLE
Enable integrity hashes on production only by default

### DIFF
--- a/symfony/webpack-encore-bundle/1.0/webpack.config.js
+++ b/symfony/webpack-encore-bundle/1.0/webpack.config.js
@@ -61,7 +61,7 @@ Encore
 
     // uncomment to get integrity="..." attributes on your script & link tags
     // requires WebpackEncoreBundle 1.4 or higher
-    //.enableIntegrityHashes()
+    //.enableIntegrityHashes(Encore.isProduction())
 
     // uncomment if you're having problems with a jQuery plugin
     //.autoProvidejQuery()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

We do the same for `enableVersioning()`
