### PR TITLE
phpunit-bridge[phpunit.xml.dist]: use dynamic xsd managed by phpunit-bridge

### DIFF
--- a/symfony/phpunit-bridge/5.3/phpunit.xml.dist
+++ b/symfony/phpunit-bridge/5.3/phpunit.xml.dist
@@ -2,7 +2,7 @@
 
 <!-- https://phpunit.readthedocs.io/en/latest/configuration.html -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="vendor/bin/.phpunit/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="tests/bootstrap.php"


### PR DESCRIPTION
phpunit-bridge manages phpunit.xsd in the folder `vendor/bin/.phpunit/phpunit.xsd` this allows config to be verified against schema corresponding to the `SYMFONY_PHPUNIT_VERSION` version specified