### PR TITLE
MercureBundle: use the URL exposed by Symfony CLI by default

### DIFF
--- a/symfony/mercure-bundle/0.1/manifest.json
+++ b/symfony/mercure-bundle/0.1/manifest.json
@@ -7,7 +7,7 @@
     },
     "env": {
         "#1": "See https://symfony.com/doc/current/mercure.html#configuration",
-        "MERCURE_PUBLISH_URL": "http://mercure/.well-known/mercure",
+        "MERCURE_PUBLISH_URL": "https://127.0.0.1:8000/.well-known/mercure",
         "#2": "The default token is signed with the secret key: !ChangeMe!",
         "MERCURE_JWT_TOKEN": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJtZXJjdXJlIjp7InB1Ymxpc2giOltdfX0.Oo0yg7y4yMa1vr_bziltxuTCqb8JVHKxp-f_FwwOim0"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | n/a

Use the built-in hub of Symfony CLI by default.