### PR TITLE
Move the mail and mailer aliases to symfony/mailer instead of swiftmailer

### DIFF
--- a/symfony/mailer/4.3/manifest.json
+++ b/symfony/mailer/4.3/manifest.json
@@ -4,5 +4,6 @@
     },
     "env": {
         "#1": "MAILER_DSN=smtp://localhost"
-    }
+    },
+    "aliases": ["mailer", "mail"]
 }

--- a/symfony/swiftmailer-bundle/2.5/manifest.json
+++ b/symfony/swiftmailer-bundle/2.5/manifest.json
@@ -11,5 +11,5 @@
         "#3": "Delivery is disabled by default via \"null://localhost\"",
         "MAILER_URL": "null://localhost"
     },
-    "aliases": ["mailer", "mail", "swiftmailer"]
+    "aliases": ["swiftmailer"]
 }


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | symfony/symfony-docs#...    

<!--
Please, carefully read the README before submitting a pull request.
-->

To be merged just after the 5.0 release.
