### PR TITLE
Add local Docker config for Mailer

### DIFF
--- a/symfony/mailer/4.3/manifest.json
+++ b/symfony/mailer/4.3/manifest.json
@@ -5,5 +5,14 @@
     "env": {
         "#1": "MAILER_DSN=smtp://localhost"
     },
+    "docker-compose": {
+        "docker-compose.override.yml": {
+            "services": [
+                "mailer:",
+                "  image: schickling/mailcatcher",
+                "  ports: [1025, 1080]"
+            ]
+        }
+    },
     "aliases": ["mailer", "mail"]
 }


### PR DESCRIPTION
When using the Mailer locally, let's use a mail catcher automatically.

/cc @dunglas 

| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | n/a
