### PR TITLE
fix inconsistency for next lexik/jwt-authentication-bundle

### DIFF
--- a/lexik/jwt-authentication-bundle/2.19/config/packages/lexik_jwt_authentication.yaml
+++ b/lexik/jwt-authentication-bundle/2.19/config/packages/lexik_jwt_authentication.yaml
@@ -1,0 +1,4 @@
+lexik_jwt_authentication:
+    secret_key: '%env(resolve:JWT_SECRET_KEY)%'
+    public_key: '%env(resolve:JWT_PUBLIC_KEY)%'
+    pass_phrase: '%env(resolve:JWT_PASSPHRASE)%'

--- a/lexik/jwt-authentication-bundle/2.19/manifest.json
+++ b/lexik/jwt-authentication-bundle/2.19/manifest.json
@@ -1,0 +1,17 @@
+{
+    "bundles": {
+        "Lexik\\Bundle\\JWTAuthenticationBundle\\LexikJWTAuthenticationBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%"
+    },
+    "aliases": ["jwt", "jwt-auth"],
+    "env": {
+        "JWT_SECRET_KEY": "%kernel.project_dir%/%CONFIG_DIR%/jwt/private.pem",
+        "JWT_PUBLIC_KEY": "%kernel.project_dir%/%CONFIG_DIR%/jwt/public.pem",
+        "JWT_PASSPHRASE": "%generate(secret, 32)%"
+    },
+    "gitignore": [
+        "/%CONFIG_DIR%/jwt/*.pem"
+    ]
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

The current version uses `resolve:` inconsistently:

https://github.com/symfony/recipes/blob/dc38f0073eecc3c28906e33354059f987c640018/lexik/jwt-authentication-bundle/2.5/config/packages/lexik_jwt_authentication.yaml#L2-L4

2.19 is the next version: https://github.com/lexik/LexikJWTAuthenticationBundle/releases