### PR TITLE
[symfony/security-bundle:5.3] Enable authenticator security by default

### DIFF
--- a/symfony/security-bundle/5.3/config/packages/security.yaml
+++ b/symfony/security-bundle/5.3/config/packages/security.yaml
@@ -1,0 +1,25 @@
+security:
+    # https://symfony.com/doc/current/security/experimental_authenticators.html
+    enable_authenticator_manager: true
+    # https://symfony.com/doc/current/security.html#where-do-users-come-from-user-providers
+    providers:
+        users_in_memory: { memory: null }
+    firewalls:
+        dev:
+            pattern: ^/(_(profiler|wdt)|css|images|js)/
+            security: false
+        main:
+            lazy: true
+            provider: users_in_memory
+
+            # activate different ways to authenticate
+            # https://symfony.com/doc/current/security.html#firewalls-authentication
+
+            # https://symfony.com/doc/current/security/impersonating_user.html
+            # switch_user: true
+
+    # Easy way to control access for large sections of your site
+    # Note: Only the *first* access control that matches will be used
+    access_control:
+        # - { path: ^/admin, roles: ROLE_ADMIN }
+        # - { path: ^/profile, roles: ROLE_USER }

--- a/symfony/security-bundle/5.3/manifest.json
+++ b/symfony/security-bundle/5.3/manifest.json
@@ -1,0 +1,9 @@
+{
+    "bundles": {
+        "Symfony\\Bundle\\SecurityBundle\\SecurityBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "aliases": ["security"]
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | I'm working on it :wink: 

As of 5.3, the authenticator security is no longer experimental (ref: https://github.com/symfony/symfony/pull/40814 ). We're going to revamp the security docs for 5.3 to always use the authenticator security. I think it's good to also default to this new system in 5.3.

```diff
--- symfony/security-bundle/5.1/config/packages/security.yaml
+++ symfony/security-bundle/5.3/config/packages/security.yaml
@@ -1,4 +1,6 @@
 security:
+    # https://symfony.com/doc/current/security/experimental_authenticators.html
+    enable_authenticator_manager: true
     # https://symfony.com/doc/current/security.html#where-do-users-come-from-user-providers
     providers:
         users_in_memory: { memory: null }
@@ -7,7 +9,6 @@
             pattern: ^/(_(profiler|wdt)|css|images|js)/
             security: false
         main:
-            anonymous: true
             lazy: true
             provider: users_in_memory

```