### PR TITLE
bumping to encore 1.0

### DIFF
--- a/symfony/webpack-encore-bundle/1.0/package.json
+++ b/symfony/webpack-encore-bundle/1.0/package.json
@@ -1,7 +1,7 @@
 {
     "devDependencies": {
         "@symfony/stimulus-bridge": "^1.1.0",
-        "@symfony/webpack-encore": "^0.32.0",
+        "@symfony/webpack-encore": "^1.0.0",
         "core-js": "^3.0.0",
         "regenerator-runtime": "^0.13.2",
         "stimulus": "^2.0.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | Not needed

Webpack Encore 1.0 was just released 🌟 

PR #883 is now just for the upcoming stimulus-bridge release.