### PR TITLE
Tweak controllers.json path to support Windows

### DIFF
--- a/symfony/webpack-encore-bundle/1.9/webpack.config.js
+++ b/symfony/webpack-encore-bundle/1.9/webpack.config.js
@@ -1,4 +1,5 @@
 const Encore = require('@symfony/webpack-encore');
+const { join } = require('path');
 
 // Manually configure the runtime environment if not already configured yet by the "encore" command.
 // It's useful when you use tools that rely on webpack.config.js file.
@@ -23,7 +24,7 @@ Encore
     .addEntry('app', './assets/app.js')
 
     // enables the Symfony UX Stimulus bridge (used in assets/bootstrap.js)
-    .enableStimulusBridge('./assets/controllers.json')
+    .enableStimulusBridge(join(__dirname, './assets/controllers.json'))
 
     // When enabled, Webpack "splits" your files into smaller pieces for greater optimization.
     .splitEntryChunks()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | symfony/symfony-docs#...

<!--
Please, carefully read the README before submitting a pull request.
-->


Hello, @weaverryan 
for some reason webpack method [enableStimulusBridge](https://github.com/symfony/recipes/blob/master/symfony/webpack-encore-bundle/1.9/webpack.config.js#L26) cannot find `controllers.json` in `assets` folder in windows 10 operating system while passing the absolute path for the file`controllers.json` works


#### How the issue started?
after installing `@symfony/ux-dropzone` and running `yarn dev` webpack encore displayed the following error:

```
 ERROR  Failed to compile with 1 errors                                                                                      12:59:43 AM
 error  in ./node_modules/@symfony/stimulus-bridge/controllers.json                                                          12:59:43 AM
Module build failed (from ./node_modules/@symfony/stimulus-bridge/dist/webpack/loader.js):
Error: Your controllers.json file was not found. Be sure to add a Webpack alias from "@symfony/stimulus-bridge/controllers.json" to *your* controllers.json file.
```

keep in mind that i was using the default `webpack.config.js` and `controllers.json` exists in `assets` folder.

#### Details about my environment:
```
Node Version: v14.18.1
Webpack Version: 1.7.0
```


#### How did i fix it ?
```js
// webpack.config.js
const { join } = require('path');

// get the absolute path for the current working directory using `__dirname` and concatenate it with ./aseets/controllers.json
enableStimulusBridge(join(__dirname, './assets/controllers.json'))
```


_thanks.._
