### PR TITLE
Leverage the new Runtime component

### DIFF
--- a/symfony/console/5.3/bin/console
+++ b/symfony/console/5.3/bin/console
@@ -1,0 +1,17 @@
+#!/usr/bin/env php
+<?php
+
+use App\Kernel;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+
+if (!is_file(dirname(__DIR__).'/vendor/autoload_runtime.php')) {
+    throw new LogicException('Symfony Runtime is missing. Try running "composer require symfony/runtime".');
+}
+
+require_once dirname(__DIR__).'/vendor/autoload_runtime.php';
+
+return function (array $context) {
+    $kernel = new Kernel($context['APP_ENV'], (bool) $context['APP_DEBUG']);
+
+    return new Application($kernel);
+};

--- a/symfony/console/5.3/manifest.json
+++ b/symfony/console/5.3/manifest.json
@@ -1,0 +1,6 @@
+{
+    "copy-from-recipe": {
+        "bin/": "%BIN_DIR%/"
+    },
+    "aliases": ["cli"]
+}

--- a/symfony/framework-bundle/5.3/public/index.php
+++ b/symfony/framework-bundle/5.3/public/index.php
@@ -1,22 +1,9 @@
 <?php
 
 use App\Kernel;
-use Symfony\Component\Dotenv\Dotenv;
-use Symfony\Component\ErrorHandler\Debug;
-use Symfony\Component\HttpFoundation\Request;
 
-require dirname(__DIR__).'/vendor/autoload.php';
+require_once dirname(__DIR__).'/vendor/autoload_runtime.php';
 
-(new Dotenv())->bootEnv(dirname(__DIR__).'/.env');
-
-if ($_SERVER['APP_DEBUG']) {
-    umask(0000);
-
-    Debug::enable();
-}
-
-$kernel = new Kernel($_SERVER['APP_ENV'], (bool) $_SERVER['APP_DEBUG']);
-$request = Request::createFromGlobals();
-$response = $kernel->handle($request);
-$response->send();
-$kernel->terminate($request, $response);
+return function (array $context) {
+    return new Kernel($context['APP_ENV'], (bool) $context['APP_DEBUG']);
+};


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

This recipe-update is a sidekick of https://github.com/symfony/symfony/pull/36652
As you can see, much of the logic has been removed from the recipe and moved to vendor/. This means it will be easier to upgrade such apps.