### PR TITLE
Fixed bundle class in symfony/ux-translator recipe

### DIFF
--- a/symfony/ux-translator/2.7/manifest.json
+++ b/symfony/ux-translator/2.7/manifest.json
@@ -1,6 +1,6 @@
 {
     "bundles": {
-        "Symfony\\UX\\Translator\\TranslatorBundle": ["all"]
+        "Symfony\\UX\\Translator\\UxTranslatorBundle": ["all"]
     },
     "copy-from-recipe": {
         "assets/": "assets/",


### PR DESCRIPTION
`TranslatorBundle` does not exist, it's called `UxTranslatorBundle`. :-)

| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | symfony/symfony-docs#...

<!--
Please, carefully read the README before submitting a pull request.
-->
