### PR TITLE
Add "early" StimulusBundle recipe without conflicts to ensure bundle is registered

### DIFF
--- a/symfony/stimulus-bundle/2.8/manifest.json
+++ b/symfony/stimulus-bundle/2.8/manifest.json
@@ -1,0 +1,6 @@
+{
+    "bundles": {
+        "Symfony\\UX\\StimulusBundle\\StimulusBundle": ["all"]
+    },
+    "aliases": ["stimulus", "stimulus-bundle"]
+}

--- a/symfony/stimulus-bundle/2.9/manifest.json
+++ b/symfony/stimulus-bundle/2.9/manifest.json
@@ -40,7 +40,8 @@
             "content": "            {{ ux_controller_link_tags() }}",
             "position": "after_target",
             "target": "{% block stylesheets %}",
-            "warn_if_missing": true
+            "warn_if_missing": true,
+            "requires": "symfony/asset-mapper"
         }
     ]
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | Not needed

Hi!

This is one step in resolving https://github.com/symfony/ux/issues/907:

The StimulusBundle 2.9 recipe is set to conflict with
  - (1) old Flex versions that don't support `add-lines` so that the recipe doesn't run and skip these important items
  - (2) WebpackEncoreBundle 1.0 whose recipe adds many of the same files - StimulusBundle's recipe is meant to fit in with EncoreBundel 2.0's recipe.

I assumed that if no compatible recipe was found, Flex would still "auto-generate" a recipe and install the bundle. That actually does NOT happen.

This PR adds a "fake" StimulusBundle 2.8 recipe. That bundle doesn't exist in 2.8, but it installs just fine. The result is:

A) If you have WebpackEncoreBundle 2.0 and the latest Flex, you get the full StimulusBundle 2.9 recipe
B) Else, you hit the 2.8 version, which at least adds the bundle to `bundles.php`.

Also added a missing `requires` - that `ux_controller_link_tags()` is only needed with AssetMapper.

Thanks!