### PR TITLE
Moving `{% block importmap %}` *above* `{% block javascripts %}`

### DIFF
--- a/symfony/asset-mapper/6.4/manifest.json
+++ b/symfony/asset-mapper/6.4/manifest.json
@@ -16,7 +16,7 @@
         {
             "file": "templates/base.html.twig",
             "content": "{% block importmap %}{{ importmap('app') }}{% endblock %}",
-            "position": "after_target",
+            "position": "before_target",
             "target": "{% block javascripts %}",
             "warn_if_missing": true
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | none

@weaverryan
Disclaimer: I'm not sure about this - especially I didn't check if `before_target` is actually doing what I want ;-)

Here's the scenario I'm talking about:
```twig
{# base.html.twig #}
{% block javascripts %}
    {% block importmap %}{{ importmap('app') }}{% endblock %}
    // Here's some important JavaScript stuff that's needed on *every* page
{% endblock %}
```
```twig
{# some_page.html.twig #}
{% block importmap %}{{ importmap(['app', 'some_page']) }}{% endblock %}
```
Now how can I get the other important JavaScript onto `some_page`? IMO only by doing:
```twig
{% block javascripts %}
    {{ parent() }}
{% endblock %}
```
But this will also render the importmap *twice*.
Right?

My solution: Move `{% block importmap %}` **outside** of `{% block javascripts %}`. What do you think?

If you merge this, the code block at https://symfony.com/doc/6.4/frontend/asset_mapper.html#installation would need to be updated again... :-)