### PR TITLE
simplify regex in the stimulus app bootstrap.js

### DIFF
--- a/symfony/webpack-encore-bundle/1.9/assets/bootstrap.js
+++ b/symfony/webpack-encore-bundle/1.9/assets/bootstrap.js
@@ -4,7 +4,7 @@ import { startStimulusApp } from '@symfony/stimulus-bridge';
 export const app = startStimulusApp(require.context(
     '@symfony/stimulus-bridge/lazy-controller-loader!./controllers',
     true,
-    /\.(j|t)sx?$/
+    /\.[jt]sx?$/
 ));
 
 // register any custom, 3rd party controllers here


### PR DESCRIPTION
use character class instead of group capture with an alternation
