### PR TITLE
[api-platform/core] prevent a deprecation warning and sync with upstream

### DIFF
--- a/api-platform/core/2.1/post-install.txt
+++ b/api-platform/core/2.1/post-install.txt
@@ -1,8 +1,10 @@
   * Your API is almost ready:
-    1. Create your first API resource in <info>src/Entity</info>;
+    1. Create your first API resource in <info>src/ApiResource</info>;
     2. Go to <info>/api</info> to browse your API
+
+  * Using MakerBundle? Try <info>php bin/console make:entity --api-resource</info> 
 
   * To enable the GraphQL support, run <comment>composer require webonyx/graphql-php</>,
     then browse <info>/api/graphql</info>.
 
-  * <fg=blue>Read</> the documentation at <comment>https://api-platform.com/docs</>
+  * <fg=blue>Read</> the documentation at <comment>https://api-platform.com/docs/</>

--- a/api-platform/core/2.5/post-install.txt
+++ b/api-platform/core/2.5/post-install.txt
@@ -1,8 +1,10 @@
   * Your API is almost ready:
-    1. Create your first API resource in <info>src/Entity</info>;
+    1. Create your first API resource in <info>src/ApiResource</info>;
     2. Go to <info>/api</info> to browse your API
+
+  * Using MakerBundle? Try <info>php bin/console make:entity --api-resource</info> 
 
   * To enable the GraphQL support, run <comment>composer require webonyx/graphql-php</>,
     then browse <info>/api/graphql</info>.
 
-  * <fg=blue>Read</> the documentation at <comment>https://api-platform.com/docs</>
+  * <fg=blue>Read</> the documentation at <comment>https://api-platform.com/docs/</>

--- a/api-platform/core/3.0/post-install.txt
+++ b/api-platform/core/3.0/post-install.txt
@@ -2,7 +2,9 @@
     1. Create your first API resource in <info>src/ApiResource</info>;
     2. Go to <info>/api</info> to browse your API
 
+  * Using MakerBundle? Try <info>php bin/console make:entity --api-resource</info> 
+
   * To enable the GraphQL support, run <comment>composer require webonyx/graphql-php</>,
     then browse <info>/api/graphql</info>.
 
-  * <fg=blue>Read</> the documentation at <comment>https://api-platform.com/docs</>
+  * <fg=blue>Read</> the documentation at <comment>https://api-platform.com/docs/</>

--- a/api-platform/core/3.1/config/packages/api_platform.yaml
+++ b/api-platform/core/3.1/config/packages/api_platform.yaml
@@ -1,0 +1,10 @@
+api_platform:
+    title: Hello API Platform
+    version: 1.0.0
+    # Good defaults for REST APIs
+    defaults:
+        stateless: true
+        cache_headers:
+            vary: ['Content-Type', 'Authorization', 'Origin']
+        extra_properties:
+            standard_put: true

--- a/api-platform/core/3.1/config/routes/api_platform.yaml
+++ b/api-platform/core/3.1/config/routes/api_platform.yaml
@@ -1,0 +1,4 @@
+api_platform:
+    resource: .
+    type: api_platform
+    prefix: /api

--- a/api-platform/core/3.1/manifest.json
+++ b/api-platform/core/3.1/manifest.json
@@ -1,0 +1,9 @@
+{
+    "bundles": {
+        "ApiPlatform\\Symfony\\Bundle\\ApiPlatformBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/",
+        "src/": "%SRC_DIR%/"
+    }
+}

--- a/api-platform/core/3.1/post-install.txt
+++ b/api-platform/core/3.1/post-install.txt
@@ -1,0 +1,8 @@
+  * Your API is almost ready:
+    1. Create your first API resource in <info>src/ApiResource</info>;
+    2. Go to <info>/api</info> to browse your API
+
+  * To enable the GraphQL support, run <comment>composer require webonyx/graphql-php</>,
+    then browse <info>/api/graphql</info>.
+
+  * <fg=blue>Read</> the documentation at <comment>https://api-platform.com/docs</>

--- a/api-platform/core/3.1/post-install.txt
+++ b/api-platform/core/3.1/post-install.txt
@@ -2,7 +2,9 @@
     1. Create your first API resource in <info>src/ApiResource</info>;
     2. Go to <info>/api</info> to browse your API
 
+  * Using MakerBundle? Try <info>php bin/console make:entity --api-resource</info> 
+
   * To enable the GraphQL support, run <comment>composer require webonyx/graphql-php</>,
     then browse <info>/api/graphql</info>.
 
-  * <fg=blue>Read</> the documentation at <comment>https://api-platform.com/docs</>
+  * <fg=blue>Read</> the documentation at <comment>https://api-platform.com/docs/</>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | n/a

Enabling the standard behavior for PUT requests is necessary to prevent a deprecation warning.
I also imported the defaults [we set in the API Platform distribution](https://github.com/api-platform/api-platform/blob/main/api/config/packages/api_platform.yaml).