### PR TITLE
Use "resolve" processor for MAILER_DSN env variable

### DIFF
--- a/symfony/mailer/4.3/config/packages/mailer.yaml
+++ b/symfony/mailer/4.3/config/packages/mailer.yaml
@@ -1,3 +1,3 @@
 framework:
     mailer:
-        dsn: '%env(MAILER_DSN)%'
+        dsn: '%env(resolve:MAILER_DSN)%'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

For the Doctrine bundle, the `DATABASE_URL` variable is processed by the `resolve` env var processor. This is nice, since the value can be read from file by using the `file` processor when defining its value, for instance. It would be nice if this would be applied to the `MAILER_DSN` for the Symfony Mailer as well, for the same reasons.