### PR TITLE
Packages that do not support symfony6 ignore errors when symfony6 sup…

### DIFF
--- a/.github/workflows/callable-qa.yml
+++ b/.github/workflows/callable-qa.yml
@@ -288,3 +288,10 @@ jobs:
                     composer config minimum-stability dev
                     export SYMFONY_ENDPOINT=https://raw.githubusercontent.com/${{ github.repository }}/flex/pull-${{ github.event.number }}/index.json
                     composer require -W --ansi $PACKAGES
+                    EXIT_CODE=$?
+
+                    if [[ EXIT_CODE -eq 2 ]]; then
+                        echo -e "\n#\n#\n# You can ignore this error if your package does not support Symfony 6\n#\n#\n#\n"
+                    fi
+
+                    exit $EXIT_CODE


### PR DESCRIPTION
…port checks, pass validation

| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | symfony/symfony-docs#...

<!--
Please, carefully read the README before submitting a pull request.
-->

My library only supports up to 5.4 not symfony6 , and my pull requests always fail when symfony6 checks automatically

[#1423](https://github.com/symfony/recipes-contrib/issues/1423)