### PR TITLE
Adding manual action for flex-update-archived

### DIFF
--- a/.github/workflows/flex-update-achived.yml
+++ b/.github/workflows/flex-update-achived.yml
@@ -1,0 +1,7 @@
+name: Update Flex Archives
+
+on: [workflow_dispatch]
+
+jobs:
+    call-flex-update:
+        uses: symfony/recipes/.github/workflows/callable-flex-update-archived.yml@main


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | Relates to #1038 

This will allow us to manually trigger this new GH action to build the `archived/` directory.