### PR TITLE
[symfony/phpunit-bridge] run PHPUnit by it's official entrypoint

### DIFF
--- a/symfony/phpunit-bridge/5.3/bin/phpunit
+++ b/symfony/phpunit-bridge/5.3/bin/phpunit
@@ -6,9 +6,7 @@ if (!ini_get('date.timezone')) {
 }
 
 if (is_file(dirname(__DIR__).'/vendor/phpunit/phpunit/phpunit')) {
-    define('PHPUNIT_COMPOSER_INSTALL', dirname(__DIR__).'/vendor/autoload.php');
-    require PHPUNIT_COMPOSER_INSTALL;
-    PHPUnit\TextUI\Command::main();
+    require dirname(__DIR__).'/vendor/phpunit/phpunit/phpunit';
 } else {
     if (!is_file(dirname(__DIR__).'/vendor/symfony/phpunit-bridge/bin/simple-phpunit.php')) {
         echo "Unable to find the `simple-phpunit.php` script in `vendor/symfony/phpunit-bridge/bin/`.\n";


### PR DESCRIPTION
Run the PHPUnit script by it's own entrypoint - so this script does not depend on the internal class

| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | N/A

Resolves https://github.com/symfony/recipes/issues/1173