### PR TITLE
Default to empty DATABASE_URL

### DIFF
--- a/doctrine/doctrine-bundle/2.0/config/packages/doctrine.yaml
+++ b/doctrine/doctrine-bundle/2.0/config/packages/doctrine.yaml
@@ -1,3 +1,6 @@
+parameters:
+    env(DATABASE_URL): ""
+
 doctrine:
     dbal:
         url: '%env(resolve:DATABASE_URL)%'


### PR DESCRIPTION
If using a common pattern to pre-warm the cache in Docker containers, this will instantly fail until set by the developer.

| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | symfony/symfony-docs#...    
