### PR TITLE
Revert "[webpack-encore-bundle] disable strict_mode by default"

### DIFF
--- a/symfony/webpack-encore-bundle/1.10/config/packages/webpack_encore.yaml
+++ b/symfony/webpack-encore-bundle/1.10/config/packages/webpack_encore.yaml
@@ -20,8 +20,8 @@ webpack_encore:
     # Preload all rendered script and link tags automatically via the HTTP/2 Link header
     # preload: true
 
-    # Set to true to throw an exception if the entrypoints.json file is missing or an entry is missing from the data
-    strict_mode: false
+    # Throw an exception if the entrypoints.json file is missing or an entry is missing from the data
+    # strict_mode: false
 
     # If you have multiple builds:
     # builds:


### PR DESCRIPTION
Reverts symfony/recipes#1087

Not needed since https://github.com/symfony/webapp-pack/pull/7