### PR TITLE
Align code coverage settings with documentation

### DIFF
--- a/phpunit/phpunit/4.7/phpunit.xml.dist
+++ b/phpunit/phpunit/4.7/phpunit.xml.dist
@@ -20,8 +20,8 @@
     </testsuites>
 
     <filter>
-        <whitelist>
-            <directory>src</directory>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">src</directory>
         </whitelist>
     </filter>
 </phpunit>

--- a/symfony/phpunit-bridge/4.1/phpunit.xml.dist
+++ b/symfony/phpunit-bridge/4.1/phpunit.xml.dist
@@ -22,8 +22,8 @@
     </testsuites>
 
     <filter>
-        <whitelist>
-            <directory>src</directory>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">src</directory>
         </whitelist>
     </filter>
 


### PR DESCRIPTION
After noticing slow coverage collection on our jenkins server for our symfony project, i noticed after some time that we were missing the on the whitelist configuration the processUncoveredFilesFromWhitelist attribute. I tried to backtrace why this configuration was missing and realized that this might come from the phpunit flex recipe. So here we go with the fix.

Fixes issues with slow coverage collection mentioned here:  
https://github.com/sebastianbergmann/phpunit/issues/2489  
Also the documentation already includes the configuration:  
https://symfony.com/doc/4.4/create_framework/unit_testing.html
https://symfony.com/doc/current/create_framework/unit_testing.html

| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | symfony/symfony-docs#...    

<!--
Please, carefully read the README before submitting a pull request.
-->
