### PR TITLE
removing services_test.yaml from symfony/phpunit-bridge recipe

### DIFF
--- a/symfony/phpunit-bridge/3.3/config/services_test.yaml
+++ b/symfony/phpunit-bridge/3.3/config/services_test.yaml
@@ -1,9 +1,0 @@
-services:
-    _defaults:
-        public: true
-
-    # If you need to access services in a test, create an alias
-    # and then fetch that alias from the container. As a convention,
-    # aliases are prefixed with test. For example:
-    #
-    # test.App\Service\MyService: '@App\Service\MyService'

--- a/symfony/phpunit-bridge/3.3/manifest.json
+++ b/symfony/phpunit-bridge/3.3/manifest.json
@@ -2,7 +2,6 @@
     "copy-from-recipe": {
         ".env.test": ".env.test",
         "bin/": "%BIN_DIR%/",
-        "config/": "%CONFIG_DIR%/",
         "phpunit.xml.dist": "phpunit.xml.dist",
         "tests/": "tests/"
     },


### PR DESCRIPTION
Since Symfony 4.1, you can fetch private services from a test using
a special method - creating public aliases is not required anymore.

| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | Docs already mention this https://symfony.com/doc/current/testing.html#accessing-the-container

I'm removing this instead of creating a new version of the recipe mostly for simplicity. The only version that would still need this and is NOT EOL is 3.4. This recipe change would only affect people installing phpunit-bridge into 3.4 today - I think it's worth just keeping the one recipe version. But I can split into a newer version if we want.

Cheers!