### PR TITLE
[phpunit-bridge] Changed bootEnv to loadEnv

### DIFF
--- a/symfony/phpunit-bridge/3.3/tests/bootstrap.php
+++ b/symfony/phpunit-bridge/3.3/tests/bootstrap.php
@@ -6,6 +6,6 @@ require dirname(__DIR__).'/vendor/autoload.php';
 
 if (file_exists(dirname(__DIR__).'/config/bootstrap.php')) {
     require dirname(__DIR__).'/config/bootstrap.php';
-} elseif (method_exists(Dotenv::class, 'bootEnv')) {
-    (new Dotenv())->bootEnv(dirname(__DIR__).'/.env');
+} elseif (method_exists(Dotenv::class, 'loadEnv')) {
+    (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | symfony/symfony-docs#...    

bootEnv is not supported anymore by symfony/dotenv