### PR TITLE
Restore deprecation filter for Symfony versions prior 5.1

### DIFF
--- a/symfony/monolog-bundle/3.1/config/packages/prod/deprecations.yaml
+++ b/symfony/monolog-bundle/3.1/config/packages/prod/deprecations.yaml
@@ -1,4 +1,5 @@
 # As of Symfony 5.1, deprecations are logged in the dedicated "deprecation" channel when it exists
+# Please remove deprecation and deprecation_filter in monolog.yaml to use this handler
 #monolog:
 #    channels: [deprecation]
 #    handlers:

--- a/symfony/monolog-bundle/3.1/config/packages/prod/monolog.yaml
+++ b/symfony/monolog-bundle/3.1/config/packages/prod/monolog.yaml
@@ -16,3 +16,11 @@ monolog:
             type: console
             process_psr_3_messages: false
             channels: ["!event", "!doctrine"]
+        deprecation:
+            type: stream
+            path: "%kernel.logs_dir%/%kernel.environment%.deprecations.log"
+        deprecation_filter:
+            type: filter
+            handler: deprecation
+            max_level: info
+            channels: ["php"]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  |    

Related to https://github.com/symfony/recipes/pull/775#issuecomment-697953963

Deprecations handler with filter should not be removed since it's still needed for Kernel/Fwb versions < 5.1.