### PR TITLE
Use boolean instead of string.

### DIFF
--- a/symfony/webpack-encore-bundle/1.0/config/packages/webpack_encore.yaml
+++ b/symfony/webpack-encore-bundle/1.0/config/packages/webpack_encore.yaml
@@ -11,4 +11,4 @@ webpack_encore:
     # Cache the entrypoints.json (rebuild Symfony's cache when entrypoints.json changes).
     # To enable caching for the production environment, creating a webpack_encore.yaml in the config/packages/prod directory with this value set to true
     # Available in version 1.2
-    #cache: 'false'
+    #cache: false


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Otherwise I get:
```
  Invalid type for path "webpack_encore.cache". Expected boolean, but got string.
  Hint: Enable caching of the entry point file(s)
```

In the `prod` file, everything is correct.

cc @weaverryan 