### PR TITLE
[AssetMapper] surrounding importmap() in a block

### DIFF
--- a/symfony/asset-mapper/6.4/manifest.json
+++ b/symfony/asset-mapper/6.4/manifest.json
@@ -12,7 +12,7 @@
     "add-lines": [
         {
             "file": "templates/base.html.twig",
-            "content": "            {{ importmap('app') }}",
+            "content": "{% block importmap %}{{ importmap('app') }}{% endblock %}",
             "position": "after_target",
             "target": "{% block javascripts %}",
             "warn_if_missing": true


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | https://github.com/symfony/symfony-docs/pull/19252

If you want to have page-specific JS, you need to override `{{ importmap() }}` and NOT call it twice. If you override `javascripts` and do not call `parent()`, it could accidentally not include some other JS you have. So, the proposal is to wrap `{{ importmap() }}` in its own block so you can override it.