### PR TITLE
[DoctrineBundle] Re-add the doctrine.orm.metadata_cache_driver option in production

### DIFF
--- a/doctrine/doctrine-bundle/2.4/config/packages/prod/doctrine.yaml
+++ b/doctrine/doctrine-bundle/2.4/config/packages/prod/doctrine.yaml
@@ -1,6 +1,9 @@
 doctrine:
     orm:
         auto_generate_proxy_classes: false
+        metadata_cache_driver:
+            type: pool
+            pool: doctrine.system_cache_pool
         query_cache_driver:
             type: pool
             pool: doctrine.system_cache_pool


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

This was removed in #996 but apparently Doctrine has un-reverted this removal. See https://github.com/doctrine/DoctrineBundle/pull/1405