### PR TITLE
[doctrine/doctrine-bundle/2.0] Update post-install.txt for postgresql

### DIFF
--- a/doctrine/doctrine-bundle/2.0/post-install.txt
+++ b/doctrine/doctrine-bundle/2.0/post-install.txt
@@ -1,1 +1,8 @@
-../1.6/post-install.txt
+<bg=blue;fg=white>                        </>
+<bg=blue;fg=white> Database Configuration </>
+<bg=blue;fg=white>                        </>
+
+  * Modify your DATABASE_URL config in <fg=green>.env</>
+
+  * Configure the <fg=green>driver</> (postgresql) and
+    <fg=green>server_version</> (13) in <fg=green>config/packages/doctrine.yaml</>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | symfony/symfony-docs#...    

doctrine/doctrine-bundle/2.0/post-install.txt was not changed for postgresql in https://github.com/symfony/recipes/pull/113/commits/6a91adfe6230f753d0175bcdbdba6e0f673acdd2. This PR unlinks previous https://github.com/symfony/recipes/blob/master/doctrine/doctrine-bundle/1.6/post-install.txt and provides updated messages