### PR TITLE
[DoctrineBundle] Removed deprecated config

### DIFF
--- a/doctrine/doctrine-bundle/2.3/config/packages/prod/doctrine.yaml
+++ b/doctrine/doctrine-bundle/2.3/config/packages/prod/doctrine.yaml
@@ -1,9 +1,6 @@
 doctrine:
     orm:
         auto_generate_proxy_classes: false
-        metadata_cache_driver:
-            type: pool
-            pool: doctrine.system_cache_pool
         query_cache_driver:
             type: pool
             pool: doctrine.system_cache_pool

--- a/doctrine/doctrine-bundle/2.4/config/packages/prod/doctrine.yaml
+++ b/doctrine/doctrine-bundle/2.4/config/packages/prod/doctrine.yaml
@@ -1,9 +1,6 @@
 doctrine:
     orm:
         auto_generate_proxy_classes: false
-        metadata_cache_driver:
-            type: pool
-            pool: doctrine.system_cache_pool
         query_cache_driver:
             type: pool
             pool: doctrine.system_cache_pool


### PR DESCRIPTION
Removed deprecated configuration key metadata_cache_driver from DoctrineBundle config for 2.3 and 2.4, fixes #994
