### PR TITLE
remove "array_syntax" option in php-cs-fixer configuration

### DIFF
--- a/friendsofphp/php-cs-fixer/2.16/.php_cs.dist
+++ b/friendsofphp/php-cs-fixer/2.16/.php_cs.dist
@@ -1,0 +1,13 @@
+<?php
+
+$finder = PhpCsFixer\Finder::create()
+    ->in(__DIR__)
+    ->exclude('var')
+;
+
+return PhpCsFixer\Config::create()
+    ->setRules([
+        '@Symfony' => true,
+    ])
+    ->setFinder($finder)
+;

--- a/friendsofphp/php-cs-fixer/2.16/manifest.json
+++ b/friendsofphp/php-cs-fixer/2.16/manifest.json
@@ -1,0 +1,10 @@
+{
+    "aliases": ["cs-fixer", "php-cs-fixer"],
+    "copy-from-recipe": {
+        ".php_cs.dist": ".php_cs.dist"
+    },
+    "gitignore": [
+        "/.php_cs",
+        "/.php_cs.cache"
+    ]
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | none

Since version 2.16.0, `@Symfony` ruleset is including `array_syntax` option. So, such option is not needed any more.
