### PR TITLE
Add recipe for symfony/requirements-checker 2.0

### DIFF
--- a/symfony/requirements-checker/2.0/manifest.json
+++ b/symfony/requirements-checker/2.0/manifest.json
@@ -1,0 +1,6 @@
+{
+    "composer-scripts": {
+        "requirements-checker": "script"
+    },
+    "aliases": ["requirement-check", "requirement-checker", "req-checker", "req-check", "req-checks"]
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

The public/check.php file was removed in requirements-checker 2.0.