### PR TITLE
Recipe files for scheb/2fa-bundle v6

### DIFF
--- a/scheb/2fa-bundle/5.0/config/packages/scheb_2fa.yaml
+++ b/scheb/2fa-bundle/5.0/config/packages/scheb_2fa.yaml
@@ -1,4 +1,4 @@
-# See the configuration reference at https://github.com/scheb/2fa/blob/master/doc/configuration.md
+# See the configuration reference at https://symfony.com/bundles/SchebTwoFactorBundle/5.x/configuration.html
 scheb_two_factor:
     security_tokens:
         - Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken

--- a/scheb/2fa-bundle/6.0/config/packages/scheb_2fa.yaml
+++ b/scheb/2fa-bundle/6.0/config/packages/scheb_2fa.yaml
@@ -1,0 +1,5 @@
+# See the configuration reference at https://symfony.com/bundles/SchebTwoFactorBundle/6.x/configuration.html
+scheb_two_factor:
+    security_tokens:
+        - Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken
+        - Symfony\Component\Security\Http\Authenticator\Token\PostAuthenticationToken

--- a/scheb/2fa-bundle/6.0/config/routes/scheb_2fa.yaml
+++ b/scheb/2fa-bundle/6.0/config/routes/scheb_2fa.yaml
@@ -1,0 +1,7 @@
+2fa_login:
+    path: /2fa
+    defaults:
+        _controller: "scheb_two_factor.form_controller:form"
+
+2fa_login_check:
+    path: /2fa_check

--- a/scheb/2fa-bundle/6.0/manifest.json
+++ b/scheb/2fa-bundle/6.0/manifest.json
@@ -1,0 +1,9 @@
+{
+    "bundles": {
+        "Scheb\\TwoFactorBundle\\SchebTwoFactorBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "aliases": ["2fa"]
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

- Add up-to-date recipe files for `scheb/2fa-bundle` version 6
- Fix the documentation URL on v5