### PR TITLE
Wrong comment in doctrine/doctrine-bundle 2.3 recipe

### DIFF
--- a/doctrine/doctrine-bundle/2.3/config/packages/test/doctrine.yaml
+++ b/doctrine/doctrine-bundle/2.3/config/packages/test/doctrine.yaml
@@ -1,7 +1,7 @@
 #doctrine:
 #    dbal:
 #        # Overrides the database name in the test environment only
-#        # "host", "port", "username", & "password" can also be set to override their respective url parts
+#        # "host", "port", "user", & "password" can also be set to override their respective url parts
 #        #
 #        # If you're using ParaTest, "TEST_TOKEN" is set by ParaTest otherwise nothing is appended to the database name.
 #        dbname: main_test%env(default::TEST_TOKEN)%


### PR DESCRIPTION
 Unrecognized option "username" under "doctrine.dbal.connections.default"

| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | symfony/symfony-docs#...    

<!--
Please, carefully read the README before submitting a pull request.
-->
