### PR TITLE
Allow .php config files (and others) to be loaded in the Kernel by default.

### DIFF
--- a/symfony/framework-bundle/5.3/src/Kernel.php
+++ b/symfony/framework-bundle/5.3/src/Kernel.php
@@ -11,10 +11,12 @@ class Kernel extends BaseKernel
 {
     use MicroKernelTrait;
 
+    private const CONFIG_EXTS = '{php,xml,yaml,yml}';
+
     protected function configureContainer(ContainerConfigurator $container): void
     {
-        $container->import('../config/{packages}/*.yaml');
-        $container->import('../config/{packages}/'.$this->environment.'/*.yaml');
+        $container->import('../config/{packages}/*.' . self::CONFIG_EXTS);
+        $container->import('../config/{packages}/'.$this->environment.'/*.' . self::CONFIG_EXTS);
 
         if (is_file(\dirname(__DIR__).'/config/services.yaml')) {
             $container->import('../config/services.yaml');
@@ -26,8 +28,8 @@ class Kernel extends BaseKernel
 
     protected function configureRoutes(RoutingConfigurator $routes): void
     {
-        $routes->import('../config/{routes}/'.$this->environment.'/*.yaml');
-        $routes->import('../config/{routes}/*.yaml');
+        $routes->import('../config/{routes}/'.$this->environment.'/*.' . self::CONFIG_EXTS);
+        $routes->import('../config/{routes}/*.' . self::CONFIG_EXTS);
 
         if (is_file(\dirname(__DIR__).'/config/routes.yaml')) {
             $routes->import('../config/routes.yaml');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | symfony/symfony-docs#...    

I'd like to suggest a partial rollback of this [PR](https://github.com/symfony/recipes/pull/705) by @nicolas-grekas. Since both Symfony [internally](https://github.com/symfony/symfony/issues/37186) and the [community](https://tomasvotruba.com/blog/2020/07/16/10-cool-features-you-get-after-switching-from-yaml-to-php-configs/) are moving in the direction of PHP configs, I feel like it'd be nice to allow these out-of-the-box when using the framework bundle. 

Right now if you switch to PHP config files, either manually or by using a [tool](https://github.com/symplify/config-transformer), you end up with a broken Symfony app. If we import .php config files in the default kernel, this would work straight away.

My apologies if this PR is misplaced in any way, it is my first attempt to contribute and I couldn't quite figure out which repo I had to submit the PR to.