### PR TITLE
[symfony/framework-bundle] revert use of RoutingConfigurator from FrameworkBundle

### DIFF
--- a/symfony/framework-bundle/5.1/src/Kernel.php
+++ b/symfony/framework-bundle/5.1/src/Kernel.php
@@ -3,9 +3,9 @@
 namespace App;
 
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
-use Symfony\Bundle\FrameworkBundle\Routing\Loader\Configurator\RoutingConfigurator;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\HttpKernel\Kernel as BaseKernel;
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 
 class Kernel extends BaseKernel
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

This class has been reverted in 5.1.