### PR TITLE
fix(console): stop to require autoload twice

### DIFF
--- a/symfony/console/4.4/bin/console
+++ b/symfony/console/4.4/bin/console
@@ -12,7 +12,7 @@ if (!in_array(PHP_SAPI, ['cli', 'phpdbg', 'embed'], true)) {
 
 set_time_limit(0);
 
-require dirname(__DIR__).'/vendor/autoload.php';
+require dirname(__DIR__).'/config/bootstrap.php';
 
 if (!class_exists(Application::class)) {
     throw new LogicException('You need to add "symfony/framework-bundle" as a Composer dependency.');
@@ -26,8 +26,6 @@ if (null !== $env = $input->getParameterOption(['--env', '-e'], null, true)) {
 if ($input->hasParameterOption('--no-debug', true)) {
     putenv('APP_DEBUG='.$_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = '0');
 }
-
-require dirname(__DIR__).'/config/bootstrap.php';
 
 if ($_SERVER['APP_DEBUG']) {
     umask(0000);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT 

<!--
Please, carefully read the README before submitting a pull request.
-->

- because `config/boostrap.php` also requires autoload
- no need to apply this in `5.1` recipe because `config/bootstrap.php` has already been replaced with `Dotenv::bootEnv()`