### PR TITLE
listing mysql, pgsql and sqlite DATABASE_URL examples in .env

### DIFF
--- a/doctrine/doctrine-bundle/1.12/config/packages/doctrine.yaml
+++ b/doctrine/doctrine-bundle/1.12/config/packages/doctrine.yaml
@@ -4,7 +4,7 @@ doctrine:
 
         # IMPORTANT: You MUST configure your server version,
         # either here or in the DATABASE_URL env var (see .env file)
-        #server_version: '5.7'
+        #server_version: '13'
 
         # only needed for MySQL
         charset: utf8mb4

--- a/doctrine/doctrine-bundle/1.6/config/packages/doctrine.yaml
+++ b/doctrine/doctrine-bundle/1.6/config/packages/doctrine.yaml
@@ -4,7 +4,7 @@ doctrine:
 
         # IMPORTANT: You MUST configure your server version,
         # either here or in the DATABASE_URL env var (see .env file)
-        #server_version: '5.7'
+        #server_version: '13'
 
         # only needed for MySQL
         charset: utf8mb4

--- a/doctrine/doctrine-bundle/1.6/manifest.json
+++ b/doctrine/doctrine-bundle/1.6/manifest.json
@@ -8,9 +8,10 @@
     },
     "env": {
         "#1": "Format described at https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url",
-        "#2": "For an SQLite database, use: \"sqlite:///%kernel.project_dir%/var/data.db\"",
-        "#3": "For a MySQL database, use: \"mysql://db_user:db_password@127.0.0.1:3306/db_name?serverVersion=5.7\"",
-        "#4": "IMPORTANT: You MUST configure your server version, either here or in config/packages/doctrine.yaml",
+        "#2": "IMPORTANT: You MUST configure your server version, either here or in config/packages/doctrine.yaml",
+        "#3": "",
+        "#4": "DATABASE_URL=\"sqlite:///%kernel.project_dir%/var/data.db\"",
+        "#5": "DATABASE_URL=\"mysql://db_user:db_password@127.0.0.1:3306/db_name?serverVersion=5.7\"",
         "DATABASE_URL": "postgresql://db_user:db_password@127.0.0.1:5432/db_name?serverVersion=13&charset=utf8"
     },
     "dockerfile": [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | (Wouter is already checking into some related changes from #113)

This changes the `.env` to this:

```
###> doctrine/doctrine-bundle ###
# Format described at https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url
# IMPORTANT: You MUST configure your server version, either here or in config/packages/doctrine.yaml
#
# DATABASE_URL="sqlite:///%kernel.project_dir%/var/data.db"
# DATABASE_URL="mysql://db_user:db_password@127.0.0.1:3306/db_name?serverVersion=5.7"
DATABASE_URL="postgresql://db_user:db_password@127.0.0.1:5432/db_name?serverVersion=13&charset=utf8"
###< doctrine/doctrine-bundle ###
```