### PR TITLE
[Doctrine Migrations] Enable new profiler by default in development

### DIFF
--- a/doctrine/doctrine-migrations-bundle/3.1/config/packages/doctrine_migrations.yaml
+++ b/doctrine/doctrine-migrations-bundle/3.1/config/packages/doctrine_migrations.yaml
@@ -1,0 +1,6 @@
+doctrine_migrations:
+    migrations_paths:
+        # namespace is arbitrary but should be different from App\Migrations
+        # as migrations classes should NOT be autoloaded
+        'DoctrineMigrations': '%kernel.project_dir%/migrations'
+    enable_profiler: '%kernel.debug%'

--- a/doctrine/doctrine-migrations-bundle/3.1/manifest.json
+++ b/doctrine/doctrine-migrations-bundle/3.1/manifest.json
@@ -1,0 +1,10 @@
+{
+    "bundles": {
+        "Doctrine\\Bundle\\MigrationsBundle\\DoctrineMigrationsBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/",
+        "migrations/": "migrations/"
+    },
+    "aliases": ["doctrine-migrations", "migrations"]
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Related  | https://github.com/doctrine/DoctrineMigrationsBundle/pull/407    

~Will be updated after release of doctrine migrations 3.1~
Release: https://github.com/doctrine/DoctrineMigrationsBundle/releases/tag/3.1.0