### PR TITLE
[symfony/twig-bundle] Add name to `{% endblock %}`

### DIFF
--- a/symfony/twig-bundle/6.4/templates/base.html.twig
+++ b/symfony/twig-bundle/6.4/templates/base.html.twig
@@ -5,12 +5,12 @@
         <title>{% block title %}Welcome!{% endblock %}</title>
         <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 128 128%22><text y=%221.2em%22 font-size=%2296%22>⚫️</text><text y=%221.3em%22 x=%220.2em%22 font-size=%2276%22 fill=%22%23fff%22>sf</text></svg>">
         {% block stylesheets %}
-        {% endblock %}
+        {% endblock stylesheets %}
 
         {% block javascripts %}
-        {% endblock %}
+        {% endblock javascripts %}
     </head>
     <body>
-        {% block body %}{% endblock %}
+        {% block body %}{% endblock body %}
     </body>
 </html>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | none

Reasons:
* It's good practice anyway IMO, especially when blocks are getting longer and longer...
* Would solve the problem at https://github.com/symfony/recipes/pull/1288#discussion_r1474889507 nicely :-)