### PR TITLE
[Mailer] prevent a warning when running symfony serve

### DIFF
--- a/symfony/mailer/4.3/manifest.json
+++ b/symfony/mailer/4.3/manifest.json
@@ -3,7 +3,8 @@
         "config/": "%CONFIG_DIR%/"
     },
     "env": {
-        "#1": "MAILER_DSN=null://null"
+        "#1": "Choose a transport to deliver your emails: https://symfony.com/doc/current/mailer.html#transport-setup",
+        "MAILER_DSN": "null://null"
     },
     "docker-compose": {
         "docker-compose.override.yml": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | n/a

When running the following commands:

```
symfony new --webapp --version next myproject
cd myproject
symfony serve
```

this error shows up in the console:

```
[Application] May 30 12:39:21 |CRITICA| CONSOL Error thrown while running command "list --format=xml". Message: "Environment variable not found: "MAILER_DSN"." command="list --format=xml" message="Environment variable not found: \"MAILER_DSN\"."
[Application] May 30 12:39:21 |DEBUG  | CONSOL Command "list --format=xml" exited with code "1" code=1
[Application] May 30 12:39:21 |CRITICA| CONSOL Error thrown while running command "list --format=xml". Message: "Environment variable not found: "MAILER_DSN"." message="Environment variable not found: \"MAILER_DSN\"."
[Application] May 30 12:39:21 |DEBUG  | CONSOL Command "list --format=xml" exited with code "1" code=1
```

This patch fixes the problem. I've also added a comment to help users understand how to use the Mailer component.
