### PR TITLE
[Encore] Add regenerator-runtime to default dependencies

### DIFF
--- a/symfony/webpack-encore-bundle/1.0/package.json
+++ b/symfony/webpack-encore-bundle/1.0/package.json
@@ -2,6 +2,7 @@
     "devDependencies": {
         "@symfony/webpack-encore": "^0.27.0",
         "core-js": "^3.0.0",
+        "regenerator-runtime": "^0.13.2",
         "webpack-notifier": "^1.6.0"
     },
     "license": "UNLICENSED",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | N/A

This PR adds `regenerator-runtime` to the npm dependencies installed by the Webpack Encore Bundle.

The reason behind this change is that `@babel/preset-env` detects `async` functions usage and compile them in a way that they can't be used if you don't also import the `regenerator-runtime`.

With the current default Babel settings (`useBuiltIns: 'usage'`), `@babel/preset-env` will automatically add this import to the entries requiring it, but unless you already have `regenerator-runtime` in your dependencies you'll get an error message asking you to `npm install regenerator-runtime/runtime` (which is wrong, but that's another story).

I can't see any downside adding it by default since the worst case is that it won't be needed and users will only have a small (40KB I think) extraneous dependency in their `node_modules` folder.
