### PR TITLE
bumping encore to v3 and increasing some other dependencies

### DIFF
--- a/symfony/webpack-encore-bundle/1.10/package.json
+++ b/symfony/webpack-encore-bundle/1.10/package.json
@@ -1,11 +1,11 @@
 {
     "devDependencies": {
         "@hotwired/stimulus": "^3.0.0",
-        "@symfony/stimulus-bridge": "^3.0.0",
-        "@symfony/webpack-encore": "^2.0.0",
-        "core-js": "^3.0.0",
-        "regenerator-runtime": "^0.13.2",
-        "webpack-notifier": "^1.6.0"
+        "@symfony/stimulus-bridge": "^3.2.0",
+        "@symfony/webpack-encore": "^3.0.0",
+        "core-js": "^3.23.0",
+        "regenerator-runtime": "^0.13.9",
+        "webpack-notifier": "^1.15.0"
     },
     "license": "UNLICENSED",
     "private": true,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | Not needed

Encore 3 is out: https://github.com/symfony/webpack-encore/releases/tag/v3.0.0

The other version bumps aren't necessary and we don't need to keep them up to date. Still, it seems prudent to occasionally bump them to a version closer to the latest.

Cheers!