### PR TITLE
[DoctrineFixturesBundle] Update ObjectManager old namespace

### DIFF
--- a/doctrine/doctrine-fixtures-bundle/3.0/src/DataFixtures/AppFixtures.php
+++ b/doctrine/doctrine-fixtures-bundle/3.0/src/DataFixtures/AppFixtures.php
@@ -3,7 +3,7 @@
 namespace App\DataFixtures;
 
 use Doctrine\Bundle\FixturesBundle\Fixture;
-use Doctrine\Persistence\ObjectManager;
+use Doctrine\Common\Persistence\ObjectManager;
 
 class AppFixtures extends Fixture
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

I just noticed that the recipe is pointing to the old namespace of the `ObjectManager` class
