### PR TITLE
[FrameworkBundle] Replace deprecated `storage_id` by `storage_factory…

### DIFF
--- a/symfony/framework-bundle/5.3/config/packages/test/framework.yaml
+++ b/symfony/framework-bundle/5.3/config/packages/test/framework.yaml
@@ -1,4 +1,4 @@
 framework:
     test: true
     session:
-        storage_id: session.storage.mock_file
+        storage_factory_id: session.storage.mock_file


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | 

related to (not-merged-yet PR https://github.com/symfony/symfony/pull/40048)