### PR TITLE
Add enable_profiler option on mercure-bundle

### DIFF
--- a/symfony/mercure-bundle/0.1/config/packages/mercure.yaml
+++ b/symfony/mercure-bundle/0.1/config/packages/mercure.yaml
@@ -1,5 +1,6 @@
 mercure:
     hubs:
+        enable_profiler: '%kernel.debug%'
         default:
             url: '%env(MERCURE_PUBLISH_URL)%'
             jwt: '%env(MERCURE_JWT_TOKEN)%'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

This option will be required by https://github.com/symfony/mercure-bundle/pull/13