### PR TITLE
Resolve deprecation message for symfony/dotenv 5.1

### DIFF
--- a/symfony/framework-bundle/4.2/config/bootstrap.php
+++ b/symfony/framework-bundle/4.2/config/bootstrap.php
@@ -8,13 +8,19 @@ if (!class_exists(Dotenv::class)) {
     throw new LogicException('Please run "composer require symfony/dotenv" to load the ".env" files configuring the application.');
 }
 
+if (method_exists(Dotenv::class, 'usePutenv')) {
+    $dotenv = new Dotenv();
+} else {
+    $dotenv = new Dotenv(false);
+}
+
 // Load cached env vars if the .env.local.php file exists
 // Run "composer dump-env prod" to create it (requires symfony/flex >=1.2)
 if (is_array($env = @include dirname(__DIR__).'/.env.local.php') && (!isset($env['APP_ENV']) || ($_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? $env['APP_ENV']) === $env['APP_ENV'])) {
-    (new Dotenv(false))->populate($env);
+    $dotenv->populate($env);
 } else {
     // load all the .env files
-    (new Dotenv(false))->loadEnv(dirname(__DIR__).'/.env');
+    $dotenv->loadEnv(dirname(__DIR__).'/.env');
 }
 
 $_SERVER += $_ENV;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | n/a

Dotenv component doesn't allow anymore constructor to be called with a boolean to set on/off the use of putenv.
This PR avoid the deprecation to be triggered as it is done in this commit from symfony flex (https://github.com/symfony/flex/commit/1bf83d4678ed937a77438ae681aa97d6ad4c1094#diff-b0bd3a5ec4048cca5e142d072c4a290b).

<!--
Please, carefully read the README before submitting a pull request.
-->
