### PR TITLE
Suggest data-turbo-track="reload" attribute for Turbo users in Encore

### DIFF
--- a/symfony/webpack-encore-bundle/1.9/config/packages/webpack_encore.yaml
+++ b/symfony/webpack-encore-bundle/1.9/config/packages/webpack_encore.yaml
@@ -7,7 +7,12 @@ webpack_encore:
     # Set attributes that will be rendered on all script and link tags
     script_attributes:
         defer: true
+        # Uncomment (also under link_attributes) if using Turbo Drive
+        # https://turbo.hotwire.dev/handbook/drive#reloading-when-assets-change
+        # 'data-turbo-track': reload
     # link_attributes:
+        # Uncomment if using Turbo Drive
+        # 'data-turbo-track': reload
 
     # If using Encore.enableIntegrityHashes() and need the crossorigin attribute (default: false, or use 'anonymous' or 'use-credentials')
     # crossorigin: 'anonymous'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | TODO

This should be... just this simple! We should have a `data-turbo-track` on our `script` and `link` tags. The result is that, when the versioned filename changes, the full page will refresh.

Ref: https://turbo.hotwire.dev/handbook/drive#reloading-when-assets-change

Thanks!
