### PR TITLE
[framework-bundle/5.3] fix importing services/routes.php

### DIFF
--- a/symfony/framework-bundle/5.3/src/Kernel.php
+++ b/symfony/framework-bundle/5.3/src/Kernel.php
@@ -19,8 +19,8 @@ class Kernel extends BaseKernel
         if (is_file(\dirname(__DIR__).'/config/services.yaml')) {
             $container->import('../config/services.yaml');
             $container->import('../config/{services}_'.$this->environment.'.yaml');
-        } elseif (is_file($path = \dirname(__DIR__).'/config/services.php')) {
-            (require $path)($container->withPath($path), $this);
+        } else {
+            $container->import('../config/{services}.php');
         }
     }
 
@@ -31,8 +31,8 @@ class Kernel extends BaseKernel
 
         if (is_file(\dirname(__DIR__).'/config/routes.yaml')) {
             $routes->import('../config/routes.yaml');
-        } elseif (is_file($path = \dirname(__DIR__).'/config/routes.php')) {
-            (require $path)($routes->withPath($path), $this);
+        } else {
+            $routes->import('../config/{routes}.php');
         }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

Spotted while reviewing https://github.com/symfony/symfony/pull/41218

Using `->withPath()` allowed passing the `Kernel` to the closure, but since 5.3, this is not needed anymore since the `$env` var is now available. This also fixes using config builders inside `services.php`.