### PR TITLE
Show region parameter in Mailgun mailer DSN

### DIFF
--- a/symfony/mailgun-mailer/4.4/manifest.json
+++ b/symfony/mailgun-mailer/4.4/manifest.json
@@ -1,6 +1,6 @@
 {
     "env": {
-        "#1": "MAILER_DSN=mailgun://KEY:DOMAIN@default",
+        "#1": "MAILER_DSN=mailgun://KEY:DOMAIN@default?region=us",
         "#2": "MAILER_DSN=mailgun+smtp://USERNAME:PASSWORD@default?region=us"
     }
 }


### PR DESCRIPTION
Region parameter was missing in api DSN

| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | symfony/symfony-docs#...    

<!--
Please, carefully read the README before submitting a pull request.
-->
