### PR TITLE
[symfony/mailer] follow string recommendations

### DIFF
--- a/symfony/mailer/4.3/manifest.json
+++ b/symfony/mailer/4.3/manifest.json
@@ -10,7 +10,7 @@
             "services": [
                 "mailer:",
                 "  image: schickling/mailcatcher",
-                "  ports: [1025, 1080]"
+                "  ports: [\"1025\", \"1080\"]"
             ]
         }
     },


### PR DESCRIPTION
Follow Docker's string recommendations for port mappings: https://docs.docker.com/compose/compose-file/compose-file-v3/#ports

| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | N/A
