### PR TITLE
Enable inline_class_loader in debug mode

### DIFF
--- a/symfony/framework-bundle/4.2/src/Kernel.php
+++ b/symfony/framework-bundle/4.2/src/Kernel.php
@@ -33,7 +33,7 @@ class Kernel extends BaseKernel
     protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader): void
     {
         $container->addResource(new FileResource($this->getProjectDir().'/config/bundles.php'));
-        $container->setParameter('container.dumper.inline_class_loader', \PHP_VERSION_ID < 70400);
+        $container->setParameter('container.dumper.inline_class_loader', \PHP_VERSION_ID < 70400 || $this->debug);
         $container->setParameter('container.dumper.inline_factories', true);
         $confDir = $this->getProjectDir().'/config';
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

We forgot about it, but setting inline_class_loader to true allows bypassing `DebugClassLoader` in debug mode, which provides a significant DX improvement, even on PHP 7.4+