### PR TITLE
Allow to change the environment, kernel.debug and HttpCache by cookie

### DIFF
--- a/symfony/framework-bundle/4.4/public/index.php
+++ b/symfony/framework-bundle/4.4/public/index.php
@@ -1,8 +1,24 @@
 <?php
 
 use App\Kernel;
+use Symfony\Bundle\FrameworkBundle\HttpCache\HttpCache;
 use Symfony\Component\ErrorHandler\Debug;
 use Symfony\Component\HttpFoundation\Request;
+
+if ($_SERVER['SYMFONY_ALLOW_OVERRIDE'] ?? $_ENV['SYMFONY_ALLOW_OVERRIDE'] ?? false) {
+    if (isset($_COOKIE['APP_ENV'])) {
+        $_ENV['APP_ENV'] = $_SERVER['APP_ENV'] = $_COOKIE['APP_ENV'];
+        unset($_COOKIE['APP_ENV']);
+    }
+    if (isset($_COOKIE['APP_DEBUG'])) {
+        $_ENV['APP_DEBUG'] = $_SERVER['APP_DEBUG'] = (bool) $_COOKIE['APP_DEBUG'];
+        unset($_COOKIE['APP_DEBUG']);
+    }
+    if (isset($_COOKIE['SYMFONY_HTTP_CACHE'])) {
+        $_ENV['SYMFONY_HTTP_CACHE'] = $_SERVER['SYMFONY_HTTP_CACHE'] = (bool) $_COOKIE['SYMFONY_HTTP_CACHE'];
+        unset($_COOKIE['SYMFONY_HTTP_CACHE']);
+    }
+}
 
 require dirname(__DIR__).'/config/bootstrap.php';
 
@@ -22,6 +38,12 @@ if ($trustedHosts = $_SERVER['TRUSTED_HOSTS'] ?? $_ENV['TRUSTED_HOSTS'] ?? false
 
 $kernel = new Kernel($_SERVER['APP_ENV'], (bool) $_SERVER['APP_DEBUG']);
 $request = Request::createFromGlobals();
+
+if ($_SERVER['SYMFONY_HTTP_CACHE'] ?? $_ENV['SYMFONY_HTTP_CACHE'] ?? false) {
+    class AppCache extends HttpCache {}
+    $kernel = new AppCache($kernel);
+}
+
 $response = $kernel->handle($request);
 $response->send();
 $kernel->terminate($request, $response);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | TODO

I would like to propose the possibility to use cookies to change the Kernel environment, debug mode and enabling the `HttpCache`.

This is helpful if you want to 
* find out why things work in your `dev` environment, but fail with `production` settings
* benchmark some requests with `kernel.debug` disabled or with the `HttpCache`
* control the environment during high-level integration or acceptance tests

This solution is convenient because it can easily be used from a browser. Cookies will persist for subsequent requests and will not otherwise "pollute" the URL. JavaScript/Bookmarklets can be used to easily set, change or revert settings. Also, the cookies can easily be added in tools like `curl`, `ab` or a Behat/Mink session.

The alternative of editing `.env` files and/or the `index.php` file is not easily available in automated test setups. Also, you cannot have two browser instances/windows in parallel that work with different settings at the same time.

Of course, this should only be possible under very special conditions, namely your development environment. So, a `SYMFONY_ALLOW_OVERRIDE` environment variable must have been set in the webserver to allow it.