### PR TITLE
Updating recipe for Stimulus 3

### DIFF
--- a/symfony/webpack-encore-bundle/1.9/assets/controllers/hello_controller.js
+++ b/symfony/webpack-encore-bundle/1.9/assets/controllers/hello_controller.js
@@ -1,4 +1,4 @@
-import { Controller } from 'stimulus';
+import { Controller } from '@hotwired/stimulus';
 
 /*
  * This is an example Stimulus controller!

--- a/symfony/webpack-encore-bundle/1.9/package.json
+++ b/symfony/webpack-encore-bundle/1.9/package.json
@@ -1,10 +1,10 @@
 {
     "devDependencies": {
-        "@symfony/stimulus-bridge": "^2.0.0",
-        "@symfony/webpack-encore": "^1.0.0",
+        "@hotwired/stimulus": "^3.0.0",
+        "@symfony/stimulus-bridge": "^3.0.0",
+        "@symfony/webpack-encore": "^1.7.0",
         "core-js": "^3.0.0",
         "regenerator-runtime": "^0.13.2",
-        "stimulus": "^2.0.0",
         "webpack-notifier": "^1.6.0"
     },
     "license": "UNLICENSED",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | Unfortunately, not needed because ALL of this stuff still needs to be documented (on my list). The symfony/ux package documentation has been updated

This is waiting on new major tags from `@symfony/stimulus-bridge` (v3) and `symfony/ux` (v2).

I have no modified the recipe for earlier versions of Encore. I believe that is more consistent with our policy of not changing recipes for old versions.

Cheers!