### PR TITLE
[symfony/security-bundle] use lowest possible p/w hash "work factor" in test env

### DIFF
--- a/symfony/security-bundle/5.3/config/packages/security.yaml
+++ b/symfony/security-bundle/5.3/config/packages/security.yaml
@@ -29,7 +29,7 @@ security:
 when@test:
     security:
         password_hashers:
-            # By default, password encoders are resource intensive and take time. This is
+            # By default, password hashers are resource intensive and take time. This is
             # important to generate secure password hashes. In tests however, secure hashes
             # are not important, waste resources and increase test times. The following
             # reduces the work factor to the lowest possible values.

--- a/symfony/security-bundle/5.3/config/packages/security.yaml
+++ b/symfony/security-bundle/5.3/config/packages/security.yaml
@@ -25,3 +25,16 @@ security:
     access_control:
         # - { path: ^/admin, roles: ROLE_ADMIN }
         # - { path: ^/profile, roles: ROLE_USER }
+
+when@test:
+    security:
+        password_hashers:
+            # By default, password encoders are resource intensive and take time. This is
+            # important to generate secure password hashes. In tests however, secure hashes
+            # are not important, waste resources and increase test times. The following
+            # reduces the work factor to the lowest possible values.
+            Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface:
+                algorithm: auto
+                cost: 4 # Lowest possible value for bcrypt
+                time_cost: 3 # Lowest possible value for argon
+                memory_cost: 10 # Lowest possible value for argon


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | Fix #1024

Perhaps we could create a [`test-hasher`](https://github.com/symfony/recipes/issues/1024#issuecomment-975504242) in Symfony itself but this wouldn't be available until 6.1. Until then, I believe this is an easy win.

This is documented in the [4.4 docs](https://symfony.com/doc/4.4/testing/http_authentication.html) but was lost (I think) after a documentation refactor.

My argument for not using `plaintext` [is here](https://github.com/symfony/recipes/issues/1024#issuecomment-975015039) but I'm not strongly opposed to it.