### PR TITLE
Proposal to include stacktraces in logs

### DIFF
--- a/symfony/monolog-bundle/3.1/config/packages/dev/monolog.yaml
+++ b/symfony/monolog-bundle/3.1/config/packages/dev/monolog.yaml
@@ -3,6 +3,7 @@ monolog:
         main:
             type: stream
             path: "%kernel.logs_dir%/%kernel.environment%.log"
+            include_stacktraces: true
             level: debug
             channels: ["!event"]
         # uncomment to get logging in your browser

--- a/symfony/monolog-bundle/3.1/config/packages/prod/monolog.yaml
+++ b/symfony/monolog-bundle/3.1/config/packages/prod/monolog.yaml
@@ -11,6 +11,7 @@ monolog:
         nested:
             type: stream
             path: "%kernel.logs_dir%/%kernel.environment%.log"
+            include_stacktraces: true
             level: debug
         console:
             type: console

--- a/symfony/monolog-bundle/3.1/config/packages/test/monolog.yaml
+++ b/symfony/monolog-bundle/3.1/config/packages/test/monolog.yaml
@@ -3,5 +3,6 @@ monolog:
         main:
             type: stream
             path: "%kernel.logs_dir%/%kernel.environment%.log"
+            include_stacktraces: true
             level: debug
             channels: ["!event"]

--- a/symfony/monolog-bundle/3.3/config/packages/dev/monolog.yaml
+++ b/symfony/monolog-bundle/3.3/config/packages/dev/monolog.yaml
@@ -3,6 +3,7 @@ monolog:
         main:
             type: stream
             path: "%kernel.logs_dir%/%kernel.environment%.log"
+            include_stacktraces: true
             level: debug
             channels: ["!event"]
         # uncomment to get logging in your browser

--- a/symfony/monolog-bundle/3.3/config/packages/prod/monolog.yaml
+++ b/symfony/monolog-bundle/3.3/config/packages/prod/monolog.yaml
@@ -9,6 +9,7 @@ monolog:
         nested:
             type: stream
             path: "%kernel.logs_dir%/%kernel.environment%.log"
+            include_stacktraces: true
             level: debug
         console:
             type: console

--- a/symfony/monolog-bundle/3.3/config/packages/test/monolog.yaml
+++ b/symfony/monolog-bundle/3.3/config/packages/test/monolog.yaml
@@ -9,4 +9,5 @@ monolog:
         nested:
             type: stream
             path: "%kernel.logs_dir%/%kernel.environment%.log"
+            include_stacktraces: true
             level: debug

--- a/symfony/monolog-bundle/3.7/config/packages/dev/monolog.yaml
+++ b/symfony/monolog-bundle/3.7/config/packages/dev/monolog.yaml
@@ -3,6 +3,7 @@ monolog:
         main:
             type: stream
             path: "%kernel.logs_dir%/%kernel.environment%.log"
+            include_stacktraces: true
             level: debug
             channels: ["!event"]
         # uncomment to get logging in your browser

--- a/symfony/monolog-bundle/3.7/config/packages/prod/monolog.yaml
+++ b/symfony/monolog-bundle/3.7/config/packages/prod/monolog.yaml
@@ -9,6 +9,7 @@ monolog:
         nested:
             type: stream
             path: php://stderr
+            include_stacktraces: true
             level: debug
             formatter: monolog.formatter.json
         console:

--- a/symfony/monolog-bundle/3.7/config/packages/test/monolog.yaml
+++ b/symfony/monolog-bundle/3.7/config/packages/test/monolog.yaml
@@ -9,4 +9,5 @@ monolog:
         nested:
             type: stream
             path: "%kernel.logs_dir%/%kernel.environment%.log"
+            include_stacktraces: true
             level: debug


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | 

I didn't find any PR talking about this subject, thus I give it a try. Is there any reason to not have stacktraces in logs in the default configuration ? It's mainly useful for prod environment, but may be handy in other environments too.
