### PR TITLE
[Doctrine] fix(config): Add missing key "type" in doctrine.yaml config for symfony version 6.4/7.0 BETA

### DIFF
--- a/doctrine/doctrine-bundle/2.10/config/packages/doctrine.yaml
+++ b/doctrine/doctrine-bundle/2.10/config/packages/doctrine.yaml
@@ -16,6 +16,7 @@ doctrine:
         auto_mapping: true
         mappings:
             App:
+                type: attribute
                 is_bundle: false
                 dir: '%kernel.project_dir%/src/Entity'
                 prefix: 'App\Entity'


### PR DESCRIPTION
Hello

How to reproduce: 
- Install project with Symfony CLI (latest 5.6.0) `symfony new sf --webapp --version="7.*@dev"`

Here the error produced during `cache:clear` :
![image](https://github.com/symfony/recipes/assets/72203064/ac8c75ca-5f28-49e4-a927-0e0efe575296)

The recipes version used in 6.4/7.0 is doctrine/doctrine-bundle 2.10

| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | N/A
<!--
Please, carefully read the README before submitting a pull request.
-->
