### PR TITLE
[symfony/panther] add apt update & clean during chromium driver install

### DIFF
--- a/symfony/panther/1.0/manifest.json
+++ b/symfony/panther/1.0/manifest.json
@@ -8,7 +8,7 @@
         "",
         "# Firefox and geckodriver",
         "#ARG GECKODRIVER_VERSION=0.34.0",
-        "#RUN apt-get install -y --no-install-recommends firefox",
+        "#RUN apt-get update && apt-get install -y --no-install-recommends firefox && rm -rf /var/lib/apt/lists/*",
         "#RUN wget -q https://github.com/mozilla/geckodriver/releases/download/v$GECKODRIVER_VERSION/geckodriver-v$GECKODRIVER_VERSION-aarch64.tar.gz; \\",
         "#\ttar -zxf geckodriver-v$GECKODRIVER_VERSION-aarch64.tar.gz -C /usr/bin; \\",
         "#\trm geckodriver-v$GECKODRIVER_VERSION-aarch64.tar.gz"

--- a/symfony/panther/1.0/manifest.json
+++ b/symfony/panther/1.0/manifest.json
@@ -4,7 +4,7 @@
         "ENV PANTHER_NO_SANDBOX 1",
         "# Not mandatory, but recommended",
         "ENV PANTHER_CHROME_ARGUMENTS='--disable-dev-shm-usage'",
-        "RUN apt-get install -y --no-install-recommends chromium chromium-driver",
+        "RUN apt-get update && apt-get install -y --no-install-recommends chromium chromium-driver && rm -rf /var/lib/apt/lists/*",
         "",
         "# Firefox and geckodriver",
         "#ARG GECKODRIVER_VERSION=0.34.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | 

<!--
Please, carefully read the README before submitting a pull request.
-->

This change adds an apt update before the installation of the packages and clean up the /var/lib/apt/lists/ after. 
This will ensure that the package can be installed even if the previous docker layers using apt were cached and reduce the outputed layer size with unused apt cache files