### PR TITLE
[symfony/mercure-bundle] remove the Docker Compose service

### DIFF
--- a/symfony/mercure-bundle/0.1/manifest.json
+++ b/symfony/mercure-bundle/0.1/manifest.json
@@ -11,23 +11,5 @@
         "#2": "The default token is signed with the secret key: !ChangeMe!",
         "MERCURE_JWT_TOKEN": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJtZXJjdXJlIjp7InB1Ymxpc2giOltdfX0.Oo0yg7y4yMa1vr_bziltxuTCqb8JVHKxp-f_FwwOim0"
     },
-    "docker-compose": {
-        "docker-compose.yml": {
-            "services": [
-                "mercure:",
-                "  # In production, you may want to use the managed version of Mercure, https://mercure.rocks",
-                "  image: dunglas/mercure",
-                "  environment:",
-                "    # You should definitely change all these values in production",
-                "    - JWT_KEY=!ChangeMe!",
-                "    - ALLOW_ANONYMOUS=1",
-                "    - CORS_ALLOWED_ORIGINS=*",
-                "    - PUBLISH_ALLOWED_ORIGINS=http://localhost:1337",
-                "    - DEMO=1",
-                "  ports:",
-                "    - \"1337:80\""
-            ]
-        }
-    },
     "aliases": ["mercure"]
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | todo

Mercure is now available as a Caddy server module, which is shipped by default by Symfony Docker (https://github.com/dunglas/symfony-docker/pull/89), and will be soon in API Platform.

This service isn't necessary anymore.