### PR TITLE
[encore] Removed duplicate cache config comment

### DIFF
--- a/symfony/webpack-encore-bundle/1.10/config/packages/webpack_encore.yaml
+++ b/symfony/webpack-encore-bundle/1.10/config/packages/webpack_encore.yaml
@@ -30,10 +30,6 @@ webpack_encore:
         # pass the build name as the 3rd argument to the Twig functions
         # {{ encore_entry_script_tags('entry1', null, 'frontend') }}
 
-    # Cache the entrypoints.json (rebuild Symfony's cache when entrypoints.json changes)
-    # Put in config/packages/prod/webpack_encore.yaml
-    # cache: true
-
 framework:
     assets:
         json_manifest_path: '%kernel.project_dir%/public/build/manifest.json'


### PR DESCRIPTION
The cache option is explained twice, feels like the one under `webpack_encore` https://github.com/symfony/recipes/blob/923757ec093b9b7831891af0462bd5dfb031f020/symfony/webpack-encore-bundle/1.10/config/packages/webpack_encore.yaml#L33-L35 was left over still showing the old config.

But the same thing is written down at the new `when@prod` https://github.com/symfony/recipes/blob/923757ec093b9b7831891af0462bd5dfb031f020/symfony/webpack-encore-bundle/1.10/config/packages/webpack_encore.yaml#L43-L45.

| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | symfony/symfony-docs#...
