### PR TITLE
Check for existence of vendor directory for better error message

### DIFF
--- a/symfony/console/5.3/bin/console
+++ b/symfony/console/5.3/bin/console
@@ -4,6 +4,10 @@
 use App\Kernel;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 
+if (!is_dir(dirname(__DIR__).'/vendor')) {
+    throw new LogicException('Dependencies are missing. Try running "composer install".');
+}
+
 if (!is_file(dirname(__DIR__).'/vendor/autoload_runtime.php')) {
     throw new LogicException('Symfony Runtime is missing. Try running "composer require symfony/runtime".');
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | symfony/symfony-docs#...

The error message `Symfony Runtime is missing. Try running "composer require symfony/runtime".` is missleading if no vendor directory exists. In that case somebody want to run a Symfony project just need to run `composer install`.