### PR TITLE
Add symlink for installed assets

### DIFF
--- a/symfony/framework-bundle/5.4/manifest.json
+++ b/symfony/framework-bundle/5.4/manifest.json
@@ -9,7 +9,7 @@
     },
     "composer-scripts": {
         "cache:clear": "symfony-cmd",
-        "assets:install %PUBLIC_DIR%": "symfony-cmd"
+        "assets:install %PUBLIC_DIR% --symlink --relative": "symfony-cmd"
     },
     "env": {
         "APP_ENV": "dev",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | symfony/symfony-docs#...    

I could not find out why this was changed so I thought it was just forgotten in the recipes that it most cases it better to install the assets with symlink as creating hard copies, like it was done in the older symfony [skeleton](https://github.com/symfony/symfony-standard/blob/cd07a8df72d611ac32aacde72b3cce2ac2f49783/composer.json#L61).
