### PR TITLE
switching var to const to be more modern

### DIFF
--- a/symfony/webpack-encore-bundle/1.0/webpack.config.js
+++ b/symfony/webpack-encore-bundle/1.0/webpack.config.js
@@ -1,4 +1,4 @@
-var Encore = require('@symfony/webpack-encore');
+const Encore = require('@symfony/webpack-encore');
 
 // Manually configure the runtime environment if not already configured yet by the "encore" command.
 // It's useful when you use tools that rely on webpack.config.js file.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | WIP - I'm reviewing all the Encore docs currently

I originally (4 years ago) used `var` because `const` were still relatively new and not necessarily known widely. I think that's not true anymore, so let's use the more modern `const.

Cheers!
