### PR TITLE
[symfony/ux-translator] TranslatorBundle class now prefixed by Ux

### DIFF
--- a/symfony/ux-translator/2.7/manifest.json
+++ b/symfony/ux-translator/2.7/manifest.json
@@ -1,6 +1,6 @@
 {
     "bundles": {
-        "Symfony\\UX\\Translator\\TranslatorBundle": ["all"]
+        "Symfony\\UX\\Translator\\UxTranslatorBundle": ["all"]
     },
     "copy-from-recipe": {
         "assets/": "assets/",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | N/A

The class TranslatorBundle of the Symfony UX Translator component has recently been renamed to UxTranslatorBundle (Commit [bc96739](https://github.com/symfony/ux-translator/commit/bc96739e03cc6312f7b49cab4cb7c7060c3e4999)).

Currenty, the following line added to the bundles.php file is as the following :

```Symfony\UX\Translator\TranslatorBundle::class => ['all' => true],```

It needs to be renamed here too so it won't lead to the following error after the install :

![image](https://user-images.githubusercontent.com/132465526/235935906-d1f5b82f-3078-4eda-8b77-b173cd93dcb6.png)

<!--
Please, carefully read the README before submitting a pull request.
-->
