### PR TITLE
Replace Mailcatcher with Mailpit

### DIFF
--- a/symfony/mailer/4.3/manifest.json
+++ b/symfony/mailer/4.3/manifest.json
@@ -9,9 +9,20 @@
         "docker-compose.override.yml": {
             "services": [
                 "mailer:",
-                "  image: sj26/mailcatcher",
-                "  ports: [\"1025\", \"1080\"]"
-            ]
+                "  image: axllent/mailpit",
+                "  restart: always",
+                "  volumes:",
+                "    - mailer_data:/data",
+                "  ports:",
+                "    - \"1025\"",
+                "    - \"8025\"",
+                "  environment:",
+                "    MP_MAX_MESSAGES: 5000",
+                "    MP_DATA_FILE: /data/mailpit.db",
+                "    MP_SMTP_AUTH_ACCEPT_ANY: 1",
+                "    MP_SMTP_AUTH_ALLOW_INSECURE: 1"
+            ],
+            "volumes": ["mailer_data:"]
         }
     },
     "aliases": ["mailer", "mail"]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

As suggested by @kbond in #1279, I would like to suggest replacing Mailcatcher with [Mailpit](https://mailpit.axllent.org/), which offers many more features in addition to a much lighter docker image (27 MB for Mailpit compared to 90 MB for Mailcatcher).

I already use it in a project and integration with the Symfony CLI works without modification.