### PR TITLE
Remove the header from post-install files (handled by Flex soon)

### DIFF
--- a/api-platform/admin-pack/1.0/post-install.txt
+++ b/api-platform/admin-pack/1.0/post-install.txt
@@ -1,7 +1,3 @@
-<bg=blue;fg=white>                       </>
-<bg=blue;fg=white> To finish the install </>
-<bg=blue;fg=white>                       </>
-
   * Your admin is almost ready:
     1. Install the JavaScript dependencies by running <comment>yarn add @api-platform/admin @babel/preset-react</comment>
     2. Edit <comment>webpack.config.js</comment> and <info>uncomment</info> the following lines:

--- a/api-platform/core/2.1/post-install.txt
+++ b/api-platform/core/2.1/post-install.txt
@@ -1,7 +1,3 @@
-<bg=blue;fg=white>              </>
-<bg=blue;fg=white> What's next? </>
-<bg=blue;fg=white>              </>
-
   * Your API is almost ready:
     1. Create your first API resource in <info>src/Entity</info>;
     2. Go to <info>/api</info> to browse your API

--- a/api-platform/core/2.5/post-install.txt
+++ b/api-platform/core/2.5/post-install.txt
@@ -1,7 +1,3 @@
-<bg=blue;fg=white>              </>
-<bg=blue;fg=white> What's next? </>
-<bg=blue;fg=white>              </>
-
   * Your API is almost ready:
     1. Create your first API resource in <info>src/Entity</info>;
     2. Go to <info>/api</info> to browse your API

--- a/doctrine/doctrine-bundle/1.12/post-install.txt
+++ b/doctrine/doctrine-bundle/1.12/post-install.txt
@@ -1,7 +1,3 @@
-<bg=blue;fg=white>                        </>
-<bg=blue;fg=white> Database Configuration </>
-<bg=blue;fg=white>                        </>
-
   * Modify your DATABASE_URL config in <fg=green>.env</>
 
   * Configure the <fg=green>driver</> (mysql) and

--- a/doctrine/doctrine-bundle/1.6/post-install.txt
+++ b/doctrine/doctrine-bundle/1.6/post-install.txt
@@ -1,7 +1,3 @@
-<bg=blue;fg=white>                        </>
-<bg=blue;fg=white> Database Configuration </>
-<bg=blue;fg=white>                        </>
-
   * Modify your DATABASE_URL config in <fg=green>.env</>
 
   * Configure the <fg=green>driver</> (mysql) and

--- a/doctrine/doctrine-bundle/2.0/post-install.txt
+++ b/doctrine/doctrine-bundle/2.0/post-install.txt
@@ -1,7 +1,3 @@
-<bg=blue;fg=white>                        </>
-<bg=blue;fg=white> Database Configuration </>
-<bg=blue;fg=white>                        </>
-
   * Modify your DATABASE_URL config in <fg=green>.env</>
 
   * Configure the <fg=green>driver</> (postgresql) and

--- a/doctrine/doctrine-bundle/2.3/post-install.txt
+++ b/doctrine/doctrine-bundle/2.3/post-install.txt
@@ -1,7 +1,3 @@
-<bg=blue;fg=white>                        </>
-<bg=blue;fg=white> Database Configuration </>
-<bg=blue;fg=white>                        </>
-
   * Modify your DATABASE_URL config in <fg=green>.env</>
 
   * Configure the <fg=green>driver</> (postgresql) and

--- a/doctrine/doctrine-bundle/2.4/post-install.txt
+++ b/doctrine/doctrine-bundle/2.4/post-install.txt
@@ -1,7 +1,3 @@
-<bg=blue;fg=white>                        </>
-<bg=blue;fg=white> Database Configuration </>
-<bg=blue;fg=white>                        </>
-
   * Modify your DATABASE_URL config in <fg=green>.env</>
 
   * Configure the <fg=green>driver</> (postgresql) and

--- a/hautelook/alice-bundle/2.1/post-install.txt
+++ b/hautelook/alice-bundle/2.1/post-install.txt
@@ -1,6 +1,2 @@
-<bg=blue;fg=white>                       </>
-<bg=blue;fg=white> How to load fixtures? </>
-<bg=blue;fg=white>                       </>
-
   * <fg=blue>Write</> fixtures files in the <comment>fixtures/</> folder
   * <fg=blue>Run</> <comment>php bin/console hautelook:fixtures:load</>

--- a/symfony/framework-bundle/3.3/post-install.txt
+++ b/symfony/framework-bundle/3.3/post-install.txt
@@ -1,7 +1,3 @@
-<bg=blue;fg=white>              </>
-<bg=blue;fg=white> What's next? </>
-<bg=blue;fg=white>              </>
-
   * <fg=blue>Run</> your application:
     1. Go to the project directory
     2. Create your code repository with the <comment>git init</comment> command

--- a/symfony/framework-bundle/3.4/post-install.txt
+++ b/symfony/framework-bundle/3.4/post-install.txt
@@ -1,7 +1,3 @@
-<bg=blue;fg=white>              </>
-<bg=blue;fg=white> What's next? </>
-<bg=blue;fg=white>              </>
-
   * <fg=blue>Run</> your application:
     1. Go to the project directory
     2. Create your code repository with the <comment>git init</comment> command

--- a/symfony/framework-bundle/4.2/post-install.txt
+++ b/symfony/framework-bundle/4.2/post-install.txt
@@ -1,7 +1,3 @@
-<bg=blue;fg=white>              </>
-<bg=blue;fg=white> What's next? </>
-<bg=blue;fg=white>              </>
-
   * <fg=blue>Run</> your application:
     1. Go to the project directory
     2. Create your code repository with the <comment>git init</comment> command

--- a/symfony/framework-bundle/4.4/post-install.txt
+++ b/symfony/framework-bundle/4.4/post-install.txt
@@ -1,7 +1,3 @@
-<bg=blue;fg=white>              </>
-<bg=blue;fg=white> What's next? </>
-<bg=blue;fg=white>              </>
-
   * <fg=blue>Run</> your application:
     1. Go to the project directory
     2. Create your code repository with the <comment>git init</comment> command

--- a/symfony/framework-bundle/5.1/post-install.txt
+++ b/symfony/framework-bundle/5.1/post-install.txt
@@ -1,7 +1,3 @@
-<bg=blue;fg=white>              </>
-<bg=blue;fg=white> What's next? </>
-<bg=blue;fg=white>              </>
-
   * <fg=blue>Run</> your application:
     1. Go to the project directory
     2. Create your code repository with the <comment>git init</comment> command

--- a/symfony/framework-bundle/5.2/post-install.txt
+++ b/symfony/framework-bundle/5.2/post-install.txt
@@ -1,7 +1,3 @@
-<bg=blue;fg=white>              </>
-<bg=blue;fg=white> What's next? </>
-<bg=blue;fg=white>              </>
-
   * <fg=blue>Run</> your application:
     1. Go to the project directory
     2. Create your code repository with the <comment>git init</comment> command

--- a/symfony/framework-bundle/5.3/post-install.txt
+++ b/symfony/framework-bundle/5.3/post-install.txt
@@ -1,7 +1,3 @@
-<bg=blue;fg=white>              </>
-<bg=blue;fg=white> What's next? </>
-<bg=blue;fg=white>              </>
-
   * <fg=blue>Run</> your application:
     1. Go to the project directory
     2. Create your code repository with the <comment>git init</comment> command

--- a/symfony/framework-bundle/5.4/post-install.txt
+++ b/symfony/framework-bundle/5.4/post-install.txt
@@ -1,7 +1,3 @@
-<bg=blue;fg=white>              </>
-<bg=blue;fg=white> What's next? </>
-<bg=blue;fg=white>              </>
-
   * <fg=blue>Run</> your application:
     1. Go to the project directory
     2. Create your code repository with the <comment>git init</comment> command

--- a/symfony/mailer/4.3/post-install.txt
+++ b/symfony/mailer/4.3/post-install.txt
@@ -1,7 +1,3 @@
-<bg=blue;fg=white>              </>
-<bg=blue;fg=white> What's next? </>
-<bg=blue;fg=white>              </>
-
   * You're ready to send emails.
 
   * If you want to send emails via a supported email provider, install

--- a/symfony/messenger/4.1/post-install.txt
+++ b/symfony/messenger/4.1/post-install.txt
@@ -1,7 +1,3 @@
-<bg=blue;fg=white>              </>
-<bg=blue;fg=white> What's next? </>
-<bg=blue;fg=white>              </>
-
   * You're ready to use the Messenger component. You can define your own message buses
     or start using the default one right now by injecting the <info>messenger.bus.default</info> service
     or typehinting <info>Symfony\Component\Messenger\MessageBusInterface</info> in your code.

--- a/symfony/messenger/4.3/post-install.txt
+++ b/symfony/messenger/4.3/post-install.txt
@@ -1,7 +1,3 @@
-<bg=blue;fg=white>              </>
-<bg=blue;fg=white> What's next? </>
-<bg=blue;fg=white>              </>
-
   * You're ready to use the Messenger component. You can define your own message buses
     or start using the default one right now by injecting the <info>message_bus</info> service
     or type-hinting <info>Symfony\Component\Messenger\MessageBusInterface</info> in your code.

--- a/symfony/panther/1.0/post-install.txt
+++ b/symfony/panther/1.0/post-install.txt
@@ -1,7 +1,3 @@
-<bg=blue;fg=white>                             </>
-<bg=blue;fg=white> Finish Panther Installation </>
-<bg=blue;fg=white>                             </>
-
   * Install <fg=green>ChromeDriver</> or <fg=green>geckodriver</> with 
     the package manager of your Operating System.
     

--- a/symfony/phpunit-bridge/3.3/post-install.txt
+++ b/symfony/phpunit-bridge/3.3/post-install.txt
@@ -1,6 +1,2 @@
-<bg=blue;fg=white>              </>
-<bg=blue;fg=white> How to test? </>
-<bg=blue;fg=white>              </>
-
   * <fg=blue>Write</> test cases in the <comment>tests/</> folder
   * <fg=blue>Run</> <comment>php bin/phpunit</>

--- a/symfony/phpunit-bridge/4.1/post-install.txt
+++ b/symfony/phpunit-bridge/4.1/post-install.txt
@@ -1,6 +1,2 @@
-<bg=blue;fg=white>              </>
-<bg=blue;fg=white> How to test? </>
-<bg=blue;fg=white>              </>
-
   * <fg=blue>Write</> test cases in the <comment>tests/</> folder
   * <fg=blue>Run</> <comment>php bin/phpunit</>

--- a/symfony/phpunit-bridge/4.3/post-install.txt
+++ b/symfony/phpunit-bridge/4.3/post-install.txt
@@ -1,6 +1,2 @@
-<bg=blue;fg=white>              </>
-<bg=blue;fg=white> How to test? </>
-<bg=blue;fg=white>              </>
-
   * <fg=blue>Write</> test cases in the <comment>tests/</> folder
   * <fg=blue>Run</> <comment>php bin/phpunit</>

--- a/symfony/phpunit-bridge/5.1/post-install.txt
+++ b/symfony/phpunit-bridge/5.1/post-install.txt
@@ -1,6 +1,2 @@
-<bg=blue;fg=white>              </>
-<bg=blue;fg=white> How to test? </>
-<bg=blue;fg=white>              </>
-
   * <fg=blue>Write</> test cases in the <comment>tests/</> folder
   * <fg=blue>Run</> <comment>php bin/phpunit</>

--- a/symfony/phpunit-bridge/5.3/post-install.txt
+++ b/symfony/phpunit-bridge/5.3/post-install.txt
@@ -1,7 +1,3 @@
-<bg=blue;fg=white>              </>
-<bg=blue;fg=white> How to test? </>
-<bg=blue;fg=white>              </>
-
   * <fg=blue>Write</> test cases in the <comment>tests/</> folder
   * Use MakerBundle's <comment>make:test</> command as a shortcut!
   * <fg=blue>Run</> the tests with <comment>php bin/phpunit</>

--- a/symfony/webpack-encore-bundle/1.9/post-install.txt
+++ b/symfony/webpack-encore-bundle/1.9/post-install.txt
@@ -1,7 +1,3 @@
-<bg=blue;fg=white>                            </>
-<bg=blue;fg=white> Finish Encore Installation </>
-<bg=blue;fg=white>                            </>
-
   * Install Yarn and run <fg=green>yarn install</>
 
   * Uncomment the Twig helpers in <fg=green>templates/base.html.twig</>

--- a/zenstruck/foundry/1.9/post-install.txt
+++ b/zenstruck/foundry/1.9/post-install.txt
@@ -1,7 +1,3 @@
-<bg=blue;fg=white>              </>
-<bg=blue;fg=white> What's next? </>
-<bg=blue;fg=white>              </>
-
   * You're ready to use zenstruck/foundry. Create your first factory with
     <info>bin/console make:factory</>.
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | symfony/symfony-docs#...

When installing a pack or when installing multiple packages at once, you might have a confusing output at the end of the `composer` run as many post install file might be displayed as most of the start with a blue "What's next" header.

In a Flex PR, I will propose to move the header to Flex and Flex will also add a small header between each post install to associate each post install file to its package. See https://github.com/symfony/flex/pull/790

I'm opening this PR so that I can test things and see how I can improve the output by making some experiments.

So, please NO MERGE.
