### PR TITLE
[Messenger] Let failed transport DNS depend on environment variable

### DIFF
--- a/symfony/messenger/4.3/config/packages/messenger.yaml
+++ b/symfony/messenger/4.3/config/packages/messenger.yaml
@@ -6,7 +6,7 @@ framework:
         transports:
             # https://symfony.com/doc/current/messenger.html#transport-configuration
             # async: '%env(MESSENGER_TRANSPORT_DSN)%'
-            # failed: 'doctrine://default?queue_name=failed'
+            # failed: '%env(MESSENGER_TRANSPORT_DSN)%?queue_name=failed'
             # sync: 'sync://'
 
         routing:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | https://github.com/symfony/symfony-docs/pull/14519

To me, it didn't make sense to have the async transport be based on an environment variable, while having the failed transport hardcoded. So I thought, having both depend on the same environment variable, with the queue name added for the failed transport made more sense.