### PR TITLE
Skip recipe for doctrine/annotations when symfony/routing 6 is installed

### DIFF
--- a/doctrine/annotations/1.10/manifest.json
+++ b/doctrine/annotations/1.10/manifest.json
@@ -1,0 +1,5 @@
+{
+    "conflict": {
+        "symfony/routing": "<6.0"
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

Fix #1030