### PR TITLE
Enable entity automapping for controllers again

### DIFF
--- a/doctrine/doctrine-bundle/2.12/config/packages/doctrine.yaml
+++ b/doctrine/doctrine-bundle/2.12/config/packages/doctrine.yaml
@@ -23,7 +23,7 @@ doctrine:
                 prefix: 'App\Entity'
                 alias: App
         controller_resolver:
-            auto_mapping: false
+            auto_mapping: true
 
 when@test:
     doctrine:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

Reverts the setting set in #1299

I'm not sure this is the solution we want to merge, but I'm sure the recent changes have not been made with DX in mind, and they're making the experience worse (see comments in https://github.com/symfony/recipes/pull/1299)

I'm kindly asking to redesign this change with DX in mind. :pray: If we don't have any better idea yet, I suggest reverting the change on DoctrineBundle until we have a DX-friendly solution.
