### PR TITLE
Set NODE_ENV var when running Encore scripts

### DIFF
--- a/symfony/webpack-encore-bundle/1.0/package.json
+++ b/symfony/webpack-encore-bundle/1.0/package.json
@@ -8,9 +8,9 @@
     "license": "UNLICENSED",
     "private": true,
     "scripts": {
-        "dev-server": "encore dev-server",
-        "dev": "encore dev",
-        "watch": "encore dev --watch",
-        "build": "encore production --progress"
+        "dev-server": "NODE_ENV=development encore dev-server",
+        "dev": "NODE_ENV=development encore dev",
+        "watch": "NODE_ENV=development encore dev --watch",
+        "build": "NODE_ENV=production encore production --progress"
     }
 }

--- a/symfony/webpack-encore-bundle/1.0/package.json
+++ b/symfony/webpack-encore-bundle/1.0/package.json
@@ -8,9 +8,9 @@
     "license": "UNLICENSED",
     "private": true,
     "scripts": {
-        "dev-server": "NODE_ENV=development encore dev-server",
-        "dev": "NODE_ENV=development encore dev",
-        "watch": "NODE_ENV=development encore dev --watch",
-        "build": "NODE_ENV=production encore production --progress"
+        "dev-server": "encore dev-server",
+        "dev": "encore dev",
+        "watch": "encore dev --watch",
+        "build": "encore production --progress"
     }
 }

--- a/symfony/webpack-encore-bundle/1.0/webpack.config.js
+++ b/symfony/webpack-encore-bundle/1.0/webpack.config.js
@@ -1,7 +1,7 @@
 var Encore = require('@symfony/webpack-encore');
 
-// Optional: sync the NODE_ENV value with the current webpack environment
-// It's useful when you configure tools like PostCSS in their own config files instead of in webpack.config.js.
+// Optional: sync the NODE_ENV value with the current Webpack Encore environment
+// It’s useful if you need to read the Webpack Encore environment from some other config file
 // process.env.NODE_ENV = Encore.isProduction() ? 'production' : 'development';
 
 // Manually configure the runtime environment if not already configured yet by the "encore" command.

--- a/symfony/webpack-encore-bundle/1.0/webpack.config.js
+++ b/symfony/webpack-encore-bundle/1.0/webpack.config.js
@@ -1,5 +1,9 @@
 var Encore = require('@symfony/webpack-encore');
 
+// Optional: sync the NODE_ENV value with the current webpack environment
+// It's useful when you configure tools like PostCSS in their own config files instead of in webpack.config.js.
+// process.env.NODE_ENV = Encore.isProduction() ? 'production' : 'development';
+
 // Manually configure the runtime environment if not already configured yet by the "encore" command.
 // It's useful when you use tools that rely on webpack.config.js file.
 if (!Encore.isRuntimeEnvironmentConfigured()) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

In a project I needed to enable PurgeCSS only when in production. This is done in postcss.config.js and there's no way to know if Encore is running in production or not. I asked on Slack and @lyrkan proposed this solution to me. It worked for me nicely!

As I think this could be useful to others, I propose this change in case it makes sense to make it in general for all projects.