### PR TITLE
Commit vendor/autoload_runtime.php

### DIFF
--- a/symfony/framework-bundle/5.3/manifest.json
+++ b/symfony/framework-bundle/5.3/manifest.json
@@ -22,6 +22,7 @@
         "/%CONFIG_DIR%/secrets/prod/prod.decrypt.private.php",
         "/%PUBLIC_DIR%/bundles/",
         "/%VAR_DIR%/",
-        "/vendor/"
+        "/vendor/*",
+        "!vendor/autoload_runtime.php"
     ]
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

I propose to commit the `vendor/autoload_runtime.php` file: this will allow installing apps with composer when the `--no-scripts` or `--no-plugins` flags are passed.
