### PR TITLE
Use configureBabelPresetEnv() in webpack.config.js

### DIFF
--- a/symfony/webpack-encore-bundle/1.0/package.json
+++ b/symfony/webpack-encore-bundle/1.0/package.json
@@ -1,6 +1,6 @@
 {
     "devDependencies": {
-        "@symfony/webpack-encore": "^0.28.0",
+        "@symfony/webpack-encore": "^0.28.2",
         "core-js": "^3.0.0",
         "regenerator-runtime": "^0.13.2",
         "webpack-notifier": "^1.6.0"

--- a/symfony/webpack-encore-bundle/1.0/webpack.config.js
+++ b/symfony/webpack-encore-bundle/1.0/webpack.config.js
@@ -48,10 +48,10 @@ Encore
     .enableVersioning(Encore.isProduction())
 
     // enables @babel/preset-env polyfills
-    .configureBabel(() => {}, {
-        useBuiltIns: 'usage',
-        corejs: 3
-    })
+    .configureBabelPresetEnv((config) => {
+        config.useBuiltIns = 'usage';
+        config.corejs = 3;
+    });
 
     // enables Sass/SCSS support
     //.enableSassLoader()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | n/a

Use `configureBabelPresetEnv()` introduced in symfony/webpack-encore#642 instead of `configureBabel()`.