### PR TITLE
[WebProfilerBundle] Disable the profiler in `test` env

### DIFF
--- a/symfony/web-profiler-bundle/6.1/config/packages/web_profiler.yaml
+++ b/symfony/web-profiler-bundle/6.1/config/packages/web_profiler.yaml
@@ -14,4 +14,6 @@ when@test:
         intercept_redirects: false
 
     framework:
-        profiler: { collect: false }
+        profiler:
+            collect: false
+            enabled: false


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

After trying out the new "Setting Private Services in Testing Container" feature of Symfony 6.3 with the `MockHttpClient` I encounter the following error:

```
TypeError: Symfony\Component\HttpClient\DataCollector\HttpClientDataCollector::registerClient():
Argument #2 ($client) must be of type Symfony\Component\HttpClient\TraceableHttpClient,
Symfony\Component\HttpClient\MockHttpClient given
```

Since this isn't really a bug I just decided to disable the profiler in the `test` environment. This however got me thinking, is there a reason this isn't disabled by default? I can't really think of (or don't know) a reason why not.