### PR TITLE
import map -> importmap to match Symfony core generation

### DIFF
--- a/symfony/asset-mapper/6.4/importmap.php
+++ b/symfony/asset-mapper/6.4/importmap.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Returns the import map for this application.
+ * Returns the importmap for this application.
  *
  * - "path" is a path inside the asset mapper system. Use the
  *     "debug:asset-map" command to see the full list of paths.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | None

It now exactly matches: https://github.com/symfony/symfony/blob/6.4/src/Symfony/Component/AssetMapper/ImportMap/ImportMapConfigReader.php#L130-L142