### PR TITLE
Remove autowiring aliases for deprecated Httplug factories

### DIFF
--- a/nyholm/psr7/1.0/config/packages/nyholm_psr7.yaml
+++ b/nyholm/psr7/1.0/config/packages/nyholm_psr7.yaml
@@ -7,15 +7,5 @@ services:
     Psr\Http\Message\UploadedFileFactoryInterface: '@nyholm.psr7.psr17_factory'
     Psr\Http\Message\UriFactoryInterface: '@nyholm.psr7.psr17_factory'
 
-    # Register nyholm/psr7 services for autowiring with HTTPlug factories
-    Http\Message\MessageFactory: '@nyholm.psr7.httplug_factory'
-    Http\Message\RequestFactory: '@nyholm.psr7.httplug_factory'
-    Http\Message\ResponseFactory: '@nyholm.psr7.httplug_factory'
-    Http\Message\StreamFactory: '@nyholm.psr7.httplug_factory'
-    Http\Message\UriFactory: '@nyholm.psr7.httplug_factory'
-
     nyholm.psr7.psr17_factory:
         class: Nyholm\Psr7\Factory\Psr17Factory
-
-    nyholm.psr7.httplug_factory:
-        class: Nyholm\Psr7\Factory\HttplugFactory


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

Follows https://github.com/php-http/message-factory/pull/42 and https://github.com/Nyholm/psr7/pull/243 