### PR TITLE
[symfony/ux-live-component] Update config file

### DIFF
--- a/symfony/ux-live-component/2.6/config/routes/ux_live_component.yaml
+++ b/symfony/ux-live-component/2.6/config/routes/ux_live_component.yaml
@@ -1,4 +1,5 @@
 live_component:
+    type: php
     resource: '@LiveComponentBundle/config/routes.php'
     prefix: '/_components'
     # adjust prefix to add localization to your components


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | symfony/symfony-docs#...

Fix an error I have experienced : An exception has been thrown during the rendering of a template ("Unable to generate a URL for the named route "ux_live_component" as such route does not exist.").

symfony 6.1
symfony/ux-live-component 2.6.1
@symfony/stimulus-bridge 3.2.0
