### PR TITLE
use flock in default as it works out of the box

### DIFF
--- a/symfony/lock/4.4/manifest.json
+++ b/symfony/lock/4.4/manifest.json
@@ -5,6 +5,6 @@
     "env": {
         "#1": "Choose one of the stores below",
         "#2": "LOCK_DSN=redis://localhost",
-        "LOCK_DSN": "semaphore"
+        "LOCK_DSN": "flock"
     }
 }

--- a/symfony/lock/5.2/manifest.json
+++ b/symfony/lock/5.2/manifest.json
@@ -5,6 +5,6 @@
     "env": {
         "#1": "Choose one of the stores below",
         "#2": "postgresql+advisory://db_user:db_password@localhost/db_name",
-        "LOCK_DSN": "semaphore"
+        "LOCK_DSN": "flock"
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

`semaphore` is not always installed in any system. So it would be better to have a default which works everywhere