### PR TITLE
Set twig.strict_variables to true in test env by default

### DIFF
--- a/symfony/twig-bundle/3.3/config/packages/test/twig.yaml
+++ b/symfony/twig-bundle/3.3/config/packages/test/twig.yaml
@@ -1,0 +1,2 @@
+twig:
+    strict_variables: true

--- a/symfony/twig-bundle/4.4/config/packages/test
+++ b/symfony/twig-bundle/4.4/config/packages/test
@@ -1,0 +1,1 @@
+../../../3.3/config/packages/test


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

Resolves #665