### PR TITLE
symfony/phpunit-bridge: also set APP_ENV in $_ENV

### DIFF
--- a/phpunit/phpunit/4.7/phpunit.xml.dist
+++ b/phpunit/phpunit/4.7/phpunit.xml.dist
@@ -10,6 +10,7 @@
     <php>
         <ini name="display_errors" value="1" />
         <ini name="error_reporting" value="-1" />
+        <env name="APP_ENV" value="test" force="true" />
         <server name="APP_ENV" value="test" force="true" />
         <server name="SHELL_VERBOSITY" value="-1" />
     </php>

--- a/phpunit/phpunit/9.3/phpunit.xml.dist
+++ b/phpunit/phpunit/9.3/phpunit.xml.dist
@@ -11,6 +11,7 @@
     <php>
         <ini name="display_errors" value="1" />
         <ini name="error_reporting" value="-1" />
+        <env name="APP_ENV" value="test" force="true" />
         <server name="APP_ENV" value="test" force="true" />
         <server name="SHELL_VERBOSITY" value="-1" />
         <server name="SYMFONY_PHPUNIT_REMOVE" value="" />

--- a/symfony/phpunit-bridge/3.3/phpunit.xml.dist
+++ b/symfony/phpunit-bridge/3.3/phpunit.xml.dist
@@ -10,6 +10,7 @@
     <php>
         <ini name="display_errors" value="1" />
         <ini name="error_reporting" value="-1" />
+        <env name="APP_ENV" value="test" force="true" />
         <server name="APP_ENV" value="test" force="true" />
         <server name="SHELL_VERBOSITY" value="-1" />
     </php>

--- a/symfony/phpunit-bridge/4.1/phpunit.xml.dist
+++ b/symfony/phpunit-bridge/4.1/phpunit.xml.dist
@@ -9,6 +9,7 @@
 >
     <php>
         <ini name="error_reporting" value="-1" />
+        <env name="APP_ENV" value="test" force="true" />
         <server name="APP_ENV" value="test" force="true" />
         <server name="SHELL_VERBOSITY" value="-1" />
         <server name="SYMFONY_PHPUNIT_REMOVE" value="" />

--- a/symfony/phpunit-bridge/4.3/phpunit.xml.dist
+++ b/symfony/phpunit-bridge/4.3/phpunit.xml.dist
@@ -10,6 +10,7 @@
     <php>
         <ini name="display_errors" value="1" />
         <ini name="error_reporting" value="-1" />
+        <env name="APP_ENV" value="test" force="true" />
         <server name="APP_ENV" value="test" force="true" />
         <server name="SHELL_VERBOSITY" value="-1" />
         <server name="SYMFONY_PHPUNIT_REMOVE" value="" />

--- a/symfony/phpunit-bridge/5.1/phpunit.xml.dist
+++ b/symfony/phpunit-bridge/5.1/phpunit.xml.dist
@@ -9,6 +9,7 @@
 >
     <php>
         <ini name="error_reporting" value="-1" />
+        <env name="APP_ENV" value="test" force="true" />
         <server name="APP_ENV" value="test" force="true" />
         <server name="SHELL_VERBOSITY" value="-1" />
         <server name="SYMFONY_PHPUNIT_REMOVE" value="" />

--- a/symfony/phpunit-bridge/5.3/phpunit.xml.dist
+++ b/symfony/phpunit-bridge/5.3/phpunit.xml.dist
@@ -11,6 +11,7 @@
     <php>
         <ini name="display_errors" value="1" />
         <ini name="error_reporting" value="-1" />
+        <env name="APP_ENV" value="test" force="true" />
         <server name="APP_ENV" value="test" force="true" />
         <server name="SHELL_VERBOSITY" value="-1" />
         <server name="SYMFONY_PHPUNIT_REMOVE" value="" />


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | symfony/symfony-docs#...

Ref https://github.com/symfony/recipes/pull/561#issuecomment-953047640

> I just got a problem with this change, since `APP_ENV` exists in `$_SERVER`, `Dotenv` does not set it in `$_ENV` (https://github.com/symfony/dotenv/blob/46a528ca327e0cb7fa7493a98ed3aebef8a516ac/Dotenv.php#L195), so `$_ENV['APP_ENV']` does not exist when running the tests. Could we set both (server and env) in the phpunit config?

More context: I used `\Symfony\Component\Process\PhpProcess` in one of my test, and was expecting to have the same env vars as the current test process in the executed code by `PhpProcess` (because according to the doc: `$env The environment variables or null to use the same environment as the current PHP process`), including the `APP_ENV` var.

But it doesn't work because `$_ENV['APP_ENV']` does not exist + since `putenv()` is disabled by default in `Dotenv`, the `Process` code doesn't take it from `$_SERVER` (see https://github.com/symfony/process/blob/38f26c7d6ed535217ea393e05634cb0b244a1967/Process.php#L1665).

Or maybe we need to apply the same strategy in `Process` than in `Dotenv`, ie not using `getenv()` and instead exclude `$_SERVER` values whose key starts with `HTTP_`?