### PR TITLE
[Fwb][TwigBundle] Remove Twig Preview controller routing in favor of fwb

### DIFF
--- a/symfony/framework-bundle/4.4/config/routes/dev/framework.yaml
+++ b/symfony/framework-bundle/4.4/config/routes/dev/framework.yaml
@@ -1,3 +1,3 @@
 _errors:
     resource: '@FrameworkBundle/Resources/config/routing/errors.xml'
-    prefix: /__error
+    prefix: /_error

--- a/symfony/twig-bundle/4.4/config/routes
+++ b/symfony/twig-bundle/4.4/config/routes
@@ -1,1 +1,0 @@
-../../3.3/config/routes/


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | N/A    

<!--
Please, carefully read the README before submitting a pull request.
-->

AFAIU, the controller for this route is deprecated in favor of the `HttpKernel` one registered through the fwb recipe. So new projects starting with Twig 4.4 should not start with this deprecated route, and use the fwb one instead.