### PR TITLE
[security-bundle/5.3] Configure `auto` password hasher

### DIFF
--- a/symfony/security-bundle/5.3/config/packages/security.yaml
+++ b/symfony/security-bundle/5.3/config/packages/security.yaml
@@ -1,6 +1,9 @@
 security:
     # https://symfony.com/doc/current/security/experimental_authenticators.html
     enable_authenticator_manager: true
+    # https://symfony.com/doc/current/security.html#c-hashing-passwords
+    password_hashers:
+        Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface: 'auto'
     # https://symfony.com/doc/current/security.html#where-do-users-come-from-user-providers
     providers:
         users_in_memory: { memory: null }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

This PR configures a default "auto" password hasher on 5.3.

If one creates a user class implementing `PasswordAuthenticatedUserInterface` (i.e. authenticated via password), then one just has to use the password-hashing related services that are wired from this config. 
In case these services are not used anywhere, they are just removed from the container as usual.
 
Fixes https://github.com/symfony/symfony/issues/42071