### PR TITLE
[FrameworkBundle] Remove "framework.session.storage_factory_id"

### DIFF
--- a/symfony/framework-bundle/6.4/config/packages/framework.yaml
+++ b/symfony/framework-bundle/6.4/config/packages/framework.yaml
@@ -12,7 +12,6 @@ framework:
         handler_id: null
         cookie_secure: auto
         cookie_samesite: lax
-        storage_factory_id: session.storage.factory.native
 
     #esi: true
     #fragments: true

--- a/symfony/framework-bundle/7.0/config/packages/framework.yaml
+++ b/symfony/framework-bundle/7.0/config/packages/framework.yaml
@@ -10,7 +10,6 @@ framework:
         handler_id: null
         cookie_secure: auto
         cookie_samesite: lax
-        storage_factory_id: session.storage.factory.native
 
     #esi: true
     #fragments: true


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  |

This PR removes the `framework.session.storage_factory_id` option since it's already the default value.
