### PR TITLE
Explicit Messenger bus configuration

### DIFF
--- a/symfony/webapp-pack/1.0/config/packages/messenger.yaml
+++ b/symfony/webapp-pack/1.0/config/packages/messenger.yaml
@@ -15,6 +15,11 @@ framework:
             failed: 'doctrine://default?queue_name=failed'
             # sync: 'sync://'
 
+        default_bus: messenger.bus.default
+
+        buses:
+            messenger.bus.default: []
+
         routing:
             Symfony\Component\Mailer\Messenger\SendEmailMessage: async
             Symfony\Component\Notifier\Message\ChatMessage: async


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | 

Make bus configuration in `messenger.yaml` explicit to facilitate third-party bundles providing their bus configuration.

Without this configuration, if a bundle provides a bus configuration via a flex recipe, it silently becomes the default bus. Or if there is already a bus configuration, but without the `default_bus` setting, it will give us _"Invalid configuration for path "framework.messenger": You must specify the "default_bus" if you define more than one bus."_