### PR TITLE
[Translation] Fix translation provider add-lines instructions

### DIFF
--- a/symfony/crowdin-translation-provider/5.3/manifest.json
+++ b/symfony/crowdin-translation-provider/5.3/manifest.json
@@ -1,10 +1,10 @@
 {
     "add-lines": [
         {
-            "file": "config/packages/notifier.yaml",
+            "file": "config/packages/translation.yaml",
             "position": "after_target",
-            "target": "        texter_transports:",
-            "content": "            crowdin: '%env(CROWDIN_DSN)%'"
+            "target": "        providers:",
+            "content": "            crowdin:\n                dsn: '%env(CROWDIN_DSN)%'"
         }
     ],
     "env": {

--- a/symfony/loco-translation-provider/5.3/manifest.json
+++ b/symfony/loco-translation-provider/5.3/manifest.json
@@ -1,10 +1,10 @@
 {
     "add-lines": [
         {
-            "file": "config/packages/notifier.yaml",
+            "file": "config/packages/translation.yaml",
             "position": "after_target",
-            "target": "        texter_transports:",
-            "content": "            loco: '%env(LOCO_DSN)%'"
+            "target": "        providers:",
+            "content": "            loco:\n                dsn: '%env(LOCO_DSN)%'"
         }
     ],
     "env": {

--- a/symfony/phrase-translation-provider/6.3/manifest.json
+++ b/symfony/phrase-translation-provider/6.3/manifest.json
@@ -1,5 +1,0 @@
-{
-    "env": {
-        "#1": "PHRASE_DSN=phrase://PROJECT_ID:API_TOKEN@default?userAgent=Symfony-Phrase-Provider"
-    }
-}

--- a/symfony/phrase-translation-provider/6.4/manifest.json
+++ b/symfony/phrase-translation-provider/6.4/manifest.json
@@ -4,10 +4,10 @@
             "file": "config/packages/translation.yaml",
             "position": "after_target",
             "target": "        providers:",
-            "content": "            lokalise:\n                dsn: '%env(LOKALISE_DSN)%'"
+            "content": "            phrase:\n                dsn: '%env(PHRASE_DSN)%'"
         }
     ],
     "env": {
-        "#1": "LOKALISE_DSN=lokalise://PROJECT_ID:API_KEY@default"
+        "#1": "PHRASE_DSN=phrase://PROJECT_ID:API_TOKEN@default?userAgent=Symfony-Phrase-Provider"
     }
 }

--- a/symfony/translation/5.3/config/packages/translation.yaml
+++ b/symfony/translation/5.3/config/packages/translation.yaml
@@ -4,10 +4,4 @@ framework:
         default_path: '%kernel.project_dir%/translations'
         fallbacks:
             - en
-#        providers:
-#            crowdin:
-#                dsn: '%env(CROWDIN_DSN)%'
-#            loco:
-#                dsn: '%env(LOCO_DSN)%'
-#            lokalise:
-#                dsn: '%env(LOKALISE_DSN)%'
+        providers:

--- a/symfony/translation/6.3/config/packages/translation.yaml
+++ b/symfony/translation/6.3/config/packages/translation.yaml
@@ -4,12 +4,4 @@ framework:
         default_path: '%kernel.project_dir%/translations'
         fallbacks:
             - en
-#        providers:
-#            crowdin:
-#                dsn: '%env(CROWDIN_DSN)%'
-#            loco:
-#                dsn: '%env(LOCO_DSN)%'
-#            lokalise:
-#                dsn: '%env(LOKALISE_DSN)%'
-#            phrase:
-#                dsn: '%env(PHRASE_DSN)%'
+        providers:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | symfony/symfony-docs#...

Mistake was done in https://github.com/symfony/recipes/pull/1217, fixed now.
In addition, I've added `add-lines` for Phrase Provider.
