### PR TITLE
Allow PHP config in /packages and /routes folders

### DIFF
--- a/symfony/framework-bundle/5.1/src/Kernel.php
+++ b/symfony/framework-bundle/5.1/src/Kernel.php
@@ -13,7 +13,9 @@ class Kernel extends BaseKernel
 
     protected function configureContainer(ContainerConfigurator $container): void
     {
+        $container->import('../config/{packages}/*.php');
         $container->import('../config/{packages}/*.yaml');
+        $container->import('../config/{packages}/'.$this->environment.'/*.php');
         $container->import('../config/{packages}/'.$this->environment.'/*.yaml');
 
         if (is_file(\dirname(__DIR__).'/config/services.yaml')) {
@@ -26,7 +28,9 @@ class Kernel extends BaseKernel
 
     protected function configureRoutes(RoutingConfigurator $routes): void
     {
+        $routes->import('../config/{routes}/'.$this->environment.'/*.php');
         $routes->import('../config/{routes}/'.$this->environment.'/*.yaml');
+        $routes->import('../config/{routes}/*.php');
         $routes->import('../config/{routes}/*.yaml');
 
         if (is_file(\dirname(__DIR__).'/config/routes.yaml')) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | #805

The kernel has logic to load yaml and php config files, but ignores the `.php` config in the `packages/*` and `routes/*` folders.