### PR TITLE
Switching recipes readme to be on flex-main branch

### DIFF
--- a/.github/workflows/callable-recipe-readme-update.yml
+++ b/.github/workflows/callable-recipe-readme-update.yml
@@ -3,10 +3,6 @@ name: Update RECIPES.md
 on:
     workflow_call:
         inputs:
-            # branch where the RECIPES.md will be committed
-            branch:
-                required: true
-                type: string
             contrib:
                 required: false
                 type: boolean
@@ -41,8 +37,7 @@ jobs:
                     mkdir .github/recipe-readme
                     git switch flex/main
                     php .github/recipes-checker-main/run generate:recipes-readme index.json ${{ inputs.contrib && '--contrib' || '' }} > .github/recipe-readme/RECIPES.md
-                    git switch ${{ inputs.branch }}
                     cp .github/recipe-readme/RECIPES.md RECIPES.md
                     git add RECIPES.md
                     git commit -m 'Update Recipes README' || true
-                    git push origin ${{ inputs.branch }}
+                    git push origin flex/main

--- a/.github/workflows/flex-update.yml
+++ b/.github/workflows/flex-update.yml
@@ -18,5 +18,3 @@ jobs:
     call-recipe-readme-update:
         needs: 'call-flex-update'
         uses: symfony/recipes/.github/workflows/callable-recipe-readme-update.yml@main
-        with:
-            branch: main

--- a/README.rst
+++ b/README.rst
@@ -370,4 +370,4 @@ one used by ``symfony/framework-bundle``:
 .. _`Symfony Flex`: https://github.com/symfony/flex
 .. _`contrib repository`: https://github.com/symfony/recipes-contrib
 .. _`Symfony Console styles and colors`: https://symfony.com/doc/current/console/coloring.html
-.. _`RECIPES.md`: https://github.com/symfony/recipes/blob/main/RECIPES.md
+.. _`RECIPES.md`: https://github.com/symfony/recipes/blob/flex/main/RECIPES.md


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | Not needed

See: https://github.com/symfony/recipes/pull/1079#issuecomment-1114031628

This changes the `RECIPES.md` to live on the flex/main branch... which is fine. We we link to it, it's mostly there as a resource IF you need it.

Tested over on my fork (though, that wasn't enough last time due to permission differences in the settings between the branches).

RELATED
* update recipes-checker to update URL to the RECIPES.md: https://github.com/symfony-tools/recipes-checker/pull/10
* Update contrib to not pass the branch arg: https://github.com/symfony/recipes-contrib/pull/1402