### PR TITLE
make it easier to enable experimental authenticators for 5.1

### DIFF
--- a/symfony/security-bundle/5.1/config/packages/security.yaml
+++ b/symfony/security-bundle/5.1/config/packages/security.yaml
@@ -1,4 +1,8 @@
 security:
+    # Enable the new experimental authenticators introduced in Symfony 5.1
+    # https://symfony.com/doc/current/security.html
+    enable_authenticator_manager: false
+
     # https://symfony.com/doc/current/security.html#where-do-users-come-from-user-providers
     providers:
         users_in_memory: { memory: null }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | 13704  

This should probably be merged after https://github.com/symfony/symfony-docs/pull/13704
