### PR TITLE
Fix small typo in symfony/webpack-encore-bundle

### DIFF
--- a/symfony/webpack-encore-bundle/1.10/webpack.config.js
+++ b/symfony/webpack-encore-bundle/1.10/webpack.config.js
@@ -11,7 +11,7 @@ Encore
     .setOutputPath('public/build/')
     // public path used by the web server to access the output path
     .setPublicPath('/build')
-    // only needed for CDN's or sub-directory deploy
+    // only needed for CDN's or subdirectory deploy
     //.setManifestKeyPrefix('build/')
 
     /*


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | N/A

"Subdirectory" is correctly spelled as one word.
