### PR TITLE
Trust proxies on private and local IPs by default

### DIFF
--- a/symfony/framework-bundle/4.2/manifest.json
+++ b/symfony/framework-bundle/4.2/manifest.json
@@ -14,7 +14,7 @@
     "env": {
         "APP_ENV": "dev",
         "APP_SECRET": "%generate(secret)%",
-        "#TRUSTED_PROXIES": "127.0.0.1,127.0.0.2",
+        "TRUSTED_PROXIES": "10.0.0.0/8,172.16.0.0/12,127.0.0.0/16",
         "#TRUSTED_HOSTS": "'^localhost|example\\.com$'"
     },
     "gitignore": [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

From https://en.wikipedia.org/wiki/Reserved_IP_addresses

I did not list `192.168.0.0/16` because it's used by home routers and these don't fit in the defaults to me. Makes sense?

Fixes https://github.com/symfony/symfony/issues/33578