### PR TITLE
Allow changing environement when `.env.local.php` exists.

### DIFF
--- a/symfony/framework-bundle/3.3/config/bootstrap.php
+++ b/symfony/framework-bundle/3.3/config/bootstrap.php
@@ -6,7 +6,7 @@ require dirname(__DIR__).'/vendor/autoload.php';
 
 // Load cached env vars if the .env.local.php file exists
 // Run "composer dump-env prod" to create it (requires symfony/flex >=1.2)
-if (is_array($env = @include dirname(__DIR__).'/.env.local.php')) {
+if (is_array($env = @include dirname(__DIR__).'/.env.local.php') && ($_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? $env['APP_ENV']) === $env['APP_ENV']) {
     foreach ($env as $k => $v) {
         $_ENV[$k] = $_ENV[$k] ?? (isset($_SERVER[$k]) && 0 !== strpos($k, 'HTTP_') ? $_SERVER[$k] : $v);
     }

--- a/symfony/framework-bundle/4.2/config/bootstrap.php
+++ b/symfony/framework-bundle/4.2/config/bootstrap.php
@@ -6,7 +6,7 @@ require dirname(__DIR__).'/vendor/autoload.php';
 
 // Load cached env vars if the .env.local.php file exists
 // Run "composer dump-env prod" to create it (requires symfony/flex >=1.2)
-if (is_array($env = @include dirname(__DIR__).'/.env.local.php')) {
+if (is_array($env = @include dirname(__DIR__).'/.env.local.php') && ($_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? $env['APP_ENV']) === $env['APP_ENV']) {
     foreach ($env as $k => $v) {
         $_ENV[$k] = $_ENV[$k] ?? (isset($_SERVER[$k]) && 0 !== strpos($k, 'HTTP_') ? $_SERVER[$k] : $v);
     }


### PR DESCRIPTION
I'm not sure if this is useful for other people - but I'm sharing it, and you can just reject it if not :)

I got here because I'm building a docker image, with all my code, and optimising it for prod run time, so I've run `composer dump-env prod` - but I want to use the same image to run my tests - so I'm testing in the prod system. But actually this is easy to repeat in your dev environment, if you dump prod, and leave it there, you no longer get `.env.dev` loaded.

Basically if `.env.local.php` exists, the environment no longer properly switches, as the `.env.$env` files are not used. This PR changes this so that the correct env is always loaded.

| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | 
