### PR TITLE
Put migrations back in src/Migrations/

### DIFF
--- a/doctrine/doctrine-migrations-bundle/2.2/config/packages/doctrine_migrations.yaml
+++ b/doctrine/doctrine-migrations-bundle/2.2/config/packages/doctrine_migrations.yaml
@@ -2,4 +2,4 @@ doctrine_migrations:
     migrations_paths:
         # namespace is arbitrary but should be different from App\Migrations
         # as migrations classes should NOT be autoloaded
-        'DoctrineMigrations': '%kernel.project_dir%/migrations'
+        'DoctrineMigrations': '%kernel.project_dir%/src/Migrations'

--- a/doctrine/doctrine-migrations-bundle/2.2/manifest.json
+++ b/doctrine/doctrine-migrations-bundle/2.2/manifest.json
@@ -4,7 +4,7 @@
     },
     "copy-from-recipe": {
         "config/": "%CONFIG_DIR%/",
-        "migrations/": "migrations/"
+        "src/": "%SRC_DIR%/"
     },
     "aliases": ["doctrine-migrations", "migrations"]
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

Changing this directory made the recipes incompatible with the-fast-track book.
Since the book is an important asset for the community, we'd better not break it.

Changes https://github.com/symfony/recipes/pull/729
Invalidates https://github.com/symfony/recipes/issues/718