### PR TITLE
Set 'lang' attribute in 'html' node

### DIFF
--- a/symfony/twig-bundle/5.4/templates/base.html.twig
+++ b/symfony/twig-bundle/5.4/templates/base.html.twig
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="{{ app.request.locale }}">
     <head>
         <meta charset="UTF-8">
         <title>{% block title %}Welcome!{% endblock %}</title>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | N/A

What do you think guys about setting the html `lang` attribute straight with the current locale?
IMO that would help us to make websites with better web accessibility.