### PR TITLE
Remove `config/bootstrap.php` when not needed anymore

### DIFF
--- a/symfony/phpunit-bridge/5.3/manifest.json
+++ b/symfony/phpunit-bridge/5.3/manifest.json
@@ -9,5 +9,8 @@
         ".phpunit.result.cache",
         "/phpunit.xml"
     ],
+    "conflict": {
+        "symfony/framework-bundle": "<5.4"
+    },
     "aliases": ["simple-phpunit"]
 }

--- a/symfony/phpunit-bridge/5.3/tests/bootstrap.php
+++ b/symfony/phpunit-bridge/5.3/tests/bootstrap.php
@@ -4,9 +4,7 @@ use Symfony\Component\Dotenv\Dotenv;
 
 require dirname(__DIR__).'/vendor/autoload.php';
 
-if (file_exists(dirname(__DIR__).'/config/bootstrap.php')) {
-    require dirname(__DIR__).'/config/bootstrap.php';
-} elseif (method_exists(Dotenv::class, 'bootEnv')) {
+if (method_exists(Dotenv::class, 'bootEnv')) {
     (new Dotenv())->bootEnv(dirname(__DIR__).'/.env');
 }
 

--- a/symfony/phpunit-bridge/6.3/manifest.json
+++ b/symfony/phpunit-bridge/6.3/manifest.json
@@ -10,7 +10,8 @@
         "/phpunit.xml"
     ],
     "conflict": {
-        "phpunit/phpunit": "<9.6"
+        "phpunit/phpunit": "<9.6",
+        "symfony/framework-bundle": "<5.4"
     },
     "aliases": ["simple-phpunit"]
 }

--- a/symfony/phpunit-bridge/6.3/tests/bootstrap.php
+++ b/symfony/phpunit-bridge/6.3/tests/bootstrap.php
@@ -4,9 +4,7 @@ use Symfony\Component\Dotenv\Dotenv;
 
 require dirname(__DIR__).'/vendor/autoload.php';
 
-if (file_exists(dirname(__DIR__).'/config/bootstrap.php')) {
-    require dirname(__DIR__).'/config/bootstrap.php';
-} elseif (method_exists(Dotenv::class, 'bootEnv')) {
+if (method_exists(Dotenv::class, 'bootEnv')) {
     (new Dotenv())->bootEnv(dirname(__DIR__).'/.env');
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | symfony/symfony-docs#...

Fixes #1179
