### PR TITLE
Register a new "ux" alias

### DIFF
--- a/symfony/webpack-encore-bundle/1.0/manifest.json
+++ b/symfony/webpack-encore-bundle/1.0/manifest.json
@@ -8,7 +8,7 @@
         "package.json": "package.json",
         "webpack.config.js": "webpack.config.js"
     },
-    "aliases": ["encore", "webpack", "webpack-encore"],
+    "aliases": ["ux", "encore", "webpack", "webpack-encore"],
     "gitignore": [
         "/node_modules/",
         "/%PUBLIC_DIR%/build/",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | n/a

Currently, it's not obvious how to start using Symfony DX. Actually the "entrypoint" of Symfony UX is Webpack Encore. I suggest adding a new alias to Encore to provide an easy step to get started with Symfony UX: `composer req ux`.

Companion PR of #890.