### PR TITLE
[DoctrineBundle] Add charset option to postgres example

### DIFF
--- a/doctrine/doctrine-bundle/1.6/manifest.json
+++ b/doctrine/doctrine-bundle/1.6/manifest.json
@@ -9,7 +9,7 @@
     "env": {
         "#1": "Format described at https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url",
         "#2": "For an SQLite database, use: \"sqlite:///%kernel.project_dir%/var/data.db\"",
-        "#3": "For a PostgreSQL database, use: \"postgresql://db_user:db_password@127.0.0.1:5432/db_name?serverVersion=11\"",
+        "#3": "For a PostgreSQL database, use: \"postgresql://db_user:db_password@127.0.0.1:5432/db_name?serverVersion=11&charset=UTF-8\"",
         "#4": "IMPORTANT: You MUST configure your db driver and server version, either here or in config/packages/doctrine.yaml",
         "DATABASE_URL": "mysql://db_user:db_password@127.0.0.1:3306/db_name?serverVersion=5.7"
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | 

We should add charset on example DSN otherwise the charset option of `doctrine.yaml` leads to an error

<img width="1432" alt="Bildschirmfoto 2019-11-24 um 23 31 36" src="https://user-images.githubusercontent.com/2852185/69502740-015eb280-0f13-11ea-9279-217b927f6674.png">
