### PR TITLE
Add built-in support for symfony/requirements-checker

### DIFF
--- a/symfony/framework-bundle/4.2/config/bootstrap.php
+++ b/symfony/framework-bundle/4.2/config/bootstrap.php
@@ -7,7 +7,7 @@ require dirname(__DIR__).'/vendor/autoload.php';
 
 // Verify Symfony requirements
 if (class_exists(SymfonyRequirements::class)) {
-    $argv = [];
+    $argv = ['-v'];
     echo (isset($_SERVER['HTTP_HOST']) ? '<pre>' : '')."REMOVE THIS MESSAGE: composer remove symfony/requirements-checker\n\n";
     require dirname(__DIR__).'/vendor/symfony/requirements-checker/bin/requirements-checker.php';
     die(1);

--- a/symfony/framework-bundle/4.2/config/bootstrap.php
+++ b/symfony/framework-bundle/4.2/config/bootstrap.php
@@ -1,16 +1,14 @@
 <?php
 
 use Symfony\Component\Dotenv\Dotenv;
-use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Requirements\SymfonyRequirements;
 
 require dirname(__DIR__).'/vendor/autoload.php';
 
 // Verify Symfony requirements
 if (class_exists(SymfonyRequirements::class)) {
-    $requirements = new SymfonyRequirements(dirname(__DIR__), Kernel::VERSION);
     $argv = [];
-    echo "<pre>REMOVE THIS MESSAGE: composer remove symfony/requirements-checker\n\n";
+    echo (isset($_SERVER['HTTP_HOST']) ? '<pre>' : '')."REMOVE THIS MESSAGE: composer remove symfony/requirements-checker\n\n";
     require dirname(__DIR__).'/vendor/symfony/requirements-checker/bin/requirements-checker.php';
     die(1);
 }

--- a/symfony/framework-bundle/4.2/config/bootstrap.php
+++ b/symfony/framework-bundle/4.2/config/bootstrap.php
@@ -1,8 +1,19 @@
 <?php
 
 use Symfony\Component\Dotenv\Dotenv;
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Requirements\SymfonyRequirements;
 
 require dirname(__DIR__).'/vendor/autoload.php';
+
+// Verify Symfony requirements
+if (class_exists(SymfonyRequirements::class)) {
+    $requirements = new SymfonyRequirements(dirname(__DIR__), Kernel::VERSION);
+    $argv = [];
+    echo "<pre>REMOVE THIS MESSAGE: composer remove symfony/requirements-checker\n\n";
+    require dirname(__DIR__).'/vendor/symfony/requirements-checker/bin/requirements-checker.php';
+    die(1);
+}
 
 // Load cached env vars if the .env.local.php file exists
 // Run "composer dump-env prod" to create it (requires symfony/flex >=1.2)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | symfony/symfony-docs#...    (https://symfony.com/doc/current/reference/requirements.html)

This is an alternative approach for https://github.com/symfony/requirements-checker/pull/35 at the recipe level.

:+1:  It works for everybody
:+1:  It enforces requirements checking
:+1:  It's boilerplate, ditch it if not needed
:man_shrugging: It's boilerplate
:man_shrugging:  we could remove the template upstream to reduce maintenance, plain text is nice actually IMHO
:+1:  CLI/WEB support out-of-the-box, no upstream changes needed other than polishing maybe
:+1: Out-of-the-box workflow by leveraging `composer require/remove req-check`

![image](https://user-images.githubusercontent.com/1047696/60127988-e3d5c300-9791-11e9-8fc6-d0280f74472b.png)

![image](https://user-images.githubusercontent.com/1047696/60128159-47f88700-9792-11e9-84a3-2acd4321ef9e.png)
