### PR TITLE
[FrameworkBundle] Remove router and translator default values

### DIFF
--- a/symfony/routing/6.0/config/packages/routing.yaml
+++ b/symfony/routing/6.0/config/packages/routing.yaml
@@ -1,7 +1,5 @@
 framework:
     router:
-        utf8: true
-
         # Configure how to generate URLs in non-HTTP contexts, such as CLI commands.
         # See https://symfony.com/doc/current/routing.html#generating-urls-in-commands
         #default_uri: http://localhost

--- a/symfony/routing/6.1/config/packages/routing.yaml
+++ b/symfony/routing/6.1/config/packages/routing.yaml
@@ -1,7 +1,5 @@
 framework:
     router:
-        utf8: true
-
         # Configure how to generate URLs in non-HTTP contexts, such as CLI commands.
         # See https://symfony.com/doc/current/routing.html#generating-urls-in-commands
         #default_uri: http://localhost

--- a/symfony/routing/6.2/config/packages/routing.yaml
+++ b/symfony/routing/6.2/config/packages/routing.yaml
@@ -1,7 +1,5 @@
 framework:
     router:
-        utf8: true
-
         # Configure how to generate URLs in non-HTTP contexts, such as CLI commands.
         # See https://symfony.com/doc/current/routing.html#generating-urls-in-commands
         #default_uri: http://localhost

--- a/symfony/translation/5.3/config/packages/translation.yaml
+++ b/symfony/translation/5.3/config/packages/translation.yaml
@@ -1,9 +1,6 @@
 framework:
-    default_locale: en
     translator:
         default_path: '%kernel.project_dir%/translations'
-        fallbacks:
-            - en
 #        providers:
 #            crowdin:
 #                dsn: '%env(CROWDIN_DSN)%'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  |

This PR removes the `framework.default_locale`,  `framework.translator.fallback` and  `framework.router.utf8` options since it's already their default value.
