### PR TITLE
Fix healthcheck for database service

### DIFF
--- a/doctrine/doctrine-bundle/2.12/manifest.json
+++ b/doctrine/doctrine-bundle/2.12/manifest.json
@@ -29,7 +29,7 @@
                 "    POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-!ChangeMe!}",
                 "    POSTGRES_USER: ${POSTGRES_USER:-app}",
                 "  healthcheck:",
-                "    test: [\"CMD\", \"pg_isready -U ${POSTGRES_USER:-app}\"]",
+                "    test: [\"CMD\", \"pg_isready\", \"-d\", \"${POSTGRES_DB:-app}\", \"-U\", \"${POSTGRES_USER:-app}\"]",
                 "    timeout: 5s",
                 "    retries: 5",
                 "    start_period: 60s",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | [PR#1307](https://github.com/symfony/recipes/pull/1307)

As per discussed in https://github.com/symfony/recipes/pull/1307, the current healthcheck makes container always unhealthy. After testing every combination, the only implementations that produce healty status are the following:
```yaml
test: ["CMD", "pg_isready", "-d", "${POSTGRES_DB:-app}", "-U", "${POSTGRES_USER:-app}"]
```
and
```yaml
test: ["CMD-SHELL", "pg_isready -d ${POSTGRES_DB:-app} -U ${POSTGRES_USER:-app} || exit 1"]
```

This PR uses the first approach.