### PR TITLE
Always log application specific logs by default

### DIFF
--- a/symfony/monolog-bundle/3.1/config/packages/prod/monolog.yaml
+++ b/symfony/monolog-bundle/3.1/config/packages/prod/monolog.yaml
@@ -8,6 +8,7 @@ monolog:
             excluded_404s:
                 # regex: exclude all 404 errors from the logs
                 - ^/
+            channels: ["!app"]
         nested:
             type: stream
             path: "%kernel.logs_dir%/%kernel.environment%.log"
@@ -16,3 +17,7 @@ monolog:
             type: console
             process_psr_3_messages: false
             channels: ["!event", "!doctrine"]
+        app:
+            type: stream
+            path: "%kernel.logs_dir%/%kernel.environment%-app.log"
+            channels: ["app"]

--- a/symfony/monolog-bundle/3.3/config/packages/prod/monolog.yaml
+++ b/symfony/monolog-bundle/3.3/config/packages/prod/monolog.yaml
@@ -6,6 +6,7 @@ monolog:
             handler: nested
             excluded_http_codes: [404, 405]
             buffer_size: 50 # How many messages should be saved? Prevent memory leaks
+            channels: ["!app"]
         nested:
             type: stream
             path: "%kernel.logs_dir%/%kernel.environment%.log"
@@ -14,3 +15,7 @@ monolog:
             type: console
             process_psr_3_messages: false
             channels: ["!event", "!doctrine"]
+        app:
+            type: stream
+            path: "%kernel.logs_dir%/%kernel.environment%-app.log"
+            channels: ["app"]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | symfony/symfony-docs#...    

Current default ignores ALL logs where there was no error in a HTTP request. This is not good, because it means any application specific logging, eg. the ones tied to business logic, is not recorded.

I would like to change that and hence have more sane logging by default. I don't think people expect that if they do `$this->logger->log(...)` in their service, it won't be logged in production. I would think that only framework/library diagnostic logs should not logged by default.


This PR solves that. Application using this proposed config will have all logs recorded that was created via `$this->logger->log(...)`, but old logging behaviour for rest of the logs is preserved.