### PR TITLE
Use PHP to define the services and routes of the app

### DIFF
--- a/symfony/framework-bundle/5.1/config/routes.php
+++ b/symfony/framework-bundle/5.1/config/routes.php
@@ -1,0 +1,12 @@
+<?php
+
+use App\Kernel;
+use Symfony\Bundle\FrameworkBundle\Routing\Loader\Configurator\RoutingConfigurator;
+
+return static function (RoutingConfigurator $routes, Kernel $kernel): void {
+
+//    $routes->add('index', '/')
+//        ->controller([App\Controller\DefaultController::class, 'index'])
+//    ;
+
+};

--- a/symfony/framework-bundle/5.1/config/services.php
+++ b/symfony/framework-bundle/5.1/config/services.php
@@ -1,0 +1,59 @@
+<?php
+
+use App\Kernel;
+use Symfony\Component\DependencyInjection\Loader\Configurator as di;
+
+// This file is the entry point to configure your own services.
+// Files in the packages/ subdirectory configure your dependencies.
+
+return static function (di\ContainerConfigurator $container, Kernel $kernel): void {
+
+    // Parameters are configuration that don't need to change depending on the machine where the app is deployed.
+    // see https://symfony.com/doc/current/best_practices/configuration.html#application-related-configuration
+    $container->parameters()
+    //    ->set(...)
+    ;
+
+    $services = $container->services()
+        ->defaults()
+            ->autowire()
+            ->autoconfigure()
+    ;
+
+    // Makes classes in src/ available to be used as services
+    $src = dirname(__DIR__).'/src';
+    $services
+        ->load('App\\', $src)
+        ->exclude([
+            $src.'/DependencyInjection',
+            $src.'/Entity',
+            $src.'/Migrations',
+            $src.'/Tests',
+            $src.'/Kernel.php',
+        ])
+    ;
+
+    // Controllers are imported separately to make sure services can be injected
+    // as action arguments even if you don't extend any base controller class
+    $services
+        ->load('App\\Controller\\', $src.'/Controller')
+        ->tag('controller.service_arguments')
+    ;
+
+    // Add more service definitions when explicit configuration is needed.
+    // Please note that last definitions *replace* previous ones when using $services->set().
+    // It is possible to alter a previously declared definition by using $services->get() instead.
+    $services
+    //    ->set(App\MyService::class)
+    //        ->args([di\ref(App\AnotherService::class)])
+    ;
+
+    if ('test' === $kernel->getEnvironment()) {
+        // When a test case needs access to a service, getting it via
+        // a public alias with the "test." prefix is recommended.
+        $services->public()
+        //    ->alias('test.App\MyService', App\MyService::class)
+        ;
+    }
+
+};

--- a/symfony/framework-bundle/5.1/config/services.yaml
+++ b/symfony/framework-bundle/5.1/config/services.yaml
@@ -1,1 +1,0 @@
-../../4.2/config/services.yaml

--- a/symfony/framework-bundle/5.1/src/Kernel.php
+++ b/symfony/framework-bundle/5.1/src/Kernel.php
@@ -15,14 +15,26 @@ class Kernel extends BaseKernel
     {
         $container->import('../config/{packages}/*.yaml');
         $container->import('../config/{packages}/'.$this->environment.'/*.yaml');
-        $container->import('../config/{services}.yaml');
-        $container->import('../config/{services}_'.$this->environment.'.yaml');
+
+        if (file_exists(\dirname(__DIR__).'/config/services.yaml')) {
+            $container->import('../config/{services}.yaml');
+            $container->import('../config/{services}_'.$this->environment.'.yaml');
+        } else {
+            $path = \dirname(__DIR__).'/config/services.php';
+            (require $path)($container->withPath($path), $this);
+        }
     }
 
     protected function configureRoutes(RoutingConfigurator $routes): void
     {
         $routes->import('../config/{routes}/'.$this->environment.'/*.yaml');
         $routes->import('../config/{routes}/*.yaml');
-        $routes->import('../config/{routes}.yaml');
+
+        if (file_exists(\dirname(__DIR__).'/config/routes.yaml')) {
+            $routes->import('../config/{routes}.yaml');
+        } else {
+            $path = \dirname(__DIR__).'/config/routes.php';
+            (require $path)($routes->withPath($path), $this);
+        }
     }
 }

--- a/symfony/routing/5.1/config/packages
+++ b/symfony/routing/5.1/config/packages
@@ -1,0 +1,1 @@
+../../4.2/config/packages/

--- a/symfony/routing/5.1/manifest.json
+++ b/symfony/routing/5.1/manifest.json
@@ -1,0 +1,6 @@
+{
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "aliases": ["router"]
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

This PR is here to demonstrate the new capabilities of Symfony 5.1.
Basically, we can now develop a full Symfony app in a single file, like "microframeworks" 
No `services.yaml`, no `routes.yaml` here.