### PR TITLE
Add missing return type

### DIFF
--- a/doctrine/doctrine-fixtures-bundle/3.0/src/DataFixtures/AppFixtures.php
+++ b/doctrine/doctrine-fixtures-bundle/3.0/src/DataFixtures/AppFixtures.php
@@ -7,7 +7,7 @@ use Doctrine\Persistence\ObjectManager;
 
 class AppFixtures extends Fixture
 {
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
         // $product = new Product();
         // $manager->persist($product);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | symfony/symfony-docs#...

Fresh Symfony project with doctrine/fixture-bundle as a dependency will not pass PHPStan validation due to this missing return type.
