### PR TITLE
Remove webpack encore pack recipe

### DIFF
--- a/symfony/webpack-encore-pack/1.0/manifest.json
+++ b/symfony/webpack-encore-pack/1.0/manifest.json
@@ -1,8 +1,0 @@
-{
-    "gitignore": [
-        "/node_modules/",
-        "/%PUBLIC_DIR%/build/",
-        "npm-debug.log",
-        "yarn-error.log"
-    ]
-}

--- a/symfony/webpack-encore-pack/1.0/post-install.txt
+++ b/symfony/webpack-encore-pack/1.0/post-install.txt
@@ -1,7 +1,0 @@
-<bg=yellow;fg=black>                                                                                                            </>
-<bg=yellow;fg=black> The symfony/webpack-encore-pack is no longer required anymore. Instead, use symfony/webpack-encore-bundle. </>
-<bg=yellow;fg=black>                                                                                                            </>
-
-  * <fg=blue>Instead</>:
-    1. Remove it now: <comment>composer remove symfony/webpack-encore-pack</>
-    2. Use Symfony's bridge: <comment>composer require encore</>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | symfony/symfony-docs#...

The pack was deprecated years ago and the package does not exist anymore.
