### PR TITLE
Clarifying the purpose of the "app" cache

### DIFF
--- a/symfony/framework-bundle/3.3/config/packages/cache.yaml
+++ b/symfony/framework-bundle/3.3/config/packages/cache.yaml
@@ -1,10 +1,10 @@
 framework:
     cache:
-        # Put the unique name of your app here: the prefix seed
-        # is used to compute stable namespaces for cache keys.
+        # Unique name of your app: used to compute stable namespaces for cache keys.
         #prefix_seed: your_vendor_name/app_name
 
-        # The app cache caches to the filesystem by default.
+        # The "app" cache stores to the filesystem by default.
+        # The data in this cache should persist between deploys.
         # Other options include:
 
         # Redis


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | not needed

A user I talked to recently didn't realize that the "app" cache should persist between deploys (i.e. not be cleared/reset like the "system" cache). This is meant to clarify that.

Cheers!