### PR TITLE
[mailer] recipe: docker-compose ports as string

### DIFF
--- a/symfony/mailer/4.3/manifest.json
+++ b/symfony/mailer/4.3/manifest.json
@@ -10,7 +10,7 @@
             "services": [
                 "mailer:",
                 "  image: schickling/mailcatcher",
-                "  ports: [1025, 1080]"
+                "  ports: [\"1025\", \"1080\"]"
             ]
         }
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | 

<!--
Please, carefully read the README before submitting a pull request.
-->

This change is required to allow compatibility with [podman-compose](https://github.com/containers/podman-compose).

If ports are declared as int (AKA not in quote marks), podman-compose errors with: `TypeError: port should be either string or dict`

The relevant spec for this is: https://github.com/compose-spec/compose-spec/blob/master/spec.md#ports

> Either specify both ports (HOST:CONTAINER), or just the container port. In the latter case, the Compose implementation SHOULD automatically allocate any unassigned host port.
> 
> HOST:CONTAINER SHOULD always be specified as a (quoted) string, to avoid conflicts with [yaml base-60 float](https://yaml.org/type/float.html).

So this says port must be quoted string when specified as HOST:CONTAINER. But no explicit instructions for just the container port.

Whether to do this change or not, I'll leave it up to the symfony team. I'll also open a issue in podman-compose repo.