### PR TITLE
[symfony/twig-bundle] add flash messages to `base.html.twig`

### DIFF
--- a/symfony/twig-bundle/5.4/templates/base.html.twig
+++ b/symfony/twig-bundle/5.4/templates/base.html.twig
@@ -14,6 +14,18 @@
         {% endblock %}
     </head>
     <body>
+        {% block flashes %}
+            {% if app.request.hasPreviousSession %}
+                {% for type, messages in app.flashes %}
+                    {% for message in messages %}
+                        <div class="alert alert-{{ type }}" role="alert">
+                            {{ message }}
+                        </div>
+                    {% endfor %}
+                {% endfor %}
+            {% endif %}
+        {% endblock %}
+
         {% block body %}{% endblock %}
     </body>
 </html>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | n/a

This adds out of the box flash message support to `base.html.twig`. If there is no session or no flashes, this block will be ignored.
