### PR TITLE
Tweaking "post install" message: Encore functions may already be uncommented

### DIFF
--- a/symfony/webpack-encore-bundle/1.9/post-install.txt
+++ b/symfony/webpack-encore-bundle/1.9/post-install.txt
@@ -1,5 +1,5 @@
   * Install Yarn and run <fg=green>yarn install</>
 
-  * Uncomment the Twig helpers in <fg=green>templates/base.html.twig</>
+  * Uncomment the Twig helpers in <fg=green>templates/base.html.twig</> (they may be already)
 
   * Start the development server: <fg=green>yarn encore dev-server</>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | Working on updating docs now...

If you have TwigBundle 5.4, then the helpers are already uncommented. But since we don't know what version of TwigBundle the user has, I think, for now, this is the best middleground.

Cheers!