### PR TITLE
Added an empty recipe for EA3

### DIFF
--- a/easycorp/easyadmin-bundle/3.0/manifest.json
+++ b/easycorp/easyadmin-bundle/3.0/manifest.json
@@ -1,0 +1,6 @@
+{
+    "bundles": {
+        "EasyCorp\\Bundle\\EasyAdminBundle\\EasyAdminBundle": ["all"]
+    },
+    "aliases": ["admin-gen", "admin-generator", "admin"]
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -


As discussed in #827 EA3 doesn't need a recipe, but EA2 defined one, so we need to create an empty recipe to nullify the existing one.