### PR TITLE
Fix doctrine-bundle recipe for prod caching pools

### DIFF
--- a/doctrine/doctrine-bundle/1.12/config/packages/prod/doctrine.yaml
+++ b/doctrine/doctrine-bundle/1.12/config/packages/prod/doctrine.yaml
@@ -1,3 +1,20 @@
 doctrine:
     orm:
         auto_generate_proxy_classes: false
+        metadata_cache_driver:
+            type: pool
+            pool: doctrine.system_cache_pool
+        query_cache_driver:
+            type: pool
+            pool: doctrine.system_cache_pool
+        result_cache_driver:
+            type: pool
+            pool: doctrine.result_cache_pool
+        
+framework:
+    cache:
+        pools:
+            doctrine.result_cache_pool:
+                adapter: cache.app
+            doctrine.system_cache_pool:
+                adapter: cache.system


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

This change is required since we reverted some changes on doctrine-bundle to restore non-persistent caches for non-prod environments: https://github.com/doctrine/DoctrineBundle/pull/1073

This fixes some issues that were reported:
https://github.com/symfony/recipes/issues/688
https://github.com/doctrine/DoctrineBundle/issues/1069
https://github.com/doctrine/migrations/issues/873

Tested this on symfony-demo with doctrine-bundle 1.12.x

```
it@7444b85a5a96:/var/www/symfony-demo  (master) $ bin/console debug:container doctrine.orm.default_metadata_cache --env=prod --show-arguments

 // This service is a private alias for the service                                                                     
 // doctrine.orm.cache.provider.doctrine.system_cache_pool                                                              

Information for Service "doctrine.orm.cache.provider.doctrine.system_cache_pool"
================================================================================

 ---------------- -------------------------------------------------------- 
  Option           Value                                                   
 ---------------- -------------------------------------------------------- 
  Service ID       doctrine.orm.cache.provider.doctrine.system_cache_pool  
  Class            Symfony\Component\Cache\DoctrineProvider                
  Tags             -                                                       
  Public           no                                                      
  Synthetic        no                                                      
  Lazy             no                                                      
  Shared           yes                                                     
  Abstract         no                                                      
  Autowired        no                                                      
  Autoconfigured   no                                                      
  Arguments        Service(doctrine.system_cache_pool)                     
 ---------------- -------------------------------------------------------- 

it@7444b85a5a96:/var/www/symfony-demo  (master) $ bin/console debug:container doctrine.system_cache_pool --env=prod --show-arguments

Information for Service "doctrine.system_cache_pool"
====================================================

 Interface for adapters managing instances of Symfony's CacheItem.

 ---------------- -------------------------------------------------- 
  Option           Value                                             
 ---------------- -------------------------------------------------- 
  Service ID       doctrine.system_cache_pool                        
  Class            Symfony\Component\Cache\Adapter\AdapterInterface  
  Tags             cache.pool                                        
                   kernel.reset (method: reset)                      
  Public           no                                                
  Synthetic        no                                                
  Lazy             no                                                
  Shared           yes                                               
  Abstract         no                                                
  Autowired        no                                                
  Autoconfigured   no                                                
  Factory Class    Symfony\Component\Cache\Adapter\AbstractAdapter   
  Factory Method   createSystemCache                                 
  Arguments        ZuhLw62S5q                                        
                   0                                                 
                   %container.build_id%                              
                   /var/www/symfony-demo/var/cache/prod/pools        
                   Service(monolog.logger.cache)                     
 ---------------- -------------------------------------------------- 



