### PR TITLE
bumping to php 7.5 to stay on supported version

### DIFF
--- a/symfony/phpunit-bridge/4.1/phpunit.xml.dist
+++ b/symfony/phpunit-bridge/4.1/phpunit.xml.dist
@@ -12,7 +12,7 @@
         <server name="APP_ENV" value="test" force="true" />
         <server name="SHELL_VERBOSITY" value="-1" />
         <server name="SYMFONY_PHPUNIT_REMOVE" value="" />
-        <server name="SYMFONY_PHPUNIT_VERSION" value="6.5" />
+        <server name="SYMFONY_PHPUNIT_VERSION" value="7.5" />
     </php>
 
     <testsuites>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | none should be needed   

6.5 if EOL since February. Is the philosophy that we stay on the oldest-supported... or stay on the newest (and I should bump to 8.2?)
