### PR TITLE
Use UUID v7 as default for new projects

### DIFF
--- a/symfony/framework-bundle/6.2/config/packages/uid.yaml
+++ b/symfony/framework-bundle/6.2/config/packages/uid.yaml
@@ -1,0 +1,4 @@
+framework:
+    uid:
+        default_uuid_version: 7
+        time_based_uuid_version: 7


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | n/a

Symfony 6.2 introduces support for UUID v7, which is to be preferred over UUID v6 [according to the draft RFC][1]:

> Implementations SHOULD utilize UUID version 7 over UUID version 1 and
> 6 if possible.

In order not to change the UUID generation in existing projects, UUID v7 could be configured as default for new projects via this recipe.

[1]: https://www.ietf.org/archive/id/draft-peabody-dispatch-new-uuid-format-04.html#section-5.2-2