### PR TITLE
monolog-bundle: forward deprecations to nested handler

### DIFF
--- a/symfony/monolog-bundle/3.7/config/packages/monolog.yaml
+++ b/symfony/monolog-bundle/3.7/config/packages/monolog.yaml
@@ -46,6 +46,10 @@ when@prod:
                 handler: nested
                 excluded_http_codes: [404, 405]
                 buffer_size: 50 # How many messages should be saved? Prevent memory leaks
+            deprecation:
+                type: filter
+                handler: nested
+                channels: [deprecation]
             nested:
                 type: stream
                 path: php://stderr
@@ -55,7 +59,3 @@ when@prod:
                 type: console
                 process_psr_3_messages: false
                 channels: ["!event", "!doctrine"]
-            deprecation:
-                type: stream
-                channels: [deprecation]
-                path: php://stderr


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | symfony/symfony-docs#...

I tend to believe  in prod a single log handler for persistence (eg. `nested`) is common, rather than multiple streams.

As such this PR forwards deprecations to the nested handler (in our case syslog).

It reduces a duplicated stream.

It unifies log formatting.
