### PR TITLE
pass static functions to runtime (clearer intent and improves performance)

### DIFF
--- a/symfony/console/5.3/bin/console
+++ b/symfony/console/5.3/bin/console
@@ -10,7 +10,7 @@ if (!is_file(dirname(__DIR__).'/vendor/autoload_runtime.php')) {
 
 require_once dirname(__DIR__).'/vendor/autoload_runtime.php';
 
-return function (array $context) {
+return static function (array $context) {
     $kernel = new Kernel($context['APP_ENV'], (bool) $context['APP_DEBUG']);
 
     return new Application($kernel);

--- a/symfony/framework-bundle/5.3/public/index.php
+++ b/symfony/framework-bundle/5.3/public/index.php
@@ -4,6 +4,6 @@ use App\Kernel;
 
 require_once dirname(__DIR__).'/vendor/autoload_runtime.php';
 
-return function (array $context) {
+return static function (array $context) {
     return new Kernel($context['APP_ENV'], (bool) $context['APP_DEBUG']);
 };

--- a/symfony/framework-bundle/5.4/public/index.php
+++ b/symfony/framework-bundle/5.4/public/index.php
@@ -4,6 +4,6 @@ use App\Kernel;
 
 require_once dirname(__DIR__).'/vendor/autoload_runtime.php';
 
-return function (array $context) {
+return static function (array $context) {
     return new Kernel($context['APP_ENV'], (bool) $context['APP_DEBUG']);
 };


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | symfony/symfony-docs#...

<!--
Please, carefully read the README before submitting a pull request.
-->

before:
```
% autocannon -c 10 -a 100 http://127.0.0.1:8080 
Running 100 requests test @ http://127.0.0.1:8080
10 connections

┌─────────┬───────┬────────┬────────┬────────┬───────────┬──────────┬────────┐
│ Stat    │ 2.5%  │ 50%    │ 97.5%  │ 99%    │ Avg       │ Stdev    │ Max    │
├─────────┼───────┼────────┼────────┼────────┼───────────┼──────────┼────────┤
│ Latency │ 94 ms │ 442 ms │ 584 ms │ 587 ms │ 441.91 ms │ 96.86 ms │ 630 ms │
└─────────┴───────┴────────┴────────┴────────┴───────────┴──────────┴────────┘
┌───────────┬────────┬────────┬────────┬─────────┬─────────┬────────┬────────┐
│ Stat      │ 1%     │ 2.5%   │ 50%    │ 97.5%   │ Avg     │ Stdev  │ Min    │
├───────────┼────────┼────────┼────────┼─────────┼─────────┼────────┼────────┤
│ Req/Sec   │ 14     │ 14     │ 21     │ 22      │ 20      │ 3.04   │ 14     │
├───────────┼────────┼────────┼────────┼─────────┼─────────┼────────┼────────┤
│ Bytes/Sec │ 736 kB │ 736 kB │ 1.1 MB │ 1.16 MB │ 1.05 MB │ 159 kB │ 736 kB │
└───────────┴────────┴────────┴────────┴─────────┴─────────┴────────┴────────┘

Req/Bytes counts sampled once per second.

100 requests in 5.02s, 5.25 MB read
```

after:
```
% autocannon -c 10 -a 100 http://127.0.0.1:8080
Running 100 requests test @ http://127.0.0.1:8080
10 connections

┌─────────┬────────┬────────┬────────┬────────┬──────────┬──────────┬────────┐
│ Stat    │ 2.5%   │ 50%    │ 97.5%  │ 99%    │ Avg      │ Stdev    │ Max    │
├─────────┼────────┼────────┼────────┼────────┼──────────┼──────────┼────────┤
│ Latency │ 106 ms │ 401 ms │ 472 ms │ 472 ms │ 388.1 ms │ 70.83 ms │ 473 ms │
└─────────┴────────┴────────┴────────┴────────┴──────────┴──────────┴────────┘
┌───────────┬────────┬────────┬─────────┬─────────┬─────────┬────────┬────────┐
│ Stat      │ 1%     │ 2.5%   │ 50%     │ 97.5%   │ Avg     │ Stdev  │ Min    │
├───────────┼────────┼────────┼─────────┼─────────┼─────────┼────────┼────────┤
│ Req/Sec   │ 2      │ 2      │ 24      │ 27      │ 20      │ 9.1    │ 2      │
├───────────┼────────┼────────┼─────────┼─────────┼─────────┼────────┼────────┤
│ Bytes/Sec │ 105 kB │ 105 kB │ 1.26 MB │ 1.42 MB │ 1.05 MB │ 478 kB │ 105 kB │
└───────────┴────────┴────────┴─────────┴─────────┴─────────┴────────┴────────┘

Req/Bytes counts sampled once per second.

100 requests in 5.02s, 5.25 MB read
```
