### PR TITLE
Add scheb/2fa-bundle to official recipes

### DIFF
--- a/scheb/2fa-bundle/5.0/config/packages/scheb_2fa.yaml
+++ b/scheb/2fa-bundle/5.0/config/packages/scheb_2fa.yaml
@@ -1,0 +1,8 @@
+# See the configuration reference at https://github.com/scheb/2fa/blob/master/doc/configuration.md
+scheb_two_factor:
+    security_tokens:
+        - Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken
+        # If you're using guard-based authentication, you have to use this one:
+        # - Symfony\Component\Security\Guard\Token\PostAuthenticationGuardToken
+        # If you're using authenticator-based security (introduced in Symfony 5.1), you have to use this one:
+        # - Symfony\Component\Security\Http\Authenticator\Token\PostAuthenticationToken

--- a/scheb/2fa-bundle/5.0/config/routes/scheb_2fa.yaml
+++ b/scheb/2fa-bundle/5.0/config/routes/scheb_2fa.yaml
@@ -1,0 +1,7 @@
+2fa_login:
+    path: /2fa
+    defaults:
+        _controller: "scheb_two_factor.form_controller:form"
+
+2fa_login_check:
+    path: /2fa_check

--- a/scheb/2fa-bundle/5.0/manifest.json
+++ b/scheb/2fa-bundle/5.0/manifest.json
@@ -1,0 +1,9 @@
+{
+    "bundles": {
+        "Scheb\\TwoFactorBundle\\SchebTwoFactorBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "aliases": ["2fa"]
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

I propose to move @scheb's 2fa bundle from the contrib repository to the official recipes:

- This bundle provides multi factor authentication, a feature which we likely won't ever cover fully in Symfony core and rather rely on this bundle.
- The bundle is stable, works great and @scheb is doing a great job of keeping up to date with Symfony versions (and even giving feedback on new security changes that affect the bundle).

For discoverability, I also propose to give the bundle the "2fa" alias.
