### PR TITLE
CS Fixer: Don't use the deprecated create method

### DIFF
--- a/friendsofphp/php-cs-fixer/2.17/.php_cs.dist
+++ b/friendsofphp/php-cs-fixer/2.17/.php_cs.dist
@@ -1,0 +1,13 @@
+<?php
+
+$finder = (new PhpCsFixer\Finder())
+    ->in(__DIR__)
+    ->exclude('var')
+;
+
+return (new PhpCsFixer\Config())
+    ->setRules([
+        '@Symfony' => true,
+    ])
+    ->setFinder($finder)
+;

--- a/friendsofphp/php-cs-fixer/2.17/manifest.json
+++ b/friendsofphp/php-cs-fixer/2.17/manifest.json
@@ -1,0 +1,10 @@
+{
+    "aliases": ["cs-fixer", "php-cs-fixer"],
+    "copy-from-recipe": {
+        ".php_cs.dist": ".php_cs.dist"
+    },
+    "gitignore": [
+        "/.php_cs",
+        "/.php_cs.cache"
+    ]
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | N/A

Follows FriendsOfPHP/PHP-CS-Fixer#4828