### PR TITLE
Add mariadb example to DATABASE_URL

### DIFF
--- a/doctrine/doctrine-bundle/2.8/manifest.json
+++ b/doctrine/doctrine-bundle/2.8/manifest.json
@@ -11,7 +11,8 @@
         "#2": "IMPORTANT: You MUST configure your server version, either here or in config/packages/doctrine.yaml",
         "#3": "",
         "#4": "DATABASE_URL=\"sqlite:///%kernel.project_dir%/var/data.db\"",
-        "#5": "DATABASE_URL=\"mysql://app:!ChangeMe!@127.0.0.1:3306/app?serverVersion=8&charset=utf8mb4\"",
+        "#5": "DATABASE_URL=\"mysql://app:!ChangeMe!@127.0.0.1:3306/app?serverVersion=mariadb-10.11&charset=utf8mb4\"",
+        "#6": "DATABASE_URL=\"mysql://app:!ChangeMe!@127.0.0.1:3306/app?serverVersion=8&charset=utf8mb4\"",
         "DATABASE_URL": "postgresql://app:!ChangeMe!@127.0.0.1:5432/app?serverVersion=15&charset=utf8"
     },
     "dockerfile": [

--- a/doctrine/doctrine-bundle/2.8/manifest.json
+++ b/doctrine/doctrine-bundle/2.8/manifest.json
@@ -12,7 +12,7 @@
         "#3": "",
         "#4": "DATABASE_URL=\"sqlite:///%kernel.project_dir%/var/data.db\"",
         "#5": "DATABASE_URL=\"mysql://app:!ChangeMe!@127.0.0.1:3306/app?serverVersion=8.0.36&charset=utf8mb4\"",
-        "#6": "DATABASE_URL=\"mysql://app:!ChangeMe!@127.0.0.1:3306/app?serverVersion=10.11.2-mariadb&charset=utf8mb4\"",
+        "#6": "DATABASE_URL=\"mysql://app:!ChangeMe!@127.0.0.1:3306/app?serverVersion=10.11.2-MariaDB&charset=utf8mb4\"",
         "DATABASE_URL": "postgresql://app:!ChangeMe!@127.0.0.1:5432/app?serverVersion=15.2&charset=utf8"
     },
     "dockerfile": [

--- a/doctrine/doctrine-bundle/2.8/manifest.json
+++ b/doctrine/doctrine-bundle/2.8/manifest.json
@@ -11,7 +11,7 @@
         "#2": "IMPORTANT: You MUST configure your server version, either here or in config/packages/doctrine.yaml",
         "#3": "",
         "#4": "DATABASE_URL=\"sqlite:///%kernel.project_dir%/var/data.db\"",
-        "#5": "DATABASE_URL=\"mysql://app:!ChangeMe!@127.0.0.1:3306/app?serverVersion=8.0.36&charset=utf8mb4\"",
+        "#5": "DATABASE_URL=\"mysql://app:!ChangeMe!@127.0.0.1:3306/app?serverVersion=8.0.32&charset=utf8mb4\"",
         "#6": "DATABASE_URL=\"mysql://app:!ChangeMe!@127.0.0.1:3306/app?serverVersion=10.11.2-MariaDB&charset=utf8mb4\"",
         "DATABASE_URL": "postgresql://app:!ChangeMe!@127.0.0.1:5432/app?serverVersion=15.2&charset=utf8"
     },

--- a/doctrine/doctrine-bundle/2.8/manifest.json
+++ b/doctrine/doctrine-bundle/2.8/manifest.json
@@ -13,7 +13,7 @@
         "#4": "DATABASE_URL=\"sqlite:///%kernel.project_dir%/var/data.db\"",
         "#5": "DATABASE_URL=\"mysql://app:!ChangeMe!@127.0.0.1:3306/app?serverVersion=8.0.32&charset=utf8mb4\"",
         "#6": "DATABASE_URL=\"mysql://app:!ChangeMe!@127.0.0.1:3306/app?serverVersion=10.11.2-MariaDB&charset=utf8mb4\"",
-        "DATABASE_URL": "postgresql://app:!ChangeMe!@127.0.0.1:5432/app?serverVersion=15.2&charset=utf8"
+        "DATABASE_URL": "postgresql://app:!ChangeMe!@127.0.0.1:5432/app?serverVersion=15&charset=utf8"
     },
     "dockerfile": [
         "RUN apk add --no-cache --virtual .pgsql-deps postgresql-dev; \\",

--- a/doctrine/doctrine-bundle/2.8/manifest.json
+++ b/doctrine/doctrine-bundle/2.8/manifest.json
@@ -11,9 +11,9 @@
         "#2": "IMPORTANT: You MUST configure your server version, either here or in config/packages/doctrine.yaml",
         "#3": "",
         "#4": "DATABASE_URL=\"sqlite:///%kernel.project_dir%/var/data.db\"",
-        "#5": "DATABASE_URL=\"mysql://app:!ChangeMe!@127.0.0.1:3306/app?serverVersion=mariadb-10.11&charset=utf8mb4\"",
-        "#6": "DATABASE_URL=\"mysql://app:!ChangeMe!@127.0.0.1:3306/app?serverVersion=8&charset=utf8mb4\"",
-        "DATABASE_URL": "postgresql://app:!ChangeMe!@127.0.0.1:5432/app?serverVersion=15&charset=utf8"
+        "#5": "DATABASE_URL=\"mysql://app:!ChangeMe!@127.0.0.1:3306/app?serverVersion=8.0.36&charset=utf8mb4\"",
+        "#6": "DATABASE_URL=\"mysql://app:!ChangeMe!@127.0.0.1:3306/app?serverVersion=10.11.2-mariadb&charset=utf8mb4\"",
+        "DATABASE_URL": "postgresql://app:!ChangeMe!@127.0.0.1:5432/app?serverVersion=15.2&charset=utf8"
     },
     "dockerfile": [
         "RUN apk add --no-cache --virtual .pgsql-deps postgresql-dev; \\",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | symfony/symfony-docs#...

I did see in the past a lot of misconfigured versions strings for users which did use @sulu with `mariadb` and run into an SQL error because they did not configure the mariadb version string instead used mysql version. Think it would make sense to have also mariadb as an example beside mysql and sqlite.

Related PRs: https://github.com/doctrine/dbal/pull/5971
