### PR TITLE
monolog: log on stderr and use JSON in prod

### DIFF
--- a/symfony/monolog-bundle/3.7/config/packages/dev/monolog.yaml
+++ b/symfony/monolog-bundle/3.7/config/packages/dev/monolog.yaml
@@ -1,0 +1,19 @@
+monolog:
+    handlers:
+        main:
+            type: stream
+            path: php://stderr
+            level: debug
+            channels: ["!event"]
+        # uncomment to get logging in your browser
+        # you may have to allow bigger header sizes in your Web server configuration
+        #firephp:
+        #    type: firephp
+        #    level: info
+        #chromephp:
+        #    type: chromephp
+        #    level: info
+        console:
+            type: console
+            process_psr_3_messages: false
+            channels: ["!event", "!doctrine", "!console"]

--- a/symfony/monolog-bundle/3.7/config/packages/prod/deprecations.yaml
+++ b/symfony/monolog-bundle/3.7/config/packages/prod/deprecations.yaml
@@ -1,0 +1,8 @@
+# As of Symfony 5.1, deprecations are logged in the dedicated "deprecation" channel when it exists
+#monolog:
+#    channels: [deprecation]
+#    handlers:
+#        deprecation:
+#            type: stream
+#            channels: [deprecation]
+#            path: php://stderr

--- a/symfony/monolog-bundle/3.7/config/packages/prod/monolog.yaml
+++ b/symfony/monolog-bundle/3.7/config/packages/prod/monolog.yaml
@@ -1,0 +1,17 @@
+monolog:
+    handlers:
+        main:
+            type: fingers_crossed
+            action_level: error
+            handler: nested
+            excluded_http_codes: [404, 405]
+            buffer_size: 50 # How many messages should be saved? Prevent memory leaks
+        nested:
+            type: stream
+            path: php://stderr
+            level: debug
+            formatter: monolog.formatter.json
+        console:
+            type: console
+            process_psr_3_messages: false
+            channels: ["!event", "!doctrine"]

--- a/symfony/monolog-bundle/3.7/config/packages/test
+++ b/symfony/monolog-bundle/3.7/config/packages/test
@@ -1,0 +1,1 @@
+../../../3.3/config/packages/test

--- a/symfony/monolog-bundle/3.7/manifest.json
+++ b/symfony/monolog-bundle/3.7/manifest.json
@@ -1,0 +1,1 @@
+../3.3/manifest.json


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | todo

Follows https://symfony.com/blog/logging-in-symfony-and-the-cloud and https://github.com/api-platform/api-platform/pull/1805.

Logging on `stderr` is considered a best practice in most containerized environments including SymfonyCloud, Docker and Kubernetes. It looks like the best default for new projects.

This PR also changes the default format used in production to JSON to improve the compatibility with modern logging systems such as ELK, EFK or DataDog (and even when using the command-line thanks to `jq`).

I targeted MonologBundle 3.7 to not impact existing installations.