### PR TITLE
Bumping Encore version to 0.28.0

### DIFF
--- a/symfony/webpack-encore-bundle/1.0/package.json
+++ b/symfony/webpack-encore-bundle/1.0/package.json
@@ -1,6 +1,6 @@
 {
     "devDependencies": {
-        "@symfony/webpack-encore": "^0.27.0",
+        "@symfony/webpack-encore": "^0.28.0",
         "core-js": "^3.0.0",
         "regenerator-runtime": "^0.13.2",
         "webpack-notifier": "^1.6.0"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | Not needed

Needed since we're still on the 0.X releases.

0.28.0 is released - so this can be merged now.