### PR TITLE
[FrameworkBundle] Use an array for exclude directive

### DIFF
--- a/symfony/framework-bundle/4.2/config/services.yaml
+++ b/symfony/framework-bundle/4.2/config/services.yaml
@@ -14,7 +14,7 @@ services:
     # makes classes in src/ available to be used as services
     # this creates a service per class whose id is the fully-qualified class name
     App\:
-        resource: '../src/*'
+        resource: '../src/'
         exclude:
             - '../src/DependencyInjection/'
             - '../src/Entity/'
@@ -24,7 +24,7 @@ services:
     # controllers are imported separately to make sure services can be injected
     # as action arguments even if you don't extend any base controller class
     App\Controller\:
-        resource: '../src/Controller'
+        resource: '../src/Controller/'
         tags: ['controller.service_arguments']
 
     # add more service definitions when explicit configuration is needed

--- a/symfony/framework-bundle/4.2/config/services.yaml
+++ b/symfony/framework-bundle/4.2/config/services.yaml
@@ -15,7 +15,11 @@ services:
     # this creates a service per class whose id is the fully-qualified class name
     App\:
         resource: '../src/*'
-        exclude: '../src/{DependencyInjection,Entity,Tests,Kernel.php}'
+        exclude:
+            - '../src/DependencyInjection/'
+            - '../src/Entity/'
+            - '../src/Kernel.php'
+            - '../src/Tests/'
 
     # controllers are imported separately to make sure services can be injected
     # as action arguments even if you don't extend any base controller class


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  |

IMHO, this notation is easier to understand. More over it scales really
better. Finally this notation is not documented on the [following
page](https://symfony.com/doc/current/service_container.html)