### PR TITLE
[FrameworkBundle] Remove src/Tests from list of excluded folders

### DIFF
--- a/symfony/framework-bundle/4.2/config/services.yaml
+++ b/symfony/framework-bundle/4.2/config/services.yaml
@@ -15,7 +15,7 @@ services:
     # this creates a service per class whose id is the fully-qualified class name
     App\:
         resource: '../src/*'
-        exclude: '../src/{DependencyInjection,Entity,Tests,Kernel.php}'
+        exclude: '../src/{DependencyInjection,Entity,Kernel.php}'
 
     # controllers are imported separately to make sure services can be injected
     # as action arguments even if you don't extend any base controller class

--- a/symfony/framework-bundle/4.4/config/services.yaml
+++ b/symfony/framework-bundle/4.4/config/services.yaml
@@ -19,7 +19,6 @@ services:
             - '../src/DependencyInjection/'
             - '../src/Entity/'
             - '../src/Kernel.php'
-            - '../src/Tests/'
 
     # controllers are imported separately to make sure services can be injected
     # as action arguments even if you don't extend any base controller class

--- a/symfony/framework-bundle/5.1/config/services.yaml
+++ b/symfony/framework-bundle/5.1/config/services.yaml
@@ -19,7 +19,6 @@ services:
             - '../src/DependencyInjection/'
             - '../src/Entity/'
             - '../src/Kernel.php'
-            - '../src/Tests/'
 
     # controllers are imported separately to make sure services can be injected
     # as action arguments even if you don't extend any base controller class

--- a/symfony/framework-bundle/5.2/config/services.yaml
+++ b/symfony/framework-bundle/5.2/config/services.yaml
@@ -19,7 +19,6 @@ services:
             - '../src/DependencyInjection/'
             - '../src/Entity/'
             - '../src/Kernel.php'
-            - '../src/Tests/'
 
     # controllers are imported separately to make sure services can be injected
     # as action arguments even if you don't extend any base controller class

--- a/symfony/framework-bundle/5.3/config/services.yaml
+++ b/symfony/framework-bundle/5.3/config/services.yaml
@@ -19,7 +19,6 @@ services:
             - '../src/DependencyInjection/'
             - '../src/Entity/'
             - '../src/Kernel.php'
-            - '../src/Tests/'
 
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones

--- a/symfony/framework-bundle/5.4/config/services.yaml
+++ b/symfony/framework-bundle/5.4/config/services.yaml
@@ -19,7 +19,6 @@ services:
             - '../src/DependencyInjection/'
             - '../src/Entity/'
             - '../src/Kernel.php'
-            - '../src/Tests/'
 
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

Since Symfony 4 & Flex the default directory structure doesn't have a `src/Tests` folder making the exclude redundant.