### PR TITLE
Specify charset when using MySQL

### DIFF
--- a/doctrine/doctrine-bundle/2.3/manifest.json
+++ b/doctrine/doctrine-bundle/2.3/manifest.json
@@ -11,7 +11,7 @@
         "#2": "IMPORTANT: You MUST configure your server version, either here or in config/packages/doctrine.yaml",
         "#3": "",
         "#4": "DATABASE_URL=\"sqlite:///%kernel.project_dir%/var/data.db\"",
-        "#5": "DATABASE_URL=\"mysql://db_user:db_password@127.0.0.1:3306/db_name?serverVersion=5.7\"",
+        "#5": "DATABASE_URL=\"mysql://db_user:db_password@127.0.0.1:3306/db_name?serverVersion=5.7&charset=utf8mb4\"",
         "DATABASE_URL": "postgresql://db_user:db_password@127.0.0.1:5432/db_name?serverVersion=13&charset=utf8"
     },
     "dockerfile": [

--- a/doctrine/doctrine-bundle/2.4/manifest.json
+++ b/doctrine/doctrine-bundle/2.4/manifest.json
@@ -11,7 +11,7 @@
         "#2": "IMPORTANT: You MUST configure your server version, either here or in config/packages/doctrine.yaml",
         "#3": "",
         "#4": "DATABASE_URL=\"sqlite:///%kernel.project_dir%/var/data.db\"",
-        "#5": "DATABASE_URL=\"mysql://db_user:db_password@127.0.0.1:3306/db_name?serverVersion=5.7\"",
+        "#5": "DATABASE_URL=\"mysql://db_user:db_password@127.0.0.1:3306/db_name?serverVersion=5.7&charset=utf8mb4\"",
         "DATABASE_URL": "postgresql://symfony:ChangeMe@127.0.0.1:5432/app?serverVersion=13&charset=utf8"
     },
     "dockerfile": [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc PR  | https://github.com/symfony/symfony-docs/pull/16515


Because of backward-compatibility reasons, not specifying the charset
will result in "utf8" being used, which is a deprecated charset.
Also, when the charset for creating tables is not specified, the one
specified in the DSN is reused if specified.

In the future, DBAL is going to drop default values, which means we will
have to specify a charset anyway.

See:
- https://github.com/doctrine/dbal/pull/5277 (about the reuse of connection charset for table charset)
- https://github.com/doctrine/dbal/pull/4644