### PR TITLE
[webpack-encore-bundle] disable strict_mode by default

### DIFF
--- a/symfony/webpack-encore-bundle/1.10/config/packages/webpack_encore.yaml
+++ b/symfony/webpack-encore-bundle/1.10/config/packages/webpack_encore.yaml
@@ -20,8 +20,8 @@ webpack_encore:
     # Preload all rendered script and link tags automatically via the HTTP/2 Link header
     # preload: true
 
-    # Throw an exception if the entrypoints.json file is missing or an entry is missing from the data
-    # strict_mode: false
+    # Set to true to throw an exception if the entrypoints.json file is missing or an entry is missing from the data
+    strict_mode: false
 
     # If you have multiple builds:
     # builds:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

Now that webapp-pack [contains webpack-encore-bundle](https://github.com/symfony/webapp-pack/blob/main/composer.json#L31), extending [`base.html.twig`](https://github.com/symfony/recipes/blob/main/symfony/twig-bundle/5.4/templates/base.html.twig) throws an exception unless one runs `yarn` beforehand.

This is bad DX for newcomers.