### PR TITLE
Exclude some tables from the schema managed by Doctrine (migrations)

### DIFF
--- a/doctrine/doctrine-bundle/1.6/config/packages/doctrine.yaml
+++ b/doctrine/doctrine-bundle/1.6/config/packages/doctrine.yaml
@@ -13,6 +13,7 @@ doctrine:
             collate: utf8mb4_unicode_ci
 
         url: '%env(resolve:DATABASE_URL)%'
+        schema_filter: ~^(?!messenger_|lock_keys|cache_items|sessions)~
     orm:
         auto_generate_proxy_classes: true
         naming_strategy: doctrine.orm.naming_strategy.underscore


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

If you are using some Symfony features that require a table in the DB, and if you are using Doctrine migrations, the current behavior is buggy. Anytime you create a migration file, Doctrine will drop the tables coming from Symfony (Messenger, Session, Lock, Cache, ...).

Ideally, all tables managed by Symfony would be prefixed by a common string like `sf_`
, but that's not (yet) the case (and people might change the names anyway).

So, in the meantime, this is what I come up with to exclude the default tables with the default names.

I'd like to also create another PR on Symfony about the prefix.

WDTY?

/cc @weaverryan @stof @xabbuh @nicolas-grekas 