### PR TITLE
Change authenticator manager doc url

### DIFF
--- a/symfony/security-bundle/5.3/config/packages/security.yaml
+++ b/symfony/security-bundle/5.3/config/packages/security.yaml
@@ -1,5 +1,5 @@
 security:
-    # https://symfony.com/doc/current/security/experimental_authenticators.html
+    # https://symfony.com/doc/current/security/authenticator_manager.html
     enable_authenticator_manager: true
     # https://symfony.com/doc/current/security.html#c-hashing-passwords
     password_hashers:


### PR DESCRIPTION
Authenticator manager doc url is changed, see https://github.com/symfony/symfony-docs/pull/15405

| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | symfony/symfony-docs#...

<!--
Please, carefully read the README before submitting a pull request.
-->
