### PR TITLE
Fix deprecation in 5.3' session config

### DIFF
--- a/symfony/framework-bundle/5.3/config/packages/framework.yaml
+++ b/symfony/framework-bundle/5.3/config/packages/framework.yaml
@@ -10,6 +10,7 @@ framework:
         handler_id: null
         cookie_secure: auto
         cookie_samesite: lax
+        storage_factory_id: session.storage.factory.native
 
     #esi: true
     #fragments: true


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  |  -

This fixes the following notice on symfony/framework-bundle:5.3-dev

 > Since symfony/framework-bundle 5.3: Not setting the "framework.session.storage_factory_id" configuration option is deprecated, it will default to "session.storage.factory.native" and will replace the "framework.session.storage_id" configuration option in version 6.0.

/cc @jderusse 