### PR TITLE
fix(doctrine): adding quote to prevent word splitting in Dockerfile

### DIFF
--- a/doctrine/doctrine-bundle/2.8/manifest.json
+++ b/doctrine/doctrine-bundle/2.8/manifest.json
@@ -16,7 +16,7 @@
     },
     "dockerfile": [
         "RUN apk add --no-cache --virtual .pgsql-deps postgresql-dev; \\",
-        "\tdocker-php-ext-install -j$(nproc) pdo_pgsql; \\",
+        "\tdocker-php-ext-install -j\"$(nproc)\" pdo_pgsql; \\",
         "\tapk add --no-cache --virtual .pgsql-rundeps so:libpq.so.5; \\",
         "\tapk del .pgsql-deps"
     ],


### PR DESCRIPTION
Based on hadolint docker, adding quotes to `$(nproc)` to prevent word splitting.

| Q             | A
| ------------- | ---
| License       | MIT

<!--
Please, carefully read the README before submitting a pull request.
-->
