### PR TITLE
[FrameworkBundle] Improve require to require_once for all maintained Symfony versions

### DIFF
--- a/symfony/framework-bundle/5.4/config/preload.php
+++ b/symfony/framework-bundle/5.4/config/preload.php
@@ -1,5 +1,5 @@
 <?php
 
 if (file_exists(dirname(__DIR__).'/var/cache/prod/App_KernelProdContainer.preload.php')) {
-    require dirname(__DIR__).'/var/cache/prod/App_KernelProdContainer.preload.php';
+    require_once dirname(__DIR__).'/var/cache/prod/App_KernelProdContainer.preload.php';
 }

--- a/symfony/framework-bundle/6.4/config/preload.php
+++ b/symfony/framework-bundle/6.4/config/preload.php
@@ -1,5 +1,5 @@
 <?php
 
 if (file_exists(dirname(__DIR__).'/var/cache/prod/App_KernelProdContainer.preload.php')) {
-    require dirname(__DIR__).'/var/cache/prod/App_KernelProdContainer.preload.php';
+    require_once dirname(__DIR__).'/var/cache/prod/App_KernelProdContainer.preload.php';
 }

--- a/symfony/framework-bundle/7.0/config/preload.php
+++ b/symfony/framework-bundle/7.0/config/preload.php
@@ -1,5 +1,5 @@
 <?php
 
 if (file_exists(dirname(__DIR__).'/var/cache/prod/App_KernelProdContainer.preload.php')) {
-    require dirname(__DIR__).'/var/cache/prod/App_KernelProdContainer.preload.php';
+    require_once dirname(__DIR__).'/var/cache/prod/App_KernelProdContainer.preload.php';
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | None

Improving `require` to `require_once` for all maintained Symfony versions (5.4, 6.4 and 7.0).