### PR TITLE
[api-platform/core] sane defaults for API Platform 3.2

### DIFF
--- a/api-platform/core/3.2/config/packages/api_platform.yaml
+++ b/api-platform/core/3.2/config/packages/api_platform.yaml
@@ -1,0 +1,18 @@
+api_platform:
+    title: Hello API Platform
+    version: 1.0.0
+    formats:
+        jsonld: ['application/ld+json']
+    doc_formats:
+        jsonld: ['application/ld+json']
+        jsonopenapi: ['application/vnd.openapi+json']
+        html: ['text/html']
+    defaults:
+        stateless: true
+        cache_headers:
+            vary: ['Content-Type', 'Authorization', 'Origin']
+        extra_properties:
+            standard_put: true
+            rfc_7807_compliant_errors: true
+    event_listeners_backward_compatibility_layer: false
+    keep_legacy_inflector: false

--- a/api-platform/core/3.2/config/routes/api_platform.yaml
+++ b/api-platform/core/3.2/config/routes/api_platform.yaml
@@ -1,0 +1,4 @@
+api_platform:
+    resource: .
+    type: api_platform
+    prefix: /api

--- a/api-platform/core/3.2/manifest.json
+++ b/api-platform/core/3.2/manifest.json
@@ -1,0 +1,9 @@
+{
+    "bundles": {
+        "ApiPlatform\\Symfony\\Bundle\\ApiPlatformBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/",
+        "src/": "%SRC_DIR%/"
+    }
+}

--- a/api-platform/core/3.2/post-install.txt
+++ b/api-platform/core/3.2/post-install.txt
@@ -1,0 +1,10 @@
+  * Your API is almost ready:
+    1. Create your first API resource in <info>src/ApiResource</info>;
+    2. Go to <info>/api</info> to browse your API
+
+  * Using MakerBundle? Try <info>php bin/console make:entity --api-resource</info> 
+
+  * To enable the GraphQL support, run <comment>composer require webonyx/graphql-php</>,
+    then browse <info>/api/graphql</info>.
+
+  * <fg=blue>Read</> the documentation at <comment>https://api-platform.com/docs/</>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

In API Platform 4 `json` will be disabled by default so it's now recommended to explicit formats.
For `event_listeners_backward_compatibility_layer` see https://github.com/api-platform/core/pull/5657
We're using the Symfony Inflector now but this will probably break current code so we need a flag to `keep_legacy_inflector`
The `rfc_7807_compliant_errors` is to make Hydra errors compatible with the [JSON Problem](https://datatracker.ietf.org/doc/rfc7807/) specification. This may lead to unexpected error fields and therefore we need a compatibility flag. 