### PR TITLE
Update services.yaml

### DIFF
--- a/symfony/framework-bundle/5.1/config/services.yaml
+++ b/symfony/framework-bundle/5.1/config/services.yaml
@@ -1,1 +1,27 @@
-../../4.2/config/services.yaml
+# This file is the entry point to configure your own services.
+# Files in the packages/ subdirectory configure your dependencies.
+
+# Put parameters here that don't need to change on each machine where the app is deployed
+# https://symfony.com/doc/current/best_practices/configuration.html#application-related-configuration
+parameters:
+
+services:
+    # default configuration for services in *this* file
+    _defaults:
+        autowire: true      # Automatically injects dependencies in your services.
+        autoconfigure: true # Automatically registers your services as commands, event subscribers, etc.
+
+    # makes classes in src/ available to be used as services
+    # this creates a service per class whose id is the fully-qualified class name
+    App\:
+        resource: '../src/*'
+        exclude: '../src/{DependencyInjection,Entity,Tests,Kernel.php}'
+
+    # controllers are imported separately to make sure services can be injected
+    # as action arguments even if you don't extend any base controller class
+    App\Controller\:
+        resource: '../src/Controller'
+        tags: ['controller.service_arguments']
+
+    # add more service definitions when explicit configuration is needed
+    # please note that last definitions always *replace* previous ones


### PR DESCRIPTION
Hello,

I just remove the `Migrations` directory from the exclude. 
Since 5.1, this directory has been moved outside of `src`.
I just talked with @javiereguiluz and he agrees.

I can also update the docs if you want.

Cheers 😉
