### PR TITLE
Doctrine Migration profiler disabled by default

### DIFF
--- a/doctrine/doctrine-migrations-bundle/3.1/config/packages/doctrine_migrations.yaml
+++ b/doctrine/doctrine-migrations-bundle/3.1/config/packages/doctrine_migrations.yaml
@@ -3,4 +3,4 @@ doctrine_migrations:
         # namespace is arbitrary but should be different from App\Migrations
         # as migrations classes should NOT be autoloaded
         'DoctrineMigrations': '%kernel.project_dir%/migrations'
-    enable_profiler: '%kernel.debug%'
+    enable_profiler: false # '%kernel.debug%' 

--- a/doctrine/doctrine-migrations-bundle/3.1/config/packages/doctrine_migrations.yaml
+++ b/doctrine/doctrine-migrations-bundle/3.1/config/packages/doctrine_migrations.yaml
@@ -3,4 +3,4 @@ doctrine_migrations:
         # namespace is arbitrary but should be different from App\Migrations
         # as migrations classes should NOT be autoloaded
         'DoctrineMigrations': '%kernel.project_dir%/migrations'
-    enable_profiler: false # '%kernel.debug%' 
+    enable_profiler: false


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | https://github.com/symfony/symfony/issues/47275

imho we should not activate this by default, but rather let ppl discover this feature as [documented here](https://github.com/doctrine/DoctrineMigrationsBundle/pull/471)