### PR TITLE
[doctrine/doctrine-bundle] dont duplicate the db settings

### DIFF
--- a/doctrine/doctrine-bundle/1.6/config/packages/doctrine.yaml
+++ b/doctrine/doctrine-bundle/1.6/config/packages/doctrine.yaml
@@ -1,18 +1,16 @@
 doctrine:
     dbal:
-        # configure these for your database server
-        # use postgresql for PostgreSQL
-        # use sqlite for SQLite
-        driver: 'mysql'
-        server_version: '5.7'
+        url: '%env(resolve:DATABASE_URL)%'
 
-        # only needed for MySQL
+        # IMPORTANT: You MUST configure your db driver and server version,
+        # either here or in the DATABASE_URL env var (see .env file)
+        #driver: 'mysql'
+        #server_version: '5.7'
+
+        # Only needed for MySQL (ignored otherwise)
         charset: utf8mb4
         default_table_options:
-            charset: utf8mb4
             collate: utf8mb4_unicode_ci
-
-        url: '%env(resolve:DATABASE_URL)%'
     orm:
         auto_generate_proxy_classes: true
         naming_strategy: doctrine.orm.naming_strategy.underscore

--- a/doctrine/doctrine-bundle/1.6/manifest.json
+++ b/doctrine/doctrine-bundle/1.6/manifest.json
@@ -10,7 +10,7 @@
         "#1": "Format described at https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url",
         "#2": "For an SQLite database, use: \"sqlite:///%kernel.project_dir%/var/data.db\"",
         "#3": "For a PostgreSQL database, use: \"postgresql://db_user:db_password@127.0.0.1:5432/db_name?serverVersion=11\"",
-        "#4": "IMPORTANT: You MUST also configure your db driver and server_version in config/packages/doctrine.yaml",
-        "DATABASE_URL": "mysql://db_user:db_password@127.0.0.1:3306/db_name"
+        "#4": "IMPORTANT: You MUST configure your db driver and server version, either here or in config/packages/doctrine.yaml",
+        "DATABASE_URL": "mysql://db_user:db_password@127.0.0.1:3306/db_name?serverVersion=5.7"
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

I've spent hours of debugging because the db driver was set differently in two places: the yaml and the .env files.

Actually, we don't need the duplication at all. Let's favor the `.env` since it is now always loaded.