### PR TITLE
[symfony/webpack-encore-bundle] Update babel preset-env config to use corejs 3.23

### DIFF
--- a/symfony/webpack-encore-bundle/1.10/webpack.config.js
+++ b/symfony/webpack-encore-bundle/1.10/webpack.config.js
@@ -53,7 +53,7 @@ Encore
     // enables and configure @babel/preset-env polyfills
     .configureBabelPresetEnv((config) => {
         config.useBuiltIns = 'usage';
-        config.corejs = 3;
+        config.corejs = '3.23';
     })
 
     // enables Sass/SCSS support


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | symfony/symfony-docs#...

Now that the minimum version for core-js has been bumped to 3.23 in package.json, it should be bumped in the @babel/preset-env configuration also.

The reason for this is explained well here: https://babeljs.io/docs/en/babel-preset-env#corejs

> It is recommended to specify the minor version otherwise "3" will be interpreted as "3.0" which may not include polyfills for the latest features.

This means polyfills released between > 3.0 and <= 3.23 are not being included during builds with the current default configuration.
