### PR TITLE
Use Dotenv::populate() to define the dumped env vars

### DIFF
--- a/symfony/framework-bundle/3.3/config/bootstrap.php
+++ b/symfony/framework-bundle/3.3/config/bootstrap.php
@@ -4,14 +4,14 @@ use Symfony\Component\Dotenv\Dotenv;
 
 require dirname(__DIR__).'/vendor/autoload.php';
 
+if (!class_exists(Dotenv::class)) {
+    throw new LogicException('Please run "composer require symfony/dotenv" to load the ".env" files configuring the application.');
+}
+
 // Load cached env vars if the .env.local.php file exists
 // Run "composer dump-env prod" to create it (requires symfony/flex >=1.2)
-if (is_array($env = @include dirname(__DIR__).'/.env.local.php') && ($_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? $env['APP_ENV'] ?? null) === ($env['APP_ENV'] ?? null)) {
-    foreach ($env as $k => $v) {
-        $_ENV[$k] = $_ENV[$k] ?? (isset($_SERVER[$k]) && 0 !== strpos($k, 'HTTP_') ? $_SERVER[$k] : $v);
-    }
-} elseif (!class_exists(Dotenv::class)) {
-    throw new RuntimeException('Please run "composer require symfony/dotenv" to load the ".env" files configuring the application.');
+if (is_array($env = @include dirname(__DIR__).'/.env.local.php') && (!isset($env['APP_ENV']) || ($_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? $env['APP_ENV']) === $env['APP_ENV'])) {
+    (new Dotenv(false))->populate($env);
 } else {
     $path = dirname(__DIR__).'/.env';
     $dotenv = new Dotenv(false);

--- a/symfony/framework-bundle/4.2/config/bootstrap.php
+++ b/symfony/framework-bundle/4.2/config/bootstrap.php
@@ -4,14 +4,14 @@ use Symfony\Component\Dotenv\Dotenv;
 
 require dirname(__DIR__).'/vendor/autoload.php';
 
+if (!class_exists(Dotenv::class)) {
+    throw new LogicException('Please run "composer require symfony/dotenv" to load the ".env" files configuring the application.');
+}
+
 // Load cached env vars if the .env.local.php file exists
 // Run "composer dump-env prod" to create it (requires symfony/flex >=1.2)
 if (is_array($env = @include dirname(__DIR__).'/.env.local.php') && (!isset($env['APP_ENV']) || ($_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? $env['APP_ENV']) === $env['APP_ENV'])) {
-    foreach ($env as $k => $v) {
-        $_ENV[$k] = $_ENV[$k] ?? (isset($_SERVER[$k]) && 0 !== strpos($k, 'HTTP_') ? $_SERVER[$k] : $v);
-    }
-} elseif (!class_exists(Dotenv::class)) {
-    throw new RuntimeException('Please run "composer require symfony/dotenv" to load the ".env" files configuring the application.');
+    (new Dotenv(false))->populate($env);
 } else {
     // load all the .env files
     (new Dotenv(false))->loadEnv(dirname(__DIR__).'/.env');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

This fixes populating the `SYMFONY_DOTENV_VARS` env var.
The overhead of loading the `Dotenv` class is removed by using preloading if one really cares. And the overhead of running the method is minimal IMHO.

This already what happens on the recipe for master btw.