### PR TITLE
Updating package.json and bootstrap.js for upcoming stimulus-bridge

### DIFF
--- a/symfony/webpack-encore-bundle/1.0/assets/bootstrap.js
+++ b/symfony/webpack-encore-bundle/1.0/assets/bootstrap.js
@@ -3,5 +3,6 @@ import { startStimulusApp } from '@symfony/stimulus-bridge';
 // Registers Stimulus controllers from controllers.json and in the controllers/ directory
 export const app = startStimulusApp(require.context(
     '@symfony/stimulus-bridge/lazy-controller-loader!./controllers',
-    true, /\.(j|t)sx?$/
+    true,
+    /\.(j|t)sx?$/
 ));

--- a/symfony/webpack-encore-bundle/1.0/assets/bootstrap.js
+++ b/symfony/webpack-encore-bundle/1.0/assets/bootstrap.js
@@ -1,5 +1,7 @@
 import { startStimulusApp } from '@symfony/stimulus-bridge';
-import '@symfony/autoimport';
 
 // Registers Stimulus controllers from controllers.json and in the controllers/ directory
-export const app = startStimulusApp(require.context('./controllers', true, /\.(j|t)sx?$/));
+export const app = startStimulusApp(require.context(
+    '@symfony/stimulus-bridge/lazy-controller-loader!./controllers',
+    true, /\.(j|t)sx?$/
+));

--- a/symfony/webpack-encore-bundle/1.0/package.json
+++ b/symfony/webpack-encore-bundle/1.0/package.json
@@ -1,6 +1,6 @@
 {
     "devDependencies": {
-        "@symfony/stimulus-bridge": "^1.1.0",
+        "@symfony/stimulus-bridge": "^2.0.0",
         "@symfony/webpack-encore": "^1.0.0",
         "core-js": "^3.0.0",
         "regenerator-runtime": "^0.13.2",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | It appears nothing is needed

This is waiting on:
* [x] Waiting on the 1.2.0 tags to make it to the sub-tree splits of the UX packages - e.g. https://github.com/symfony/ux-chartjs/tags
* [x] Merge of https://github.com/symfony/stimulus-bridge/pull/19
* [x] Release of symfony/stimulus-bridge
* [x] Release of @symfony/webpack-encore

This affects all version of WebpackEncoreBundle... but it's an odd case where the bundle and Webpack encore itself are not very "bound" together. We could update this recipe in only the latest WebpackEncoreBundle version... or even bump a new minor version of the bundle and add it there. This relates to https://github.com/symfony/recipes#updating-recipes

