### PR TITLE
Allowing php config in the kernel

### DIFF
--- a/symfony/framework-bundle/5.1/src/Kernel.php
+++ b/symfony/framework-bundle/5.1/src/Kernel.php
@@ -15,14 +15,26 @@ class Kernel extends BaseKernel
     {
         $container->import('../config/{packages}/*.yaml');
         $container->import('../config/{packages}/'.$this->environment.'/*.yaml');
-        $container->import('../config/{services}.yaml');
-        $container->import('../config/{services}_'.$this->environment.'.yaml');
+
+        if (file_exists(\dirname(__DIR__).'/config/services.yaml')) {
+            $container->import('../config/{services}.yaml');
+            $container->import('../config/{services}_'.$this->environment.'.yaml');
+        } else {
+            $path = \dirname(__DIR__).'/config/services.php';
+            (require $path)($container->withPath($path), $this);
+        }
     }
 
     protected function configureRoutes(RoutingConfigurator $routes): void
     {
         $routes->import('../config/{routes}/'.$this->environment.'/*.yaml');
         $routes->import('../config/{routes}/*.yaml');
-        $routes->import('../config/{routes}.yaml');
+
+        if (file_exists(\dirname(__DIR__).'/config/routes.yaml')) {
+            $routes->import('../config/{routes}.yaml');
+        } else {
+            $path = \dirname(__DIR__).'/config/routes.php';
+            (require $path)($routes->withPath($path), $this);
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | not needed yet - will finish maker

This cherry-picks part of #765. We're working on a command to convert yml service files to php files over at symfony/maker-bundle#604. For this to work, the user's kernel needs to at least *allow* for PHP service files to be read.