### PR TITLE
[Security] Renamed in memory provider

### DIFF
--- a/symfony/security-bundle/3.3/config/packages/security.yaml
+++ b/symfony/security-bundle/3.3/config/packages/security.yaml
@@ -1,13 +1,14 @@
 security:
     # https://symfony.com/doc/current/security.html#where-do-users-come-from-user-providers
     providers:
-        in_memory: { memory: null }
+        users_in_memory: { memory: null }
     firewalls:
         dev:
             pattern: ^/(_(profiler|wdt)|css|images|js)/
             security: false
         main:
             anonymous: true
+            provider: users_in_memory
 
             # activate different ways to authenticate
             # https://symfony.com/doc/current/security.html#firewalls-authentication

--- a/symfony/security-bundle/4.4/config/packages/security.yaml
+++ b/symfony/security-bundle/4.4/config/packages/security.yaml
@@ -1,13 +1,14 @@
 security:
     # https://symfony.com/doc/current/security.html#where-do-users-come-from-user-providers
     providers:
-        in_memory: { memory: null }
+        users_in_memory: { memory: null }
     firewalls:
         dev:
             pattern: ^/(_(profiler|wdt)|css|images|js)/
             security: false
         main:
             anonymous: lazy
+            provider: users_in_memory
 
             # activate different ways to authenticate
             # https://symfony.com/doc/current/security.html#firewalls-authentication


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | ~

The name of the default memory provider has always been confusing to me, and keep being confusing for my trainees, training after training.
Here an attempt to clarify that this is a name and not the type.

Also, having multiple providers without making explicite the one used by the firewall throws from Symfony 4, so I propose to reflect that in the recipe (maybe we should do so in the 3.3 recipe too).

If you agree I'll update the docs accordingly. Thanks!