### PR TITLE
[AssetMapper] gitignore `/assets/vendor/` as a directory

### DIFF
--- a/symfony/asset-mapper/6.4/manifest.json
+++ b/symfony/asset-mapper/6.4/manifest.json
@@ -7,7 +7,7 @@
     "aliases": ["asset-mapper", "importmap"],
     "gitignore": [
         "/%PUBLIC_DIR%/assets/",
-        "/assets/vendor"
+        "/assets/vendor/"
     ],
     "add-lines": [
         {


### PR DESCRIPTION
this is more to be consistent with the `/public/assets/` gitignore line above the fixed one; the set line is just fine

| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | 

<!--
Please, carefully read the README before submitting a pull request.
-->
