### PR TITLE
[nelmio/cors-bundle] Fix CORS_ALLOW_ORIGIN format

### DIFF
--- a/nelmio/cors-bundle/1.5/manifest.json
+++ b/nelmio/cors-bundle/1.5/manifest.json
@@ -6,7 +6,7 @@
         "config/": "%CONFIG_DIR%/"
     },
     "env": {
-        "CORS_ALLOW_ORIGIN": "^https?://(localhost|127\\.0\\.0\\.1)(:[0-9]+)?$"
+        "CORS_ALLOW_ORIGIN": "'^https?://(localhost|127\\.0\\.0\\.1)(:[0-9]+)?$'"
     },
     "aliases": ["cors"]
 }


### PR DESCRIPTION
- Wrap value between simple quotes: avoid shell error when sourcing `.env` file

| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

Fixes symfony/recipes#848  

<!--
Please, carefully read the README before submitting a pull request.
-->
