### PR TITLE
Update monolog.yaml

### DIFF
--- a/symfony/monolog-bundle/3.7/config/packages/monolog.yaml
+++ b/symfony/monolog-bundle/3.7/config/packages/monolog.yaml
@@ -10,14 +10,6 @@ when@dev:
                 path: "%kernel.logs_dir%/%kernel.environment%.log"
                 level: debug
                 channels: ["!event"]
-            # uncomment to get logging in your browser
-            # you may have to allow bigger header sizes in your Web server configuration
-            #firephp:
-            #    type: firephp
-            #    level: info
-            #chromephp:
-            #    type: chromephp
-            #    level: info
             console:
                 type: console
                 process_psr_3_messages: false


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | symfony/symfony-docs#...

https://github.com/search?l=YAML&o=desc&q=%22uncomment+to+get+logging+in+your+browser%22&s=indexed&type=Code

AFAIK web-developer-toolbar is defacto tool.

I understand this doesnt solve anything, other than clean/sensible defaults / less git changes :angel: 
