### PR TITLE
[framework-bundle] enable "inline_factories", disable "inline_class_loader" when PHP 7.4 preloading is used

### DIFF
--- a/symfony/framework-bundle/4.2/src/Kernel.php
+++ b/symfony/framework-bundle/4.2/src/Kernel.php
@@ -33,7 +33,8 @@ class Kernel extends BaseKernel
     protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader): void
     {
         $container->addResource(new FileResource($this->getProjectDir().'/config/bundles.php'));
-        $container->setParameter('container.dumper.inline_class_loader', true);
+        $container->setParameter('container.dumper.inline_class_loader', \PHP_VERSION_ID < 70400 || !ini_get('opcache.preload'));
+        $container->setParameter('container.dumper.inline_factories', true);
         $confDir = $this->getProjectDir().'/config';
 
         $loader->load($confDir.'/{packages}/*'.self::CONFIG_EXTS, 'glob');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

Closes https://github.com/symfony/symfony/issues/34368

Works around a memory leak reported in https://bugs.php.net/76982 and explained at https://jolicode.com/blog/you-may-have-memory-leaking-from-php-7-and-symfony-tests

Helps with long-running scripts (workers) that currently can break when the cache is  cleared separately (on dev mostly.)