### PR TITLE
add MAILER_DSN by default

### DIFF
--- a/symfony/mailer/4.3/config/packages/mailer.yaml
+++ b/symfony/mailer/4.3/config/packages/mailer.yaml
@@ -1,3 +1,6 @@
+parameters:
+    env(MAILER_DSN): 'null://null'
+
 framework:
     mailer:
         dsn: '%env(MAILER_DSN)%'

--- a/symfony/mailer/4.3/manifest.json
+++ b/symfony/mailer/4.3/manifest.json
@@ -3,7 +3,7 @@
         "config/": "%CONFIG_DIR%/"
     },
     "env": {
-        "MAILER_DSN": "null://null"
+        "#1": "MAILER_DSN=null://null"
     },
     "docker-compose": {
         "docker-compose.override.yml": {

--- a/symfony/mailer/4.3/manifest.json
+++ b/symfony/mailer/4.3/manifest.json
@@ -3,7 +3,7 @@
         "config/": "%CONFIG_DIR%/"
     },
     "env": {
-        "#1": "MAILER_DSN=null://null"
+        "MAILER_DSN": "null://null"
     },
     "docker-compose": {
         "docker-compose.override.yml": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | symfony/symfony-docs#...

I would like to have `MAILER_DSN` by default set to something. When the user now uses the mailer before changing the `.env` the code breaks and throws an exception as the env is not set