### PR TITLE
MercureBundle: add support for v0.3

### DIFF
--- a/symfony/mercure-bundle/0.3/config/packages/mercure.yaml
+++ b/symfony/mercure-bundle/0.3/config/packages/mercure.yaml
@@ -1,7 +1,8 @@
 mercure:
-    enable_profiler: '%kernel.debug%'
     hubs:
         default:
             url: '%env(MERCURE_URL)%'
             public_url: '%env(MERCURE_PUBLIC_URL)%'
-            jwt: '%env(MERCURE_JWT_TOKEN)%'
+            jwt:
+                secret: '%env(MERCURE_JWT_SECRET)%'
+                publish: '*'

--- a/symfony/mercure-bundle/0.3/config/packages/mercure.yaml
+++ b/symfony/mercure-bundle/0.3/config/packages/mercure.yaml
@@ -1,0 +1,7 @@
+mercure:
+    enable_profiler: '%kernel.debug%'
+    hubs:
+        default:
+            url: '%env(MERCURE_URL)%'
+            public_url: '%env(MERCURE_PUBLIC_URL)%'
+            jwt: '%env(MERCURE_JWT_TOKEN)%'

--- a/symfony/mercure-bundle/0.3/manifest.json
+++ b/symfony/mercure-bundle/0.3/manifest.json
@@ -1,0 +1,1 @@
+../0.1/manifest.json

--- a/symfony/mercure-bundle/0.3/manifest.json
+++ b/symfony/mercure-bundle/0.3/manifest.json
@@ -1,1 +1,18 @@
-../0.1/manifest.json
+{
+    "bundles": {
+        "Symfony\\Bundle\\MercureBundle\\MercureBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "env": {
+        "#1": "See https://symfony.com/doc/current/mercure.html#configuration",
+        "#2": "The URL of the Mercure hub, used by the app to publish updates (can be a local URL)",
+        "MERCURE_URL": "https://127.0.0.1:8000/.well-known/mercure",
+        "#3": "The public URL of the Mercure hub, used by the browser to connect",
+        "MERCURE_PUBLIC_URL": "https://127.0.0.1:8000/.well-known/mercure",
+        "#4": "The secret used to sign the JWTs",
+        "MERCURE_JWT_SECRET": "!ChangeMe!"
+    },
+    "aliases": ["mercure"]
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | todo

Add support for MercureBundle 0.3 (to be tagged soon). This change allows using for publication and subscription. This especially useful in production and when using Docker, so you send requests to the hub using the network from PHP (like `http://hub/.well-known/mercure`, but subscribe using a public from the JS code (`https://hub.example.com/.well-known/mercure`).

See also https://github.com/symfony/recipes/pull/917.

cc @azjezz