### PR TITLE
Introduce APP_VAULT to select the set of secrets to use for a specific deployment

### DIFF
--- a/symfony/framework-bundle/4.2/config/packages/test
+++ b/symfony/framework-bundle/4.2/config/packages/test
@@ -1,0 +1,1 @@
+../../../3.3/config/packages/test/

--- a/symfony/framework-bundle/4.2/config/packages/test/framework.yaml
+++ b/symfony/framework-bundle/4.2/config/packages/test/framework.yaml
@@ -1,4 +1,0 @@
-framework:
-    test: true
-    session:
-        storage_id: session.storage.mock_file

--- a/symfony/framework-bundle/5.1/config/packages
+++ b/symfony/framework-bundle/5.1/config/packages
@@ -1,1 +1,0 @@
-../../4.2/config/packages

--- a/symfony/framework-bundle/5.1/config/packages/cache.yaml
+++ b/symfony/framework-bundle/5.1/config/packages/cache.yaml
@@ -1,0 +1,1 @@
+../../../3.3/config/packages/cache.yaml

--- a/symfony/framework-bundle/5.1/config/packages/framework.yaml
+++ b/symfony/framework-bundle/5.1/config/packages/framework.yaml
@@ -1,0 +1,21 @@
+# see https://symfony.com/doc/current/reference/configuration/framework.html
+framework:
+    secret: '%env(APP_SECRET)%'
+    #csrf_protection: true
+    #http_method_override: true
+
+    secrets:
+        # set the APP_VAULT env var to override the directory where secrets are stored
+        vault_directory: '%kernel.project_dir%/config/secrets/%env(default:kernel.environment:APP_VAULT)%'
+
+    # Enables session support. Note that the session will ONLY be started if you read or write from it.
+    # Remove or comment this section to explicitly disable session support.
+    session:
+        handler_id: null
+        cookie_secure: auto
+        cookie_samesite: lax
+
+    #esi: true
+    #fragments: true
+    php_errors:
+        log: true

--- a/symfony/framework-bundle/5.1/config/packages/test
+++ b/symfony/framework-bundle/5.1/config/packages/test
@@ -1,0 +1,1 @@
+../../../3.3/config/packages/test/


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

The Symfony env is not enough to precisely configure the set of secrets to use for a specific deployment.
E.g. you might want to deploy a staging target in "prod" mode, but with a test-mode set of API credentials.

The proposed configuration allows doing so via a new `APP_VAULT` env var. It defaults to `APP_ENV` so that nothing changes without explicit opt-in.