### PR TITLE
Update mattermost-notifier: add documentation link

### DIFF
--- a/symfony/mattermost-notifier/5.1/manifest.json
+++ b/symfony/mattermost-notifier/5.1/manifest.json
@@ -1,5 +1,6 @@
 {
     "env": {
-        "#1": "MATTERMOST_DSN=mattermost://TOKEN@HOST?channel=CHANNEL"
+        "#1": "See https://docs.mattermost.com/developer/bot-accounts.html",
+        "#2": "MATTERMOST_DSN=mattermost://TOKEN@HOST?channel=CHANNEL_ID"
     }
 }


### PR DESCRIPTION
Mattermost notifier: add documentation link and use `CHANNEL_ID` as example value for channel, to avoid confusions with the parameter value needed there