### PR TITLE
Fix bin/phpunit for PHPUnit 10

### DIFF
--- a/symfony/phpunit-bridge/5.3/bin/phpunit
+++ b/symfony/phpunit-bridge/5.3/bin/phpunit
@@ -6,9 +6,13 @@ if (!ini_get('date.timezone')) {
 }
 
 if (is_file(dirname(__DIR__).'/vendor/phpunit/phpunit/phpunit')) {
-    define('PHPUNIT_COMPOSER_INSTALL', dirname(__DIR__).'/vendor/autoload.php');
-    require PHPUNIT_COMPOSER_INSTALL;
-    PHPUnit\TextUI\Command::main();
+    if (PHP_VERSION_ID >= 80000) {
+        require dirname(__DIR__).'/vendor/phpunit/phpunit/phpunit';
+    } else {
+        define('PHPUNIT_COMPOSER_INSTALL', dirname(__DIR__).'/vendor/autoload.php');
+        require PHPUNIT_COMPOSER_INSTALL;
+        PHPUnit\TextUI\Command::main();
+    }
 } else {
     if (!is_file(dirname(__DIR__).'/vendor/symfony/phpunit-bridge/bin/simple-phpunit.php')) {
         echo "Unable to find the `simple-phpunit.php` script in `vendor/symfony/phpunit-bridge/bin/`.\n";

--- a/symfony/phpunit-bridge/6.3/bin/phpunit
+++ b/symfony/phpunit-bridge/6.3/bin/phpunit
@@ -6,9 +6,13 @@ if (!ini_get('date.timezone')) {
 }
 
 if (is_file(dirname(__DIR__).'/vendor/phpunit/phpunit/phpunit')) {
-    define('PHPUNIT_COMPOSER_INSTALL', dirname(__DIR__).'/vendor/autoload.php');
-    require PHPUNIT_COMPOSER_INSTALL;
-    PHPUnit\TextUI\Command::main();
+    if (PHP_VERSION_ID >= 80000) {
+        require dirname(__DIR__).'/vendor/phpunit/phpunit/phpunit';
+    } else {
+        define('PHPUNIT_COMPOSER_INSTALL', dirname(__DIR__).'/vendor/autoload.php');
+        require PHPUNIT_COMPOSER_INSTALL;
+        PHPUnit\TextUI\Command::main();
+    }
 } else {
     if (!is_file(dirname(__DIR__).'/vendor/symfony/phpunit-bridge/bin/simple-phpunit.php')) {
         echo "Unable to find the `simple-phpunit.php` script in `vendor/symfony/phpunit-bridge/bin/`.\n";


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | N/A

Fixes #1248.

Our `bin/phpunit` calls the PHPUnit from the vendor folder, if we use Composer to install PHPUnit. Instead of calling `require` on PHPUnit's entrypoint directly, we call internal PHPUnit classes to bootstrap the CLI runner.

The reason for that was that PHPUnit's bin script contains a shebang (`#!/usr/bin/env php`) which would be output on PHP 7. On PHP 8 however, that limitation is gone and with it the reason for our workaround. Calling `require` on PHPUnit's entrypoint makes the bin/phpunit script more resilient against future internal changes in PHPUnit and allows the script to function with PHPUnit 10.