### PR TITLE
[panther] add Chrome and ChromeDriver to the Dockerfile

### DIFF
--- a/symfony/panther/1.0/manifest.json
+++ b/symfony/panther/1.0/manifest.json
@@ -1,0 +1,16 @@
+{
+    "dockerfile": [
+        "# Chromium and ChromeDriver",
+        "ENV PANTHER_NO_SANDBOX 1",
+        "# Not mandatory, but recommended",
+        "ENV PANTHER_CHROME_ARGUMENTS='--disable-dev-shm-usage'",
+        "RUN apk add --no-cache chromium chromium-chromedriver",
+        "",
+        "# Firefox and GeckoDriver",
+        "#ARG GECKODRIVER_VERSION=0.29.0",
+        "#RUN apk add --no-cache firefox",
+        "#RUN wget -q https://github.com/mozilla/geckodriver/releases/download/v$GECKODRIVER_VERSION/geckodriver-v$GECKODRIVER_VERSION-linux64.tar.gz; \\",
+        "#\ttar -zxf geckodriver-v$GECKODRIVER_VERSION-linux64.tar.gz -C /usr/bin; \\",
+        "#\trm geckodriver-v$GECKODRIVER_VERSION-linux64.tar.gz"
+    ]
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | n/a

Companion PR of symfony/panther#399: automatically adds Chrome and ChromeDriver in the Docker image when installing Panther.
