### PR TITLE
Asset mapper install as composer script

### DIFF
--- a/symfony/asset-mapper/6.4/importmap.php
+++ b/symfony/asset-mapper/6.4/importmap.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Returns the import map for this application.
+ * Returns the importmap for this application.
  *
  * - "path" is a path inside the asset mapper system. Use the
  *     "debug:asset-map" command to see the full list of paths.

--- a/symfony/asset-mapper/6.4/manifest.json
+++ b/symfony/asset-mapper/6.4/manifest.json
@@ -9,6 +9,9 @@
         "/%PUBLIC_DIR%/assets/",
         "/assets/vendor"
     ],
+    "composer-scripts": {
+        "importmap:install": "symfony-cmd"
+    },
     "add-lines": [
         {
             "file": "templates/base.html.twig",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | Not needed... people should now about `importmap:install`... but now they will likely never actually need to run it manually

From a suggestion by @stof - https://github.com/symfony/demo/pull/1449#issuecomment-1831722678 - it works really well!
