### PR TITLE
Add zenstruck/foundry

### DIFF
--- a/zenstruck/foundry/1.9/config/packages/dev/zenstruck_foundry.yaml
+++ b/zenstruck/foundry/1.9/config/packages/dev/zenstruck_foundry.yaml
@@ -1,0 +1,4 @@
+# See full configuration: https://github.com/zenstruck/foundry#full-default-bundle-configuration
+zenstruck_foundry:
+    # Whether to auto-refresh proxies by default (https://github.com/zenstruck/foundry#auto-refresh)
+    auto_refresh_proxies: true

--- a/zenstruck/foundry/1.9/config/packages/test/zenstruck_foundry.yaml
+++ b/zenstruck/foundry/1.9/config/packages/test/zenstruck_foundry.yaml
@@ -1,0 +1,5 @@
+# Unless you want different configuration for test/dev environments,
+# add configuration to config/packages/dev/zenstruck_foundry.yml
+# and this will be synced to your test environment.
+imports:
+    - { resource: ../dev/zenstruck_foundry.yaml }

--- a/zenstruck/foundry/1.9/manifest.json
+++ b/zenstruck/foundry/1.9/manifest.json
@@ -1,0 +1,8 @@
+{
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "bundles": {
+        "Zenstruck\\Foundry\\ZenstruckFoundryBundle": ["dev", "test"]
+    }
+}

--- a/zenstruck/foundry/1.9/post-install.txt
+++ b/zenstruck/foundry/1.9/post-install.txt
@@ -1,0 +1,8 @@
+<bg=blue;fg=white>              </>
+<bg=blue;fg=white> What's next? </>
+<bg=blue;fg=white>              </>
+
+  * You're ready to use zenstruck/foundry. Create your first factory with
+    <info>bin/console make:factory</>.
+
+  * <fg=blue>Read</> the documentation at <comment>https://github.com/zenstruck/foundry#foundry</>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | symfony/symfony-docs#14731

Based on slack discussions with @weaverryan & @wouterj.

Foundry has the concept of [auto-refreshing entities](https://github.com/zenstruck/foundry#auto-refresh) - prior to 1.9, this was disabled by default as there are caveats (entity changes silently lost). In 1.9, the caveats still exist but we were [able to throw a helpful exception](https://github.com/zenstruck/foundry/pull/131). We would now like auto-refreshing entities enabled by default but this would be a BC break in 1.x. A recipe to enable in 1.x was decided as the next best thing.

The double config is unfortunate but we couldn't think of a better way.

Likely we'll want a `post-install.txt` and probably some config comments?