### PR TITLE
[Symfony][Router] Set the default method for a route to "GET"

### DIFF
--- a/symfony/routing/6.2/config/routes.yaml
+++ b/symfony/routing/6.2/config/routes.yaml
@@ -3,3 +3,4 @@ controllers:
         path: ../src/Controller/
         namespace: App\Controller
     type: attribute
+    methods: [GET]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | symfony/symfony-docs#...

* I always sspecify the method(s) in my route declaration and it's boring
* Allowing by default all methods does not make sens
* Allowing by default all methods can be a security issue, because
  someone can DDOS the application by sending POST request, to a
  resource that is usually cached (but only for GET)
* explicit is better than implicit
