### PR TITLE
Proper APP_SECRET default value

### DIFF
--- a/phpunit/phpunit/4.7/.env.test
+++ b/phpunit/phpunit/4.7/.env.test
@@ -1,4 +1,4 @@
 # define your env variables for the test env here
 KERNEL_CLASS='App\Kernel'
-APP_SECRET='s$cretf0rt3st'
+APP_SECRET='$ecretf0rt3st'
 SYMFONY_DEPRECATIONS_HELPER=999999

--- a/symfony/phpunit-bridge/3.3/.env.test
+++ b/symfony/phpunit-bridge/3.3/.env.test
@@ -1,4 +1,4 @@
 # define your env variables for the test env here
 KERNEL_CLASS='App\Kernel'
-APP_SECRET='s$cretf0rt3st'
+APP_SECRET='$ecretf0rt3st'
 SYMFONY_DEPRECATIONS_HELPER=999999

--- a/symfony/phpunit-bridge/4.1/.env.test
+++ b/symfony/phpunit-bridge/4.1/.env.test
@@ -1,4 +1,4 @@
 # define your env variables for the test env here
 KERNEL_CLASS='App\Kernel'
-APP_SECRET='s$cretf0rt3st'
+APP_SECRET='$ecretf0rt3st'
 SYMFONY_DEPRECATIONS_HELPER=999999


### PR DESCRIPTION
Since dollar sign "represents" S letter, `s$cretf0rt3st` does not make sense.

It drives me mad every time we start new project and I see it on code review :joy: 

| Q             | A
| ------------- | ---
| License       | MIT 
