### PR TITLE
fix healthcheck postgres user

### DIFF
--- a/doctrine/doctrine-bundle/2.12/manifest.json
+++ b/doctrine/doctrine-bundle/2.12/manifest.json
@@ -29,7 +29,7 @@
                 "    POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-!ChangeMe!}",
                 "    POSTGRES_USER: ${POSTGRES_USER:-app}",
                 "  healthcheck:",
-                "    test: [\"CMD\", \"pg_isready\"]",
+                "    test: [\"CMD\", \"pg_isready -U ${POSTGRES_USER:-app}\"]",
                 "    timeout: 5s",
                 "    retries: 5",
                 "    start_period: 60s",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

By default, root user is used to connect to the postgres database.
If the database does not have a "root" role, the following error is logged everytime the health check happens:
`FATAL:  role "root" does not exist`

It does not seem to affect the 'healthy' status of the container (the command still returns zero exit code), but it spams the log:
```
database-1  | 2024-04-18 06:26:08.016 UTC [67] FATAL:  role "root" does not exist
database-1  | 2024-04-18 06:27:08.192 UTC [69] FATAL:  role "root" does not exist
database-1  | 2024-04-18 06:28:08.352 UTC [71] FATAL:  role "root" does not exist
```

