### PR TITLE
Revert "Add example how to bind arguments to the services.yaml (#1119)"

### DIFF
--- a/symfony/framework-bundle/6.2/config/services.yaml
+++ b/symfony/framework-bundle/6.2/config/services.yaml
@@ -10,11 +10,6 @@ services:
     _defaults:
         autowire: true      # Automatically injects dependencies in your services.
         autoconfigure: true # Automatically registers your services as commands, event subscribers, etc.
-        # Binding arguments by name or type
-        # https://symfony.com/doc/current/service_container.html#binding-arguments-by-name-or-type
-        #bind:
-        #    'bool $isDebug': '%kernel.debug%'
-
 
     # makes classes in src/ available to be used as services
     # this creates a service per class whose id is the fully-qualified class name


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

Reverting #1119

In 6.2, people are going to use `#[Autowire]` most of the time instead IMHO.