### PR TITLE
Remove usages of relative paths from Kernel

### DIFF
--- a/symfony/framework-bundle/5.4/config/packages/cache.yaml
+++ b/symfony/framework-bundle/5.4/config/packages/cache.yaml
@@ -1,0 +1,19 @@
+framework:
+    cache:
+        # Unique name of your app: used to compute stable namespaces for cache keys.
+        #prefix_seed: your_vendor_name/app_name
+
+        # The "app" cache stores to the filesystem by default.
+        # The data in this cache should persist between deploys.
+        # Other options include:
+
+        # Redis
+        #app: cache.adapter.redis
+        #default_redis_provider: redis://localhost
+
+        # APCu (not recommended with heavy random-write workloads as memory fragmentation can cause perf issues)
+        #app: cache.adapter.apcu
+
+        # Namespaced pools use the above "app" backend by default
+        #pools:
+            #my.dedicated.cache: null

--- a/symfony/framework-bundle/5.4/config/packages/framework.yaml
+++ b/symfony/framework-bundle/5.4/config/packages/framework.yaml
@@ -1,0 +1,24 @@
+# see https://symfony.com/doc/current/reference/configuration/framework.html
+framework:
+    secret: '%env(APP_SECRET)%'
+    #csrf_protection: true
+    http_method_override: false
+
+    # Enables session support. Note that the session will ONLY be started if you read or write from it.
+    # Remove or comment this section to explicitly disable session support.
+    session:
+        handler_id: null
+        cookie_secure: auto
+        cookie_samesite: lax
+        storage_factory_id: session.storage.factory.native
+
+    #esi: true
+    #fragments: true
+    php_errors:
+        log: true
+
+when@test:
+    framework:
+        test: true
+        session:
+            storage_factory_id: session.storage.factory.mock_file

--- a/symfony/framework-bundle/5.4/config/preload.php
+++ b/symfony/framework-bundle/5.4/config/preload.php
@@ -1,0 +1,5 @@
+<?php
+
+if (file_exists(dirname(__DIR__).'/var/cache/prod/App_KernelProdContainer.preload.php')) {
+    require dirname(__DIR__).'/var/cache/prod/App_KernelProdContainer.preload.php';
+}

--- a/symfony/framework-bundle/5.4/config/routes/framework.yaml
+++ b/symfony/framework-bundle/5.4/config/routes/framework.yaml
@@ -1,0 +1,4 @@
+when@dev:
+    _errors:
+        resource: '@FrameworkBundle/Resources/config/routing/errors.xml'
+        prefix: /_error

--- a/symfony/framework-bundle/5.4/config/services.yaml
+++ b/symfony/framework-bundle/5.4/config/services.yaml
@@ -1,0 +1,25 @@
+# This file is the entry point to configure your own services.
+# Files in the packages/ subdirectory configure your dependencies.
+
+# Put parameters here that don't need to change on each machine where the app is deployed
+# https://symfony.com/doc/current/best_practices.html#use-parameters-for-application-configuration
+parameters:
+
+services:
+    # default configuration for services in *this* file
+    _defaults:
+        autowire: true      # Automatically injects dependencies in your services.
+        autoconfigure: true # Automatically registers your services as commands, event subscribers, etc.
+
+    # makes classes in src/ available to be used as services
+    # this creates a service per class whose id is the fully-qualified class name
+    App\:
+        resource: '../src/'
+        exclude:
+            - '../src/DependencyInjection/'
+            - '../src/Entity/'
+            - '../src/Kernel.php'
+            - '../src/Tests/'
+
+    # add more service definitions when explicit configuration is needed
+    # please note that last definitions always *replace* previous ones

--- a/symfony/framework-bundle/5.4/manifest.json
+++ b/symfony/framework-bundle/5.4/manifest.json
@@ -1,0 +1,27 @@
+{
+    "bundles": {
+        "Symfony\\Bundle\\FrameworkBundle\\FrameworkBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/",
+        "public/": "%PUBLIC_DIR%/",
+        "src/": "%SRC_DIR%/"
+    },
+    "composer-scripts": {
+        "cache:clear": "symfony-cmd",
+        "assets:install %PUBLIC_DIR%": "symfony-cmd"
+    },
+    "env": {
+        "APP_ENV": "dev",
+        "APP_SECRET": "%generate(secret)%"
+    },
+    "gitignore": [
+        "/.env.local",
+        "/.env.local.php",
+        "/.env.*.local",
+        "/%CONFIG_DIR%/secrets/prod/prod.decrypt.private.php",
+        "/%PUBLIC_DIR%/bundles/",
+        "/%VAR_DIR%/",
+        "/vendor/"
+    ]
+}

--- a/symfony/framework-bundle/5.4/post-install.txt
+++ b/symfony/framework-bundle/5.4/post-install.txt
@@ -1,0 +1,10 @@
+<bg=blue;fg=white>              </>
+<bg=blue;fg=white> What's next? </>
+<bg=blue;fg=white>              </>
+
+  * <fg=blue>Run</> your application:
+    1. Go to the project directory
+    2. Create your code repository with the <comment>git init</comment> command
+    3. Download the Symfony CLI at <comment>https://symfony.com/download</> to install a development web server
+
+  * <fg=blue>Read</> the documentation at <comment>https://symfony.com/doc</>

--- a/symfony/framework-bundle/5.4/public/index.php
+++ b/symfony/framework-bundle/5.4/public/index.php
@@ -1,0 +1,9 @@
+<?php
+
+use App\Kernel;
+
+require_once dirname(__DIR__).'/vendor/autoload_runtime.php';
+
+return function (array $context) {
+    return new Kernel($context['APP_ENV'], (bool) $context['APP_DEBUG']);
+};

--- a/symfony/framework-bundle/5.4/src/Kernel.php
+++ b/symfony/framework-bundle/5.4/src/Kernel.php
@@ -13,26 +13,30 @@ class Kernel extends BaseKernel
 
     protected function configureContainer(ContainerConfigurator $container): void
     {
-        $container->import('../config/{packages}/*.yaml');
-        $container->import('../config/{packages}/'.$this->environment.'/*.yaml');
+        $projectDir = $this->getProjectDir();
+
+        $container->import($projectDir.'/config/{packages}/*.yaml');
+        $container->import($projectDir.'/config/{packages}/'.$this->environment.'/*.yaml');
 
         if (is_file(\dirname(__DIR__).'/config/services.yaml')) {
-            $container->import('../config/services.yaml');
-            $container->import('../config/{services}_'.$this->environment.'.yaml');
+            $container->import($projectDir.'/config/services.yaml');
+            $container->import($projectDir.'/config/{services}_'.$this->environment.'.yaml');
         } else {
-            $container->import('../config/{services}.php');
+            $container->import($projectDir.'/config/{services}.php');
         }
     }
 
     protected function configureRoutes(RoutingConfigurator $routes): void
     {
-        $routes->import('../config/{routes}/'.$this->environment.'/*.yaml');
-        $routes->import('../config/{routes}/*.yaml');
+        $projectDir = $this->getProjectDir();
+
+        $routes->import($projectDir.'/config/{routes}/'.$this->environment.'/*.yaml');
+        $routes->import($projectDir.'/config/{routes}/*.yaml');
 
         if (is_file(\dirname(__DIR__).'/config/routes.yaml')) {
-            $routes->import('../config/routes.yaml');
+            $routes->import($projectDir.'/config/routes.yaml');
         } else {
-            $routes->import('../config/{routes}.php');
+            $routes->import($projectDir.'/config/{routes}.php');
         }
     }
 }

--- a/symfony/framework-bundle/5.4/src/Kernel.php
+++ b/symfony/framework-bundle/5.4/src/Kernel.php
@@ -18,7 +18,7 @@ class Kernel extends BaseKernel
         $container->import($projectDir.'/config/{packages}/*.yaml');
         $container->import($projectDir.'/config/{packages}/'.$this->environment.'/*.yaml');
 
-        if (is_file(\dirname(__DIR__).'/config/services.yaml')) {
+        if (is_file($projectDir.'/config/services.yaml')) {
             $container->import($projectDir.'/config/services.yaml');
             $container->import($projectDir.'/config/{services}_'.$this->environment.'.yaml');
         } else {
@@ -33,7 +33,7 @@ class Kernel extends BaseKernel
         $routes->import($projectDir.'/config/{routes}/'.$this->environment.'/*.yaml');
         $routes->import($projectDir.'/config/{routes}/*.yaml');
 
-        if (is_file(\dirname(__DIR__).'/config/routes.yaml')) {
+        if (is_file($projectDir.'/config/routes.yaml')) {
             $routes->import($projectDir.'/config/routes.yaml');
         } else {
             $routes->import($projectDir.'/config/{routes}.php');

--- a/symfony/framework-bundle/5.4/src/Kernel.php
+++ b/symfony/framework-bundle/5.4/src/Kernel.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App;
+
+use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Component\HttpKernel\Kernel as BaseKernel;
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+
+class Kernel extends BaseKernel
+{
+    use MicroKernelTrait;
+
+    protected function configureContainer(ContainerConfigurator $container): void
+    {
+        $container->import('../config/{packages}/*.yaml');
+        $container->import('../config/{packages}/'.$this->environment.'/*.yaml');
+
+        if (is_file(\dirname(__DIR__).'/config/services.yaml')) {
+            $container->import('../config/services.yaml');
+            $container->import('../config/{services}_'.$this->environment.'.yaml');
+        } else {
+            $container->import('../config/{services}.php');
+        }
+    }
+
+    protected function configureRoutes(RoutingConfigurator $routes): void
+    {
+        $routes->import('../config/{routes}/'.$this->environment.'/*.yaml');
+        $routes->import('../config/{routes}/*.yaml');
+
+        if (is_file(\dirname(__DIR__).'/config/routes.yaml')) {
+            $routes->import('../config/routes.yaml');
+        } else {
+            $routes->import('../config/{routes}.php');
+        }
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | n/a

This PR changes the Kernel for two reasons:
 * consistency
 * using relative paths breaks when extending the Kernel

I was doing the latter for testing purposes (I want to import some configurations only in certain tests, not in all the `test` environment) and it breaks under this situation.

If this gets merged, maybe we could consider backporting it to older recipes too?
