### PR TITLE
Simplify the MercureBundle recipe

### DIFF
--- a/symfony/mercure-bundle/0.1/config/packages/mercure.yaml
+++ b/symfony/mercure-bundle/0.1/config/packages/mercure.yaml
@@ -2,4 +2,4 @@ mercure:
     hubs:
         default:
             url: '%env(MERCURE_PUBLISH_URL)%'
-            jwt: '%env(MERCURE_JWT_SECRET)%'
+            jwt: '%env(MERCURE_JWT_TOKEN)%'

--- a/symfony/mercure-bundle/0.1/manifest.json
+++ b/symfony/mercure-bundle/0.1/manifest.json
@@ -5,14 +5,11 @@
     "copy-from-recipe": {
         "config/": "%CONFIG_DIR%/"
     },
-    "container": {
-        "env(MERCURE_PUBLISH_URL)": "",
-        "env(MERCURE_JWT_SECRET)": ""
-    },
     "env": {
         "#1": "See https://symfony.com/doc/current/mercure.html#configuration",
         "MERCURE_PUBLISH_URL": "http://mercure/hub",
-        "MERCURE_JWT_SECRET": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJtZXJjdXJlIjp7InB1Ymxpc2giOltdfX0.Oo0yg7y4yMa1vr_bziltxuTCqb8JVHKxp-f_FwwOim0"
+        "#2": "The default token is signed with the secret key: !ChangeMe!",
+        "MERCURE_JWT_TOKEN": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJtZXJjdXJlIjp7InB1Ymxpc2giOltdfX0.Oo0yg7y4yMa1vr_bziltxuTCqb8JVHKxp-f_FwwOim0"
     },
     "docker-compose": {
         "services": [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | N/A

Renamed the confusing `MERCURE_JWT_SECRET` to `MERCURE_JWT_TOKEN`. Should be okay according to https://github.com/symfony/recipes/pull/525#issuecomment-523363694

Removed default values for the env vars, in line with https://github.com/symfony/recipes/pull/588