### PR TITLE
[RFC] Changing anonymous back to true in security.yaml

### DIFF
--- a/symfony/security-bundle/4.4/config/packages/security.yaml
+++ b/symfony/security-bundle/4.4/config/packages/security.yaml
@@ -7,7 +7,7 @@ security:
             pattern: ^/(_(profiler|wdt)|css|images|js)/
             security: false
         main:
-            anonymous: lazy
+            anonymous: true
 
             # activate different ways to authenticate
             # https://symfony.com/doc/current/security.html#firewalls-authentication


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | not needed - `anonymous: lazy` is not shown there

See: https://github.com/symfony/symfony/issues/34614

The authenticator behavior in 4.4 has changed in a way that I don't think we want. Either `anonymous: lazy` has a bug. Or, if it's the intended behavior - that's fine - but I think it's unexpected enough that it should not be the default.

So, we should merge this OR https://github.com/symfony/symfony/issues/34614