### PR TITLE
Fix zenstruck/foundry doc links

### DIFF
--- a/zenstruck/foundry/1.9/config/packages/dev/zenstruck_foundry.yaml
+++ b/zenstruck/foundry/1.9/config/packages/dev/zenstruck_foundry.yaml
@@ -1,4 +1,4 @@
-# See full configuration: https://github.com/zenstruck/foundry#full-default-bundle-configuration
+# See full configuration: https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#full-default-bundle-configuration
 zenstruck_foundry:
-    # Whether to auto-refresh proxies by default (https://github.com/zenstruck/foundry#auto-refresh)
+    # Whether to auto-refresh proxies by default (https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#auto-refresh)
     auto_refresh_proxies: true

--- a/zenstruck/foundry/1.9/post-install.txt
+++ b/zenstruck/foundry/1.9/post-install.txt
@@ -1,4 +1,4 @@
   * You're ready to use zenstruck/foundry. Create your first factory with
     <info>bin/console make:factory</>.
 
-  * <fg=blue>Read</> the documentation at <comment>https://github.com/zenstruck/foundry#foundry</>
+  * <fg=blue>Read</> the documentation at <comment>https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html</>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | N/A

Hi, just a few doc links update as docs have moved to Symfony.com docs.