### PR TITLE
[symfony/framework-bundle/5.3] remove "controller.service_arguments"

### DIFF
--- a/symfony/framework-bundle/5.3/config/services.yaml
+++ b/symfony/framework-bundle/5.3/config/services.yaml
@@ -21,11 +21,5 @@ services:
             - '../src/Kernel.php'
             - '../src/Tests/'
 
-    # controllers are imported separately to make sure services can be injected
-    # as action arguments even if you don't extend any base controller class
-    App\Controller\:
-        resource: '../src/Controller/'
-        tags: ['controller.service_arguments']
-
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

These lines are hard to explain and understand, and they cover advanced use cases.
Let's keep things simple.
Also, this use case should be better covered by https://github.com/symfony/symfony/pull/40555 in the future.