### PR TITLE
Use new scheb/2fa package (replaces scheb/2fa-bundle)

### DIFF
--- a/scheb/2fa/5.0/config/packages/scheb_2fa.yaml
+++ b/scheb/2fa/5.0/config/packages/scheb_2fa.yaml
@@ -1,0 +1,8 @@
+# See the configuration reference at https://github.com/scheb/2fa/blob/master/doc/configuration.md
+scheb_two_factor:
+    security_tokens:
+        - Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken
+        # If you're using guard-based authentication, you have to use this one:
+        # - Symfony\Component\Security\Guard\Token\PostAuthenticationGuardToken
+        # If you're using authenticator-based security (introduced in Symfony 5.1), you have to use this one:
+        # - Symfony\Component\Security\Http\Authenticator\Token\PostAuthenticationToken

--- a/scheb/2fa/5.0/config/routes/scheb_2fa.yaml
+++ b/scheb/2fa/5.0/config/routes/scheb_2fa.yaml
@@ -1,0 +1,7 @@
+2fa_login:
+    path: /2fa
+    defaults:
+        _controller: "scheb_two_factor.form_controller:form"
+
+2fa_login_check:
+    path: /2fa_check

--- a/scheb/2fa/5.0/manifest.json
+++ b/scheb/2fa/5.0/manifest.json
@@ -4,5 +4,6 @@
     },
     "copy-from-recipe": {
         "config/": "%CONFIG_DIR%/"
-    }
+    },
+    "aliases": ["2fa"]
 }

--- a/scheb/2fa/6.0/config/packages/scheb_2fa.yaml
+++ b/scheb/2fa/6.0/config/packages/scheb_2fa.yaml
@@ -1,0 +1,5 @@
+# See the configuration reference at https://github.com/scheb/2fa/blob/master/doc/configuration.md
+scheb_two_factor:
+    security_tokens:
+        - Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken
+        - Symfony\Component\Security\Http\Authenticator\Token\PostAuthenticationToken

--- a/scheb/2fa/6.0/config/routes/scheb_2fa.yaml
+++ b/scheb/2fa/6.0/config/routes/scheb_2fa.yaml
@@ -1,0 +1,7 @@
+2fa_login:
+    path: /2fa
+    defaults:
+        _controller: "scheb_two_factor.form_controller:form"
+
+2fa_login_check:
+    path: /2fa_check

--- a/scheb/2fa/6.0/manifest.json
+++ b/scheb/2fa/6.0/manifest.json
@@ -1,0 +1,9 @@
+{
+    "bundles": {
+        "Scheb\\TwoFactorBundle\\SchebTwoFactorBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "aliases": ["2fa"]
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

As of version 5.0, scheb/2fa-bundle is now named scheb/2fa. This moves the recipes/alias to the new package name.

I also added config for the 6.x-dev version. I'm not sure how we manage recipes for unstable versions, but it allows to remove some config for guards. I'm happy to remove the commit if we don't want unstable recipes in this repo.

cc @scheb 