### PR TITLE
symfony/phpunit-bridge: set umask(0000) when debug is true

### DIFF
--- a/symfony/phpunit-bridge/3.3/tests/bootstrap.php
+++ b/symfony/phpunit-bridge/3.3/tests/bootstrap.php
@@ -9,3 +9,7 @@ if (file_exists(dirname(__DIR__).'/config/bootstrap.php')) {
 } elseif (method_exists(Dotenv::class, 'bootEnv')) {
     (new Dotenv())->bootEnv(dirname(__DIR__).'/.env');
 }
+
+if ($_SERVER['APP_DEBUG']) {
+    umask(0000);
+}

--- a/symfony/phpunit-bridge/4.1/tests/bootstrap.php
+++ b/symfony/phpunit-bridge/4.1/tests/bootstrap.php
@@ -9,3 +9,7 @@ if (file_exists(dirname(__DIR__).'/config/bootstrap.php')) {
 } elseif (method_exists(Dotenv::class, 'bootEnv')) {
     (new Dotenv())->bootEnv(dirname(__DIR__).'/.env');
 }
+
+if ($_SERVER['APP_DEBUG']) {
+    umask(0000);
+}

--- a/symfony/phpunit-bridge/4.3/tests/bootstrap.php
+++ b/symfony/phpunit-bridge/4.3/tests/bootstrap.php
@@ -9,3 +9,7 @@ if (file_exists(dirname(__DIR__).'/config/bootstrap.php')) {
 } elseif (method_exists(Dotenv::class, 'bootEnv')) {
     (new Dotenv())->bootEnv(dirname(__DIR__).'/.env');
 }
+
+if ($_SERVER['APP_DEBUG']) {
+    umask(0000);
+}

--- a/symfony/phpunit-bridge/5.1/tests/bootstrap.php
+++ b/symfony/phpunit-bridge/5.1/tests/bootstrap.php
@@ -9,3 +9,7 @@ if (file_exists(dirname(__DIR__).'/config/bootstrap.php')) {
 } elseif (method_exists(Dotenv::class, 'bootEnv')) {
     (new Dotenv())->bootEnv(dirname(__DIR__).'/.env');
 }
+
+if ($_SERVER['APP_DEBUG']) {
+    umask(0000);
+}

--- a/symfony/phpunit-bridge/5.3/tests/bootstrap.php
+++ b/symfony/phpunit-bridge/5.3/tests/bootstrap.php
@@ -9,3 +9,7 @@ if (file_exists(dirname(__DIR__).'/config/bootstrap.php')) {
 } elseif (method_exists(Dotenv::class, 'bootEnv')) {
     (new Dotenv())->bootEnv(dirname(__DIR__).'/.env');
 }
+
+if ($_SERVER['APP_DEBUG']) {
+    umask(0000);
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

When running functional tests with an empty cache (no directory), the cache directory is created. I run my tests with `APP_DEBUG=1`. I expect the cache directory to be created with the same permissions whether it is created from the tests or from a real request on the front controller. Currently, running the tests and then accessing the application lead to unexpected permissions errors.

Ref https://github.com/symfony/recipes/pull/210