### PR TITLE
chore: Always catch errors when calling `console`

### DIFF
--- a/symfony/console/6.4/bin/console
+++ b/symfony/console/6.4/bin/console
@@ -1,0 +1,20 @@
+#!/usr/bin/env php
+<?php
+
+use App\Kernel;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+
+if (!is_file(dirname(__DIR__).'/vendor/autoload_runtime.php')) {
+    throw new LogicException('Symfony Runtime is missing. Try running "composer require symfony/runtime".');
+}
+
+require_once dirname(__DIR__).'/vendor/autoload_runtime.php';
+
+return function (array $context) {
+    $kernel = new Kernel($context['APP_ENV'], (bool) $context['APP_DEBUG']);
+
+    $app = new Application($kernel);
+    $app->setCatchErrors('prod' === $context['APP_ENV']);
+
+    return $app;
+};

--- a/symfony/console/6.4/bin/console
+++ b/symfony/console/6.4/bin/console
@@ -14,7 +14,7 @@ return function (array $context) {
     $kernel = new Kernel($context['APP_ENV'], (bool) $context['APP_DEBUG']);
 
     $app = new Application($kernel);
-    $app->setCatchErrors('prod' === $context['APP_ENV']);
+    $app->setCatchErrors(true);
 
     return $app;
 };

--- a/symfony/console/6.4/manifest.json
+++ b/symfony/console/6.4/manifest.json
@@ -1,0 +1,6 @@
+{
+    "copy-from-recipe": {
+        "bin/": "%BIN_DIR%/"
+    },
+    "aliases": ["cli"]
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | [#53946](https://github.com/symfony/symfony/issues/53946)

Pinging @wouterj @greg0ire 

This is my first time doing "recipe" work and I am not sure if this is the correct place to open this PR. Let me know for any change needed! 

In short: when executing console commands in production mode/env commands **have to fail** with exit 1, and not render the `\Error` and exit 0. 
