### PR TITLE
Using Encore 2.0

### DIFF
--- a/symfony/webpack-encore-bundle/1.10/package.json
+++ b/symfony/webpack-encore-bundle/1.10/package.json
@@ -2,7 +2,7 @@
     "devDependencies": {
         "@hotwired/stimulus": "^3.0.0",
         "@symfony/stimulus-bridge": "^3.0.0",
-        "@symfony/webpack-encore": "^1.7.0",
+        "@symfony/webpack-encore": "^2.0.0",
         "core-js": "^3.0.0",
         "regenerator-runtime": "^0.13.2",
         "webpack-notifier": "^1.6.0"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | None: I don't see any mention of the Encore version in the docs, nor has anything changed that would need updating.

See: https://github.com/symfony/webpack-encore/releases/tag/v2.0.0