### PR TITLE
Add secret env to framework configuration

### DIFF
--- a/symfony/framework-bundle/5.1/config/packages
+++ b/symfony/framework-bundle/5.1/config/packages
@@ -1,0 +1,1 @@
+../../4.2/config/packages

--- a/symfony/framework-bundle/5.1/config/packages/cache.yaml
+++ b/symfony/framework-bundle/5.1/config/packages/cache.yaml
@@ -1,1 +1,0 @@
-../../../3.3/config/packages/cache.yaml

--- a/symfony/framework-bundle/5.1/config/packages/framework.yaml
+++ b/symfony/framework-bundle/5.1/config/packages/framework.yaml
@@ -1,4 +1,5 @@
 framework:
+    secret: '%env(APP_SECRET)%'
     #csrf_protection: true
     #http_method_override: true
 

--- a/symfony/framework-bundle/5.1/config/packages/framework.yaml
+++ b/symfony/framework-bundle/5.1/config/packages/framework.yaml
@@ -1,1 +1,0 @@
-../../../4.2/config/packages/framework.yaml

--- a/symfony/framework-bundle/5.1/config/packages/framework.yaml
+++ b/symfony/framework-bundle/5.1/config/packages/framework.yaml
@@ -1,16 +1,1 @@
-framework:
-    secret: '%env(APP_SECRET)%'
-    #csrf_protection: true
-    #http_method_override: true
-
-    # Enables session support. Note that the session will ONLY be started if you read or write from it.
-    # Remove or comment this section to explicitly disable session support.
-    session:
-        handler_id: null
-        cookie_secure: auto
-        cookie_samesite: lax
-
-    #esi: true
-    #fragments: true
-    php_errors:
-        log: true
+../../../4.2/config/packages/framework.yaml

--- a/symfony/framework-bundle/5.1/config/packages/test
+++ b/symfony/framework-bundle/5.1/config/packages/test
@@ -1,1 +1,0 @@
-../../../4.2/config/packages/test/


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

The `APP_SECRET` is defined but never set to the framework configuration.
