### PR TITLE
Update docker image for Mailcatcher

### DIFF
--- a/symfony/mailer/4.3/manifest.json
+++ b/symfony/mailer/4.3/manifest.json
@@ -9,7 +9,7 @@
         "docker-compose.override.yml": {
             "services": [
                 "mailer:",
-                "  image: schickling/mailcatcher",
+                "  image: sj26/mailcatcher",
                 "  ports: [\"1025\", \"1080\"]"
             ]
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

This PR replace the unmaintained `schickling` image with the official Mailcatcher image
