### PR TITLE
Put doctrine proxies in build dir for production

### DIFF
--- a/doctrine/doctrine-bundle/2.4/config/packages/doctrine.yaml
+++ b/doctrine/doctrine-bundle/2.4/config/packages/doctrine.yaml
@@ -26,6 +26,7 @@ when@prod:
     doctrine:
         orm:
             auto_generate_proxy_classes: false
+            proxy_dir: '%kernel.build_dir%/doctrine/orm/Proxies'
             query_cache_driver:
                 type: pool
                 pool: doctrine.system_cache_pool


### PR DESCRIPTION
When auto_generate_proxy_classes: false is set, the proxies need to be pre-generated with the cache warmer. So in this case, the files are much better suited in the build dir. The build dir is the same as the cache dir by default. But for people trying to use the build dir properly, this makes much more sense. See https://github.com/symfony/symfony/issues/40827#issuecomment-820653578

| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | 
