### PR TITLE
Tweaking phpunit post-install message to give more information/context

### DIFF
--- a/phpunit/phpunit/4.7/post-install.txt
+++ b/phpunit/phpunit/4.7/post-install.txt
@@ -8,4 +8,4 @@ See: https://symfony.com/doc/current/components/phpunit_bridge.html.
 
   * <fg=blue>To install the PHPUnit bridge</>:
     1. Remove PHPUnit: <comment>composer remove --dev phpunit/phpunit</>
-    2. Install Symfony's bridge: <comment>composer require --dev phpunit</>
+    2. Install Symfony's bridge: <comment>composer require --dev symfony/phpunit-bridge</>

--- a/phpunit/phpunit/4.7/post-install.txt
+++ b/phpunit/phpunit/4.7/post-install.txt
@@ -1,7 +1,11 @@
-<bg=yellow;fg=black>                                                                                             </>
-<bg=yellow;fg=black> Adding phpunit/phpunit as a dependency is discouraged in favor of Symfony's PHPUnit Bridge. </>
-<bg=yellow;fg=black>                                                                                             </>
+<bg=yellow;fg=black>                                                                      </>
+<bg=yellow;fg=black> Suggest: install Symfony's PHPUnit Bridge instead of phpunit/phpunit </>
+<bg=yellow;fg=black>                                                                      </>
 
-  * <fg=blue>Instead</>:
-    1. Remove it now: <comment>composer remove --dev phpunit/phpunit</>
-    2. Use Symfony's bridge: <comment>composer require --dev phpunit</>
+Symfony's PHPUnit bridge is a wrapper around PHPUnit that adds reports for deprecated code
+calls, an isolated PHPUnit that's separate from the dependencies of your app and more.
+See: https://symfony.com/doc/current/components/phpunit_bridge.html.
+
+  * <fg=blue>To install the PHPUnit bridge</>:
+    1. Remove PHPUnit: <comment>composer remove --dev phpunit/phpunit</>
+    2. Install Symfony's bridge: <comment>composer require --dev phpunit</>

--- a/phpunit/phpunit/4.7/post-install.txt
+++ b/phpunit/phpunit/4.7/post-install.txt
@@ -6,6 +6,6 @@ Symfony's PHPUnit bridge is a wrapper around PHPUnit that adds reports for depre
 calls, an isolated PHPUnit that's separate from the dependencies of your app and more.
 See: https://symfony.com/doc/current/components/phpunit_bridge.html.
 
-  * <fg=blue>To install the PHPUnit bridge</>:
+  * <fg=blue>If you want to install the PHPUnit bridge</>:
     1. Remove PHPUnit: <comment>composer remove --dev phpunit/phpunit</>
     2. Install Symfony's bridge: <comment>composer require --dev symfony/phpunit-bridge</>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | not needed

The previous message appears to some people like Symfony is trying to "force" people what to do or to replace PHPUnit. 

In reality, the goal is to make sure the user is aware that - to follow the "documented path" - the bridge is available. But if they still want to install PHPUnit, that's totally fine.

<img width="1200" alt="Screen Shot 2020-08-19 at 9 16 40 AM" src="https://user-images.githubusercontent.com/121003/90639491-bb622100-e1fc-11ea-8159-1b80bc11f574.png">


Related to: https://github.com/symfony/symfony/issues/27289 and https://twitter.com/Ocramius/status/1293169839582973952