### PR TITLE
Add callable action to repopulate the recipe archives

### DIFF
--- a/.github/workflows/callable-flex-update-archived.yml
+++ b/.github/workflows/callable-flex-update-archived.yml
@@ -4,7 +4,7 @@ on:
     workflow_call:
         inputs:
             branch:
-                default: main
+                default: master
                 required: false
                 type: string
 

--- a/.github/workflows/callable-flex-update-archived.yml
+++ b/.github/workflows/callable-flex-update-archived.yml
@@ -1,4 +1,4 @@
-name: Update Flex endpoint
+name: Update Flex Archives
 
 on:
     workflow_call:

--- a/.github/workflows/callable-flex-update-archived.yml
+++ b/.github/workflows/callable-flex-update-archived.yml
@@ -1,9 +1,13 @@
 name: Update Flex endpoint
 
 on:
-    push:
-        branches:
-            - main
+    workflow_call:
+        inputs:
+            branch:
+                default: main
+                required: false
+                type: string
+
 jobs:
     flex-update-archived:
         name: Update Flex Archives
@@ -30,10 +34,10 @@ jobs:
             -
                 name: Update Flex Archives
                 run: |
-                    git switch master
+                    git switch ${{ inputs.branch }}
 
                     mkdir .github/archived
-                    php .github/recipes-checker-main/run generate:archived-recipes . master .github/archived
+                    php .github/recipes-checker-main/run generate:archived-recipes . ${{ inputs.branch }} .github/archived
 
                     git switch flex/main
                     cp -a .github/archived .

--- a/.github/workflows/flex-update-archived.yml
+++ b/.github/workflows/flex-update-archived.yml
@@ -1,0 +1,42 @@
+name: Update Flex endpoint
+
+on:
+    push:
+        branches:
+            - main
+jobs:
+    flex-update-archived:
+        name: Update Flex Archives
+        runs-on: Ubuntu-20.04
+
+        steps:
+            -
+                name: Checkout
+                uses: actions/checkout@v2
+                id: checkout
+                with:
+                    fetch-depth: 0
+
+            -
+                name: Install tools
+                run: |
+                    git config --global user.email ""
+                    git config --global user.name "github-action[bot]"
+                    cd .github
+                    wget -q -O recipes-checker.zip https://codeload.github.com/symfony-tools/recipes-checker/zip/refs/heads/main
+                    unzip recipes-checker.zip
+                    cd recipes-checker-main
+                    composer install --ansi --no-dev
+            -
+                name: Update Flex Archives
+                run: |
+                    git switch master
+
+                    mkdir .github/archived
+                    php .github/recipes-checker-main/run generate:archived-recipes . master .github/archived
+
+                    git switch flex/main
+                    cp -a .github/archived .
+                    git add archived/
+                    git commit -m 'Update Flex archives' || true
+                    git push origin -f flex/main


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | None

Relates to: https://github.com/symfony-tools/recipes-checker/pull/3

On push to `main` - which is rare - we would run the new command to completely repopulate the `archived` directory on the `flex/main` branch. This really only needs to be done once, because it's kept up to date after automatically. But we could choose to run it on push just in case.

There IS one problem: how to replicate this for `recipes-contrib`?