### PR TITLE
Routing: don't require to install doctrine/annotations to use attributes

### DIFF
--- a/symfony/routing/6.0/config/packages/routing.yaml
+++ b/symfony/routing/6.0/config/packages/routing.yaml
@@ -1,0 +1,12 @@
+framework:
+    router:
+        utf8: true
+
+        # Configure how to generate URLs in non-HTTP contexts, such as CLI commands.
+        # See https://symfony.com/doc/current/routing.html#generating-urls-in-commands
+        #default_uri: http://localhost
+
+when@prod:
+    framework:
+        router:
+            strict_requirements: null

--- a/symfony/routing/6.0/config/routes.yaml
+++ b/symfony/routing/6.0/config/routes.yaml
@@ -1,0 +1,7 @@
+controllers:
+    resource: ../src/Controller/
+    type: annotation
+
+kernel:
+    resource: ../src/Kernel.php
+    type: annotation

--- a/symfony/routing/6.0/manifest.json
+++ b/symfony/routing/6.0/manifest.json
@@ -1,0 +1,6 @@
+{
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "aliases": ["router"]
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | n/a

Currently, installing `doctrine/annotations` is needed to be able to use the `#[Route()]` PHP 8 attribute. It'unfortunate because attributes can work out of the box and this dependency is not needed with PHP 8.

This PR enables "annotation" support (actually attribute support) by default, even if `doctrine/annotations` isn't installed.
This PR targets Symfony 5.3 as it's a new feature. A side effect will be that the default skeleton will not work by default with PHP 7, but IMHO it's not a big issue because most new projects using Symfony 5.3 should use PHP 8. Also, this moves the ecosystem forward.