### PR TITLE
Add example how to bind arguments to the services.yaml

### DIFF
--- a/symfony/framework-bundle/6.2/config/services.yaml
+++ b/symfony/framework-bundle/6.2/config/services.yaml
@@ -10,6 +10,8 @@ services:
     _defaults:
         autowire: true      # Automatically injects dependencies in your services.
         autoconfigure: true # Automatically registers your services as commands, event subscribers, etc.
+        # Bind arguments globally
+        # https://symfonycasts.com/screencast/symfony-fundamentals/global-bind
         #bind:
         #    'bool $isDebug': '%kernel.debug%'
 

--- a/symfony/framework-bundle/6.2/config/services.yaml
+++ b/symfony/framework-bundle/6.2/config/services.yaml
@@ -10,8 +10,8 @@ services:
     _defaults:
         autowire: true      # Automatically injects dependencies in your services.
         autoconfigure: true # Automatically registers your services as commands, event subscribers, etc.
-        # Bind arguments globally
-        # https://symfonycasts.com/screencast/symfony-fundamentals/global-bind
+        # Binding arguments by name or type
+        # https://symfony.com/doc/current/service_container.html#binding-arguments-by-name-or-type
         #bind:
         #    'bool $isDebug': '%kernel.debug%'
 

--- a/symfony/framework-bundle/6.2/config/services.yaml
+++ b/symfony/framework-bundle/6.2/config/services.yaml
@@ -10,6 +10,9 @@ services:
     _defaults:
         autowire: true      # Automatically injects dependencies in your services.
         autoconfigure: true # Automatically registers your services as commands, event subscribers, etc.
+        #bind:
+        #    'bool $isDebug': '%kernel.debug%'
+
 
     # makes classes in src/ available to be used as services
     # this creates a service per class whose id is the fully-qualified class name


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | symfony/symfony-docs#...

I always must google if it is `services.bind`, `services._bind` or `services._defaults.bind` or even `services._defaults._bind`. Think it would be great to have this example in it.
