### PR TITLE
Cleanup Kernel & services.yaml files

### DIFF
--- a/symfony/framework-bundle/5.3/config/packages
+++ b/symfony/framework-bundle/5.3/config/packages
@@ -1,0 +1,1 @@
+../../4.2/config/packages

--- a/symfony/framework-bundle/5.3/config/preload.php
+++ b/symfony/framework-bundle/5.3/config/preload.php
@@ -1,0 +1,1 @@
+../../5.1/config/preload.php

--- a/symfony/framework-bundle/5.3/config/routes
+++ b/symfony/framework-bundle/5.3/config/routes
@@ -1,0 +1,1 @@
+../../4.4/config/routes/

--- a/symfony/framework-bundle/5.3/config/services.yaml
+++ b/symfony/framework-bundle/5.3/config/services.yaml
@@ -1,0 +1,24 @@
+# This file is the entry point to configure your own services.
+# Files in the packages/ subdirectory configure your dependencies.
+
+# See https://symfony.com/doc/current/best_practices.html#configuration
+parameters:
+
+services:
+    # default configuration for services in *this* file
+    _defaults:
+        autowire: true      # Automatically injects dependencies in your services.
+        autoconfigure: true # Automatically registers your services as commands, event subscribers, etc.
+
+    # makes classes in src/ available to be used as services
+    # this creates a service per class whose id is the fully-qualified class name
+    App\:
+        resource: '../src/'
+        exclude:
+            - '../src/DependencyInjection/'
+            - '../src/Entity/'
+            - '../src/Kernel.php'
+            - '../src/Tests/'
+
+    # add more service definitions when explicit configuration is needed
+    # please note that last definitions always *replace* previous ones

--- a/symfony/framework-bundle/5.3/manifest.json
+++ b/symfony/framework-bundle/5.3/manifest.json
@@ -1,0 +1,1 @@
+../4.2/manifest.json

--- a/symfony/framework-bundle/5.3/post-install.txt
+++ b/symfony/framework-bundle/5.3/post-install.txt
@@ -1,0 +1,1 @@
+../4.2/post-install.txt

--- a/symfony/framework-bundle/5.3/src/Kernel.php
+++ b/symfony/framework-bundle/5.3/src/Kernel.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App;
+
+use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Component\HttpKernel\Kernel as BaseKernel;
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+
+class Kernel extends BaseKernel
+{
+    use MicroKernelTrait;
+
+    protected function configureContainer(ContainerConfigurator $container): void
+    {
+        $container->import('../config/packages/{,'.$this->environment.'/}*.yaml');
+        $container->import('../config/services{,_'.$this->environment.'}.yaml');
+    }
+
+    protected function configureRoutes(RoutingConfigurator $routes): void
+    {
+        $routes->import('../config/routes/{'.$this->environment.'/,}*.yaml');
+        $routes->import('../config/routes{_'.$this->environment.',}.yaml');
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

As shown in #872 and #765, we're not ready yet for defaulting to PHP config files.

This PR reverts #785 (/cc @weaverryan), which was motivated by https://github.com/symfony/maker-bundle/pull/604, which's got closed eventually.

Let's keep things simple.