### PR TITLE
DATABASE_URL configured like postgresql config

### DIFF
--- a/doctrine/doctrine-bundle/2.4/manifest.json
+++ b/doctrine/doctrine-bundle/2.4/manifest.json
@@ -12,7 +12,7 @@
         "#3": "",
         "#4": "DATABASE_URL=\"sqlite:///%kernel.project_dir%/var/data.db\"",
         "#5": "DATABASE_URL=\"mysql://db_user:db_password@127.0.0.1:3306/db_name?serverVersion=5.7\"",
-        "DATABASE_URL": "postgresql://db_user:db_password@127.0.0.1:5432/db_name?serverVersion=13&charset=utf8"
+        "DATABASE_URL": "postgresql://symfony:ChangeMe@127.0.0.1:5432/app?serverVersion=13&charset=utf8"
     },
     "dockerfile": [
         "RUN apk add --no-cache --virtual .pgsql-deps postgresql-dev; \\",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

PostgreSQL is configured in docker-compose.yaml file in the same manifest but with another configuration.
The purpose of this commit is to make it ready by default to reduce what the user is supposed to change at install time.
