### PR TITLE
Fix TRUSTED_HOSTS regexp example

### DIFF
--- a/symfony/framework-bundle/3.3/manifest.json
+++ b/symfony/framework-bundle/3.3/manifest.json
@@ -15,7 +15,7 @@
         "APP_ENV": "dev",
         "APP_SECRET": "%generate(secret)%",
         "#TRUSTED_PROXIES": "127.0.0.1,127.0.0.2",
-        "#TRUSTED_HOSTS": "'^localhost|example\\.com$'"
+        "#TRUSTED_HOSTS": "'^localhost$|^example\\.com$'"
     },
     "gitignore": [
         "/.env.local",

--- a/symfony/framework-bundle/3.3/manifest.json
+++ b/symfony/framework-bundle/3.3/manifest.json
@@ -15,7 +15,7 @@
         "APP_ENV": "dev",
         "APP_SECRET": "%generate(secret)%",
         "#TRUSTED_PROXIES": "127.0.0.1,127.0.0.2",
-        "#TRUSTED_HOSTS": "'^localhost$|^example\\.com$'"
+        "#TRUSTED_HOSTS": "'^(localhost|example\\.com)$'"
     },
     "gitignore": [
         "/.env.local",

--- a/symfony/framework-bundle/4.2/manifest.json
+++ b/symfony/framework-bundle/4.2/manifest.json
@@ -15,7 +15,7 @@
         "APP_ENV": "dev",
         "APP_SECRET": "%generate(secret)%",
         "#TRUSTED_PROXIES": "127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16",
-        "#TRUSTED_HOSTS": "'^localhost$|^example\\.com$'"
+        "#TRUSTED_HOSTS": "'^(localhost|example\\.com)$'"
     },
     "gitignore": [
         "/.env.local",

--- a/symfony/framework-bundle/4.2/manifest.json
+++ b/symfony/framework-bundle/4.2/manifest.json
@@ -15,7 +15,7 @@
         "APP_ENV": "dev",
         "APP_SECRET": "%generate(secret)%",
         "#TRUSTED_PROXIES": "127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16",
-        "#TRUSTED_HOSTS": "'^localhost|example\\.com$'"
+        "#TRUSTED_HOSTS": "'^localhost$|^example\\.com$'"
     },
     "gitignore": [
         "/.env.local",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

Fixes https://github.com/symfony/recipes/pull/494#discussion_r372441028

Actually the direct translation for the old `explode(',', "localhost,example.com")` into regexp would be `['^localhost$', '^example\.com$']` (like in [the docs](https://symfony.com/doc/3.4/reference/configuration/framework.html#trusted-hosts)), but this env var is expected as a single string (by [public/index.php](https://github.com/symfony/recipes/blob/master/symfony/framework-bundle/3.3/public/index.php)), hence `'^localhost$|^example\.com$'` (JSON-encoded in the file).

Equivalent alternative: `'^(?:localhost|example\.com)$'` (i.e. `"'^(?:localhost|example\\.com)$'"`), but not sure if better