### PR TITLE
Add TwigBundle 6.4 with `file_name_pattern: *.twig`

### DIFF
--- a/symfony/twig-bundle/6.4/config/packages/twig.yaml
+++ b/symfony/twig-bundle/6.4/config/packages/twig.yaml
@@ -1,5 +1,4 @@
 twig:
-    default_path: '%kernel.project_dir%/templates'
     file_name_pattern: '*.twig'
 
 when@test:

--- a/symfony/twig-bundle/6.4/config/packages/twig.yaml
+++ b/symfony/twig-bundle/6.4/config/packages/twig.yaml
@@ -1,0 +1,7 @@
+twig:
+    default_path: '%kernel.project_dir%/templates'
+    file_name_pattern: '*.twig'
+
+when@test:
+    twig:
+        strict_variables: true

--- a/symfony/twig-bundle/6.4/manifest.json
+++ b/symfony/twig-bundle/6.4/manifest.json
@@ -1,0 +1,12 @@
+{
+    "bundles": {
+        "Symfony\\Bundle\\TwigBundle\\TwigBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/",
+        "templates/": "templates/"
+    },
+    "conflict": {
+        "symfony/framework-bundle": "<5.3"
+    }
+}

--- a/symfony/twig-bundle/6.4/templates/base.html.twig
+++ b/symfony/twig-bundle/6.4/templates/base.html.twig
@@ -3,7 +3,7 @@
     <head>
         <meta charset="UTF-8">
         <title>{% block title %}Welcome!{% endblock %}</title>
-        <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 128 128%22><text y=%221.2em%22 font-size=%2296%22>⚫️</text></svg>">
+        <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 128 128%22><text y=%221.2em%22 font-size=%2296%22>⚫️</text><text y=%221.3em%22 x=%220.2em%22 font-size=%2276%22 fill=%22%23fff%22>sf</text></svg>">
         {% block stylesheets %}
         {% endblock %}
 

--- a/symfony/twig-bundle/6.4/templates/base.html.twig
+++ b/symfony/twig-bundle/6.4/templates/base.html.twig
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="UTF-8">
+        <title>{% block title %}Welcome!{% endblock %}</title>
+        <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 128 128%22><text y=%221.2em%22 font-size=%2296%22>⚫️</text></svg>">
+        {% block stylesheets %}
+        {% endblock %}
+
+        {% block javascripts %}
+        {% endblock %}
+    </head>
+    <body>
+        {% block body %}{% endblock %}
+    </body>
+</html>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

By default, Twig templates have the `.twig` extension. They can be collocated with other files (SVG, CSS, JS or even [PHP for Twig Components](https://twitter.com/weaverryan/status/1724827396279357498))

Adding the option `twig.file_name_pattern: '*.twig'` by default for new projects is necessary to avoid compiling non-twig files.

Related to symfony/symfony#45845