### PR TITLE
Remove http_method_override setting from recipe

### DIFF
--- a/symfony/framework-bundle/7.0/config/packages/framework.yaml
+++ b/symfony/framework-bundle/7.0/config/packages/framework.yaml
@@ -2,7 +2,6 @@
 framework:
     secret: '%env(APP_SECRET)%'
     #csrf_protection: true
-    http_method_override: false
     handle_all_throwables: true
 
     # Enables session support. Note that the session will ONLY be started if you read or write from it.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | Part of symfony/symfony#51097

`false` is the default setting since symfony/symfony#50873 (7.0)