### PR TITLE
[Lexik/JWT] Increase generated JWT_PASSPHRASE length to 64

### DIFF
--- a/lexik/jwt-authentication-bundle/2.5/manifest.json
+++ b/lexik/jwt-authentication-bundle/2.5/manifest.json
@@ -9,7 +9,7 @@
     "env": {
         "JWT_SECRET_KEY": "%kernel.project_dir%/%CONFIG_DIR%/jwt/private.pem",
         "JWT_PUBLIC_KEY": "%kernel.project_dir%/%CONFIG_DIR%/jwt/public.pem",
-        "JWT_PASSPHRASE": "%generate(secret)%"
+        "JWT_PASSPHRASE": "%generate(secret, 32)%"
     },
     "gitignore": [
         "/%CONFIG_DIR%/jwt/*.pem"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

The expression `%generate(secret)%` generates a 32 hex characters long random secret. For the `JWT_PASSPHRASE` this may be too short. OWASP recommends _"at least 64 characters"_. If an attacker gains a valid JWT, they can potentially brute force it locally/offline. The secret is never typed in manually by anyone, so the length doesn't affect usability.
https://cheatsheetseries.owasp.org/cheatsheets/JSON_Web_Token_for_Java_Cheat_Sheet.html#how-to-prevent_5

I propose passing 32 to the generator, which results in a 64 characters long secret, in accordance with the OWASP recommendation. This gives better security if this autogenerated secret is used. It also hints to the user that if they make a different secret, it should be at least this long. If accepted, should we also do the same for the 2.3 manifest?

Counter-argument: 32 random hex chars is still a tall order to brute force. One might say OWASP is over-cautious here, but I'd like to hear other opinions on it.

See also: `APP_SECRET`

**Refs**
https://github.com/symfony/flex/blob/2ff8465e7172790a47ab3c129f2b514eb2d8a286/src/Configurator/EnvConfigurator.php#L189
https://github.com/symfony/flex/blob/2.x/tests/Configurator/EnvConfiguratorTest.php#L181