### PR TITLE
Also ignore secret private key by default for non-prod environments

### DIFF
--- a/symfony/framework-bundle/4.4/manifest.json
+++ b/symfony/framework-bundle/4.4/manifest.json
@@ -21,7 +21,7 @@
         "/.env.local",
         "/.env.local.php",
         "/.env.*.local",
-        "/%CONFIG_DIR%/secrets/prod/prod.decrypt.private.php",
+        "/%CONFIG_DIR%/secrets/*/*.decrypt.private.php",
         "/%PUBLIC_DIR%/bundles/",
         "/%VAR_DIR%/",
         "/vendor/"

--- a/symfony/framework-bundle/5.1/manifest.json
+++ b/symfony/framework-bundle/5.1/manifest.json
@@ -21,7 +21,7 @@
         "/.env.local",
         "/.env.local.php",
         "/.env.*.local",
-        "/%CONFIG_DIR%/secrets/prod/prod.decrypt.private.php",
+        "/%CONFIG_DIR%/secrets/*/*.decrypt.private.php",
         "/%PUBLIC_DIR%/bundles/",
         "/%VAR_DIR%/",
         "/vendor/"

--- a/symfony/framework-bundle/5.2/manifest.json
+++ b/symfony/framework-bundle/5.2/manifest.json
@@ -19,7 +19,7 @@
         "/.env.local",
         "/.env.local.php",
         "/.env.*.local",
-        "/%CONFIG_DIR%/secrets/prod/prod.decrypt.private.php",
+        "/%CONFIG_DIR%/secrets/*/*.decrypt.private.php",
         "/%PUBLIC_DIR%/bundles/",
         "/%VAR_DIR%/",
         "/vendor/"

--- a/symfony/framework-bundle/5.3/manifest.json
+++ b/symfony/framework-bundle/5.3/manifest.json
@@ -19,7 +19,7 @@
         "/.env.local",
         "/.env.local.php",
         "/.env.*.local",
-        "/%CONFIG_DIR%/secrets/prod/prod.decrypt.private.php",
+        "/%CONFIG_DIR%/secrets/*/*.decrypt.private.php",
         "/%PUBLIC_DIR%/bundles/",
         "/%VAR_DIR%/",
         "/vendor/"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | 

To me every private key should be excluded by default independent of the environment.
Esp. if you use other deployment environments like staging, having this unsecure default as gitignore is kinda dangerous.
The fact that custom env don't have the private key ignored by default and https://symfony.com/doc/current/configuration.html#creating-a-new-environment does not mention it that this should be done manually is a potential security problem.

If the secrets from dev or test are not really secrets (which is why you could commit the private key), then there is not point in setting them as secrets in the first place. Those can just be normal env vars.

For the test env this is already recommended in https://symfony.com/doc/current/configuration/secrets.html#secrets-in-the-test-environment
> If you add a secret in the dev and prod environments, it will be missing from the test environment. You could create a “vault” for the test environment and define the secrets there. But an easier way is to set the test values via the .env.test file.

For dev the recommendation seems different in https://symfony.com/doc/current/configuration/secrets.html#create-or-update-secrets
which does not make sense to me. Whether something needs to be encrypted does not depend on the environment, it depends on the value. If the dev environment contains the database_url for a local docker mysql server, that does not need to be encrypted. But if you configure a real, online smtp server to be used in the dev environment, than the mailer_dsn should be encrypted.

