### PR TITLE
Comment deprecation logs (Monolog)

### DIFF
--- a/symfony/monolog-bundle/3.3/config/packages/prod/monolog.yaml
+++ b/symfony/monolog-bundle/3.3/config/packages/prod/monolog.yaml
@@ -14,11 +14,13 @@ monolog:
             type: console
             process_psr_3_messages: false
             channels: ["!event", "!doctrine"]
-        deprecation:
-            type: stream
-            path: "%kernel.logs_dir%/%kernel.environment%.deprecations.log"
-        deprecation_filter:
-            type: filter
-            handler: deprecation
-            max_level: info
-            channels: ["php"]
+
+        # Uncomment to log deprecations
+        #deprecation:
+        #    type: stream
+        #    path: "%kernel.logs_dir%/%kernel.environment%.deprecations.log"
+        #deprecation_filter:
+        #    type: filter
+        #    handler: deprecation
+        #    max_level: info
+        #    channels: ["php"]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | n/a

I suggest that we comment the logging of deprecations in production. Depending on your application, it can fill your logs pretty fast, and we don't want such a thing to happen by default. Logging deprecations in prod should be a conscious decision IMHO.
