### PR TITLE
Log in var/log in dev

### DIFF
--- a/symfony/monolog-bundle/3.7/config/packages/dev/monolog.yaml
+++ b/symfony/monolog-bundle/3.7/config/packages/dev/monolog.yaml
@@ -2,7 +2,7 @@ monolog:
     handlers:
         main:
             type: stream
-            path: php://stderr
+            path: "%kernel.logs_dir%/%kernel.environment%.log"
             level: debug
             channels: ["!event"]
         # uncomment to get logging in your browser


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

This PR partially reverts a change done in #894: logging on stderr by default in the dev env breaks the DX, because the output of console commands becomes a mess, with log line mangling the command's output.