### PR TITLE
get mock storage from the factory

### DIFF
--- a/symfony/framework-bundle/5.3/config/packages/test/framework.yaml
+++ b/symfony/framework-bundle/5.3/config/packages/test/framework.yaml
@@ -1,4 +1,4 @@
 framework:
     test: true
     session:
-        storage_factory_id: session.storage.mock_file
+        storage_factory_id: session.storage.factory.mock_file


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | https://github.com/symfony/symfony/issues/40282

Get the session storage mock file from the storage factory. Possible solution for #40282
