### PR TITLE
Prefer php-http/discovery over nyholm/psr7 when installed

### DIFF
--- a/php-http/discovery/1.18/config/packages/http_discovery.yaml
+++ b/php-http/discovery/1.18/config/packages/http_discovery.yaml
@@ -1,0 +1,10 @@
+services:
+    Psr\Http\Message\RequestFactoryInterface: '@http_discovery.psr17_factory'
+    Psr\Http\Message\ResponseFactoryInterface: '@http_discovery.psr17_factory'
+    Psr\Http\Message\ServerRequestFactoryInterface: '@http_discovery.psr17_factory'
+    Psr\Http\Message\StreamFactoryInterface: '@http_discovery.psr17_factory'
+    Psr\Http\Message\UploadedFileFactoryInterface: '@http_discovery.psr17_factory'
+    Psr\Http\Message\UriFactoryInterface: '@http_discovery.psr17_factory'
+
+    http_discovery.psr17_factory:
+        class: Http\Discovery\Psr17Factory

--- a/php-http/discovery/1.18/manifest.json
+++ b/php-http/discovery/1.18/manifest.json
@@ -1,8 +1,5 @@
 {
     "copy-from-recipe": {
         "config/": "%CONFIG_DIR%/"
-    },
-    "conflict": {
-        "php-http/discovery": ">=1.18"
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

Note that php-http/discovery itself defaults to nyholm/psr7 so in practice this shouldn't change much, except for people that want to rely on another PSR-17 implementation.