### PR TITLE
Disable logging for test env

### DIFF
--- a/symfony/monolog-bundle/3.3/config/packages/test/monolog.yaml
+++ b/symfony/monolog-bundle/3.3/config/packages/test/monolog.yaml
@@ -5,8 +5,8 @@ monolog:
             action_level: error
             handler: nested
             excluded_http_codes: [404, 405]
+            channels: ["!event"]
         nested:
             type: stream
             path: "%kernel.logs_dir%/%kernel.environment%.log"
             level: debug
-            channels: ["!event"]

--- a/symfony/monolog-bundle/3.3/config/packages/test/monolog.yaml
+++ b/symfony/monolog-bundle/3.3/config/packages/test/monolog.yaml
@@ -1,7 +1,8 @@
 monolog:
     handlers:
-        main:
-            type: stream
-            path: "%kernel.logs_dir%/%kernel.environment%.log"
-            level: debug
-            channels: ["!event"]
+        # Enable if you need logs during (automated) tests
+        #main:
+        #    type: stream
+        #    path: "%kernel.logs_dir%/%kernel.environment%.log"
+        #    level: debug
+        #    channels: ["!event"]

--- a/symfony/monolog-bundle/3.3/config/packages/test/monolog.yaml
+++ b/symfony/monolog-bundle/3.3/config/packages/test/monolog.yaml
@@ -1,8 +1,11 @@
 monolog:
     handlers:
-        # Enable if you need logs during (automated) tests
-        #main:
-        #    type: stream
-        #    path: "%kernel.logs_dir%/%kernel.environment%.log"
-        #    level: debug
-        #    channels: ["!event"]
+        main:
+            type: fingers_crossed
+            action_level: error
+            handler: nested
+            excluded_http_codes: [404, 405]
+        nested:
+            type: stream
+            path: "%kernel.logs_dir%/%kernel.environment%.log"
+            level: debug

--- a/symfony/monolog-bundle/3.3/config/packages/test/monolog.yaml
+++ b/symfony/monolog-bundle/3.3/config/packages/test/monolog.yaml
@@ -9,3 +9,4 @@ monolog:
             type: stream
             path: "%kernel.logs_dir%/%kernel.environment%.log"
             level: debug
+            channels: ["!event"]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | symfony/symfony-docs#...    

I'd argue by default you need the full application logs when running (or writing) tests.