### PR TITLE
Update SYMFONY_PHPUNIT_VERSION to 9.6

### DIFF
--- a/symfony/phpunit-bridge/6.3/phpunit.xml.dist
+++ b/symfony/phpunit-bridge/6.3/phpunit.xml.dist
@@ -14,7 +14,7 @@
         <server name="APP_ENV" value="test" force="true" />
         <server name="SHELL_VERBOSITY" value="-1" />
         <server name="SYMFONY_PHPUNIT_REMOVE" value="" />
-        <server name="SYMFONY_PHPUNIT_VERSION" value="9.5" />
+        <server name="SYMFONY_PHPUNIT_VERSION" value="9.6" />
     </php>
 
     <testsuites>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | 

According to uncomment extensions block, we need to update the SYMFONY_PHPUNIT_VERSION variable to 9.6.
