### PR TITLE
Add lock as an alias for symfony/lock

### DIFF
--- a/symfony/lock/4.4/manifest.json
+++ b/symfony/lock/4.4/manifest.json
@@ -6,5 +6,6 @@
         "#1": "Choose one of the stores below",
         "#2": "LOCK_DSN=redis://localhost",
         "LOCK_DSN": "flock"
-    }
+    },
+    "aliases": ["lock"]
 }

--- a/symfony/lock/5.2/manifest.json
+++ b/symfony/lock/5.2/manifest.json
@@ -6,5 +6,6 @@
         "#1": "Choose one of the stores below",
         "#2": "postgresql+advisory://db_user:db_password@localhost/db_name",
         "LOCK_DSN": "flock"
-    }
+    },
+    "aliases": ["lock"]
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | N/A

Add `lock` as an alias for `symfony/lock`, so that you can use `composer req lock`.
