### PR TITLE
Add Recipe for PHPUnit 10

### DIFF
--- a/phpunit/phpunit/10.0/.env.test
+++ b/phpunit/phpunit/10.0/.env.test
@@ -1,0 +1,4 @@
+# define your env variables for the test env here
+KERNEL_CLASS='App\Kernel'
+APP_SECRET='$ecretf0rt3st'
+SYMFONY_DEPRECATIONS_HELPER=999999

--- a/phpunit/phpunit/10.0/manifest.json
+++ b/phpunit/phpunit/10.0/manifest.json
@@ -1,0 +1,11 @@
+{
+    "copy-from-recipe": {
+        ".env.test": ".env.test",
+        "phpunit.dist.xml": "phpunit.dist.xml",
+        "tests/": "tests/"
+    },
+    "gitignore": [
+        "/phpunit.xml",
+        "/.phpunit.cache/"
+    ]
+}

--- a/phpunit/phpunit/10.0/phpunit.dist.xml
+++ b/phpunit/phpunit/10.0/phpunit.dist.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- https://phpunit.readthedocs.io/en/latest/configuration.html -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="tests/bootstrap.php"
+         cacheDirectory=".phpunit.cache"
+>
+    <php>
+        <ini name="display_errors" value="1" />
+        <ini name="error_reporting" value="-1" />
+        <server name="APP_ENV" value="test" force="true" />
+        <server name="SHELL_VERBOSITY" value="-1" />
+        <server name="SYMFONY_PHPUNIT_REMOVE" value="" />
+        <server name="SYMFONY_PHPUNIT_VERSION" value="9.5" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Project Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <source restrictDeprecations="true" restrictNotices="true" restrictWarnings="true">
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
+
+    <extensions>
+    </extensions>
+</phpunit>

--- a/phpunit/phpunit/10.0/phpunit.dist.xml
+++ b/phpunit/phpunit/10.0/phpunit.dist.xml
@@ -14,7 +14,7 @@
         <server name="APP_ENV" value="test" force="true" />
         <server name="SHELL_VERBOSITY" value="-1" />
         <server name="SYMFONY_PHPUNIT_REMOVE" value="" />
-        <server name="SYMFONY_PHPUNIT_VERSION" value="9.5" />
+        <server name="SYMFONY_PHPUNIT_VERSION" value="10.5" />
     </php>
 
     <testsuites>

--- a/phpunit/phpunit/10.0/tests/bootstrap.php
+++ b/phpunit/phpunit/10.0/tests/bootstrap.php
@@ -4,8 +4,6 @@ use Symfony\Component\Dotenv\Dotenv;
 
 require dirname(__DIR__).'/vendor/autoload.php';
 
-if (file_exists(dirname(__DIR__).'/config/bootstrap.php')) {
-    require dirname(__DIR__).'/config/bootstrap.php';
-} elseif (method_exists(Dotenv::class, 'bootEnv')) {
+if (method_exists(Dotenv::class, 'bootEnv')) {
     (new Dotenv())->bootEnv(dirname(__DIR__).'/.env');
 }

--- a/phpunit/phpunit/10.0/tests/bootstrap.php
+++ b/phpunit/phpunit/10.0/tests/bootstrap.php
@@ -1,0 +1,11 @@
+<?php
+
+use Symfony\Component\Dotenv\Dotenv;
+
+require dirname(__DIR__).'/vendor/autoload.php';
+
+if (file_exists(dirname(__DIR__).'/config/bootstrap.php')) {
+    require dirname(__DIR__).'/config/bootstrap.php';
+} elseif (method_exists(Dotenv::class, 'bootEnv')) {
+    (new Dotenv())->bootEnv(dirname(__DIR__).'/.env');
+}

--- a/phpunit/phpunit/4.7/tests/bootstrap.php
+++ b/phpunit/phpunit/4.7/tests/bootstrap.php
@@ -4,8 +4,6 @@ use Symfony\Component\Dotenv\Dotenv;
 
 require dirname(__DIR__).'/vendor/autoload.php';
 
-if (file_exists(dirname(__DIR__).'/config/bootstrap.php')) {
-    require dirname(__DIR__).'/config/bootstrap.php';
-} elseif (method_exists(Dotenv::class, 'bootEnv')) {
+if (method_exists(Dotenv::class, 'bootEnv')) {
     (new Dotenv())->bootEnv(dirname(__DIR__).'/.env');
 }

--- a/phpunit/phpunit/9.3/tests/bootstrap.php
+++ b/phpunit/phpunit/9.3/tests/bootstrap.php
@@ -4,8 +4,6 @@ use Symfony\Component\Dotenv\Dotenv;
 
 require dirname(__DIR__).'/vendor/autoload.php';
 
-if (file_exists(dirname(__DIR__).'/config/bootstrap.php')) {
-    require dirname(__DIR__).'/config/bootstrap.php';
-} elseif (method_exists(Dotenv::class, 'bootEnv')) {
+if (method_exists(Dotenv::class, 'bootEnv')) {
     (new Dotenv())->bootEnv(dirname(__DIR__).'/.env');
 }

--- a/phpunit/phpunit/9.6/tests/bootstrap.php
+++ b/phpunit/phpunit/9.6/tests/bootstrap.php
@@ -4,8 +4,6 @@ use Symfony\Component\Dotenv\Dotenv;
 
 require dirname(__DIR__).'/vendor/autoload.php';
 
-if (file_exists(dirname(__DIR__).'/config/bootstrap.php')) {
-    require dirname(__DIR__).'/config/bootstrap.php';
-} elseif (method_exists(Dotenv::class, 'bootEnv')) {
+if (method_exists(Dotenv::class, 'bootEnv')) {
     (new Dotenv())->bootEnv(dirname(__DIR__).'/.env');
 }

--- a/symfony/panther/1.0/manifest.json
+++ b/symfony/panther/1.0/manifest.json
@@ -19,6 +19,20 @@
             "content": "        <extension class=\"Symfony\\Component\\Panther\\ServerExtension\" />",
             "position": "after_target",
             "target": "<extensions>",
+            "warn_if_missing": false
+        },
+        {
+            "file": "phpunit.dist.xml",
+            "content": "        <bootstrap class=\"Symfony\\Component\\Panther\\ServerExtension\" />",
+            "position": "after_target",
+            "target": "<extensions>",
+            "warn_if_missing": false
+        },
+        {
+            "file": "env.test",
+            "content": "PANTHER_APP_ENV=panther\nPANTHER_ERROR_SCREENSHOT_DIR=./var/error-screenshots",
+            "position": "after_target",
+            "target": "SYMFONY_DEPRECATIONS_HELPER=999999",
             "warn_if_missing": true
         }
     ]

--- a/symfony/panther/1.0/manifest.json
+++ b/symfony/panther/1.0/manifest.json
@@ -29,7 +29,7 @@
             "warn_if_missing": false
         },
         {
-            "file": "env.test",
+            "file": ".env.test",
             "content": "PANTHER_APP_ENV=panther\nPANTHER_ERROR_SCREENSHOT_DIR=./var/error-screenshots",
             "position": "after_target",
             "target": "SYMFONY_DEPRECATIONS_HELPER=999999",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | symfony/symfony-docs#...

This will add a recipe for PHPUnit 10:

Following changes:

 - `listeners` do not longer exists in PHPUnit 10  where replaced by extensions
 - the old `extensions` still exists but need to be written differently
    - they require `bootstrap` tag now: https://docs.phpunit.de/en/10.3/configuration.html#the-extensions-element and use the new event system https://docs.phpunit.de/en/10.3/extending-phpunit.html#phpunit-s-event-system (this effects maybe phpunit-bridge and panther)
 - move from `phpunit.xml.dist` to `phpunit.dist.xml` for better IDE support (same already done for phpstan) see also: https://github.com/sebastianbergmann/phpunit/issues/4650 / https://github.com/sebastianbergmann/phpunit/commit/07a022ad0548823b04c8fab073a7bff2fbcf9c8c
 - from cache file `.phpunit.result.cache` to cache directory `/.phpunit.cache/`
 - move unrelated Panther ENV vars to Panther recipe
