### PR TITLE
switch schickling/mailcatcher to jeanberu/mailcatcher

### DIFF
--- a/symfony/mailer/4.3/manifest.json
+++ b/symfony/mailer/4.3/manifest.json
@@ -9,7 +9,7 @@
         "docker-compose.override.yml": {
             "services": [
                 "mailer:",
-                "  image: schickling/mailcatcher",
+                "  image: jeanberu/mailcatcher",
                 "  ports: [1025, 1080]"
             ]
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | symfony/symfony-docs#...

<!--
Please, carefully read the README before submitting a pull request.
-->

Replace `schickling/mailcatcher` Docker image with `jeanberu/mailcatcher` because it is smaller with less MB.
Functionality should be the same.

`schickling/mailcatcher`: Compressed size: 25.44 MB
https://github.com/schickling/dockerfiles/blob/master/mailcatcher/Dockerfile

`jeanberu/mailcatcher`: Compressed size: 15.27 MB
https://github.com/Jean-Beru/docker-mailcatcher/blob/master/Dockerfile

This should save some MBs on the internets.