### PR TITLE
[doctrine-bundle] Increased required doctrine/orm version

### DIFF
--- a/doctrine/doctrine-bundle/2.10/manifest.json
+++ b/doctrine/doctrine-bundle/2.10/manifest.json
@@ -47,7 +47,7 @@
         }
     },
     "conflict": {
-        "doctrine/orm": "<2.14",
+        "doctrine/orm": "<2.16",
         "symfony/dependency-injection": "<6.2",
         "symfony/framework-bundle": "<5.3"
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Fixes  | #1211

Increased required doctrine/orm version to 2.16 because of the newly added config options:
  - report_fields_where_declared
  - validate_xml_mapping