### PR TITLE
Add "swiftmailer" alias for symfony/swiftmailer-bundle

### DIFF
--- a/symfony/swiftmailer-bundle/2.5/manifest.json
+++ b/symfony/swiftmailer-bundle/2.5/manifest.json
@@ -11,5 +11,5 @@
         "#3": "Delivery is disabled by default via \"null://localhost\"",
         "MAILER_URL": "null://localhost"
     },
-    "aliases": ["mailer", "mail"]
+    "aliases": ["mailer", "mail", "swiftmailer"]
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | N/A

I think it makes sense. When a user of the Symfony framework asks for Swiftmailer, they most likely want the bundle too.