### PR TITLE
Replaced silent fail for loading php env file

### DIFF
--- a/symfony/framework-bundle/4.2/config/bootstrap.php
+++ b/symfony/framework-bundle/4.2/config/bootstrap.php
@@ -6,7 +6,8 @@ require dirname(__DIR__).'/vendor/autoload.php';
 
 // Load cached env vars if the .env.local.php file exists
 // Run "composer dump-env prod" to create it (requires symfony/flex >=1.2)
-if (is_array($env = @include dirname(__DIR__).'/.env.local.php')) {
+$phpEnvFile = dirname(__DIR__).'/.env.local.php');
+if (file_exists($phpEnvFile) && is_array($env = include($phpEnvFile)) {
     foreach ($env as $k => $v) {
         $_ENV[$k] = $_ENV[$k] ?? (isset($_SERVER[$k]) && 0 !== strpos($k, 'HTTP_') ? $_SERVER[$k] : $v);
     }


### PR DESCRIPTION
Replaced with actual test if file exists since the suppressing of an error just causes issues.

For instance if you run Xdebug.halt_level = E_WARNING

Xdebug notices that an error has happened but since we silenty fail for the include we never get an error output. With the change in place we do see an error if we want to see it.

| Q             | A
| ------------- | ---
| License       | MIT

<!--
Please, carefully read the README before submitting a pull request.
-->
