### PR TITLE
Adding a new callable recipes readme GH action

### DIFF
--- a/.github/workflows/callable-recipe-readme-update.yml
+++ b/.github/workflows/callable-recipe-readme-update.yml
@@ -1,0 +1,48 @@
+name: Update RECIPES.md
+
+on:
+    workflow_call:
+        inputs:
+            # branch where the RECIPES.md will be committed
+            branch:
+                required: true
+                type: string
+            contrib:
+                required: false
+                type: boolean
+
+jobs:
+    call-recipe-readme-update:
+        name: Update RECIPES.md
+        runs-on: Ubuntu-20.04
+
+        steps:
+            -
+                name: Checkout
+                uses: actions/checkout@v2
+                id: checkout
+                with:
+                    fetch-depth: 0
+
+            -
+                name: Install tools
+                run: |
+                    git config --global user.email ""
+                    git config --global user.name "github-action[bot]"
+                    cd .github
+                    wget -q -O recipes-checker.zip https://codeload.github.com/symfony-tools/recipes-checker/zip/refs/heads/main
+                    unzip recipes-checker.zip
+                    cd recipes-checker-main
+                    composer install --ansi --no-dev
+
+            -
+                name: Generate Recipes README
+                run: |
+                    mkdir .github/recipe-readme
+                    git switch flex/main
+                    php .github/recipes-checker-main/run generate:recipes-readme index.json ${{ inputs.contrib && '--contrib' || '' }} > .github/recipe-readme/RECIPES.md
+                    git switch ${{ inputs.branch }}
+                    cp .github/recipe-readme/RECIPES.md RECIPES.md
+                    git add RECIPES.md
+                    git commit -m 'Update Recipes README' || true
+                    git push origin ${{ inputs.branch }}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | None

Relates to https://github.com/symfony-tools/recipes-checker/pull/9. That should be merged first, then I can test this on a fork.