### PR TITLE
Update recipe for PHP-CS-Fixer 2.19.0 and 3.0.0

### DIFF
--- a/friendsofphp/php-cs-fixer/2.19/.php-cs-fixer.dist.php
+++ b/friendsofphp/php-cs-fixer/2.19/.php-cs-fixer.dist.php
@@ -10,5 +10,5 @@ return (new PhpCsFixer\Config())
         '@Symfony' => true,
     ])
     ->setFinder($finder)
-    ->setCacheFile(".php-cs-fixer.cache") // forward compatibility with 3.x line
+    ->setCacheFile('.php-cs-fixer.cache') // forward compatibility with 3.x line
 ;

--- a/friendsofphp/php-cs-fixer/2.19/.php-cs-fixer.dist.php
+++ b/friendsofphp/php-cs-fixer/2.19/.php-cs-fixer.dist.php
@@ -1,0 +1,13 @@
+<?php
+
+$finder = (new PhpCsFixer\Finder())
+    ->in(__DIR__)
+    ->exclude('var')
+;
+
+return (new PhpCsFixer\Config())
+    ->setRules([
+        '@Symfony' => true,
+    ])
+    ->setFinder($finder)
+;

--- a/friendsofphp/php-cs-fixer/2.19/.php-cs-fixer.dist.php
+++ b/friendsofphp/php-cs-fixer/2.19/.php-cs-fixer.dist.php
@@ -10,4 +10,5 @@ return (new PhpCsFixer\Config())
         '@Symfony' => true,
     ])
     ->setFinder($finder)
+    ->setCacheFile(".php-cs-fixer.cache") // forward compatibility with 3.x line
 ;

--- a/friendsofphp/php-cs-fixer/2.19/manifest.json
+++ b/friendsofphp/php-cs-fixer/2.19/manifest.json
@@ -1,0 +1,10 @@
+{
+    "aliases": ["cs-fixer", "php-cs-fixer"],
+    "copy-from-recipe": {
+        ".php-cs-fixer.dist.php": ".php-cs-fixer.dist.php"
+    },
+    "gitignore": [
+        "/.php-cs-fixer.php",
+        "/.php_cs.cache"
+    ]
+}

--- a/friendsofphp/php-cs-fixer/2.19/manifest.json
+++ b/friendsofphp/php-cs-fixer/2.19/manifest.json
@@ -5,6 +5,6 @@
     },
     "gitignore": [
         "/.php-cs-fixer.php",
-        "/.php_cs.cache"
+        "/.php-cs-fixer.cache"
     ]
 }

--- a/friendsofphp/php-cs-fixer/2.19/manifest.json
+++ b/friendsofphp/php-cs-fixer/2.19/manifest.json
@@ -5,6 +5,6 @@
     },
     "gitignore": [
         "/.php-cs-fixer.php",
-        "/.php-cs-fixer.cache"
+        "/.php_cs.cache"
     ]
 }

--- a/friendsofphp/php-cs-fixer/3.0/.php-cs-fixer.dist.php
+++ b/friendsofphp/php-cs-fixer/3.0/.php-cs-fixer.dist.php
@@ -1,0 +1,13 @@
+<?php
+
+$finder = (new PhpCsFixer\Finder())
+    ->in(__DIR__)
+    ->exclude('var')
+;
+
+return (new PhpCsFixer\Config())
+    ->setRules([
+        '@Symfony' => true,
+    ])
+    ->setFinder($finder)
+;

--- a/friendsofphp/php-cs-fixer/3.0/manifest.json
+++ b/friendsofphp/php-cs-fixer/3.0/manifest.json
@@ -1,0 +1,10 @@
+{
+    "aliases": ["cs-fixer", "php-cs-fixer"],
+    "copy-from-recipe": {
+        ".php-cs-fixer.dist.php": ".php-cs-fixer.dist.php"
+    },
+    "gitignore": [
+        "/.php-cs-fixer.php",
+        "/.php-cs-fixer.cache"
+    ]
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | symfony/symfony-docs#...    

Following https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/tag/v2.19.0

More specific:

[minor #5607 DX: new config filename (keradus)](https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/5607)

cc @keradus
