### PR TITLE
[symfony/phpunit-bridge] Break on v3.3 (phpunit branch 6.5 was deleted)

### DIFF
--- a/symfony/phpunit-bridge/3.3/bin/phpunit
+++ b/symfony/phpunit-bridge/3.3/bin/phpunit
@@ -7,7 +7,7 @@ if (!file_exists(dirname(__DIR__).'/vendor/symfony/phpunit-bridge/bin/simple-php
 }
 
 if (false === getenv('SYMFONY_PHPUNIT_VERSION')) {
-    putenv('SYMFONY_PHPUNIT_VERSION=6.5');
+    putenv('SYMFONY_PHPUNIT_VERSION=6.5.14');
 }
 if (false === getenv('SYMFONY_PHPUNIT_REMOVE')) {
     putenv('SYMFONY_PHPUNIT_REMOVE=symfony/yaml');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | none   

Branch `6.5` was deleted from [phpunit repository](https://github.com/sebastianbergmann/phpunit)


> PHP Fatal error:  Uncaught RuntimeException: Could not find https://github.com/sebastianbergmann/phpunit/archive/6.5.zip in /var/www/gatly/vendor/symfony/phpunit-bridge/bin/simple-phpunit:100


We need to use last minor`6.5.X` tag.