### PR TITLE
[monolog-bundle] set json formatter to deprecation handler

### DIFF
--- a/symfony/monolog-bundle/3.7/config/packages/monolog.yaml
+++ b/symfony/monolog-bundle/3.7/config/packages/monolog.yaml
@@ -59,3 +59,4 @@ when@prod:
                 type: stream
                 channels: [deprecation]
                 path: php://stderr
+                formatter: monolog.formatter.json


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | symfony/symfony-docs#...

The json formatter is configured for the main/nested handler in production; it should be set the same way for the deprecation handler to ensure uniformity.
