### PR TITLE
Show region parameter in Mailgun mailer DSN

### DIFF
--- a/symfony/mailgun-mailer/4.4/manifest.json
+++ b/symfony/mailgun-mailer/4.4/manifest.json
@@ -1,6 +1,6 @@
 {
     "env": {
         "#1": "MAILER_DSN=mailgun://KEY:DOMAIN@default",
-        "#2": "MAILER_DSN=mailgun+smtp://USERNAME:PASSWORD@default"
+        "#2": "MAILER_DSN=mailgun+smtp://USERNAME:PASSWORD@default?region=us"
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | https://github.com/symfony/symfony-docs/pull/13154

Just got a hard time to get SMTP working with european servers from Mailgun. It was unclear how to configure the EU host (ie. should I change the `@default` host? Should I add another config?). I think showing the existence of this parameter in the recipe by default would help a lot.
