### PR TITLE
Removing framework.session.cookie_samesite < FrameworkBundle 4.2

### DIFF
--- a/symfony/framework-bundle/3.4/config/packages/framework.yaml
+++ b/symfony/framework-bundle/3.4/config/packages/framework.yaml
@@ -7,7 +7,6 @@ framework:
     # Remove or comment this section to explicitly disable session support.
     session:
         handler_id: null
-        cookie_samesite: lax
 
     #esi: true
     #fragments: true


### PR DESCRIPTION
The `cookie_samesite` option is not available before Symfony 4.2, having this in the recipe results in an error:

> Unrecognized option "cookie_samesite" under "framework.session"

| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | symfony/symfony-docs#...

<!--
Please, carefully read the README before submitting a pull request.
-->
