### PR TITLE
[framework-bundle] Prefix generated APP_SECRET by NotSecure-

### DIFF
--- a/symfony/framework-bundle/6.4/manifest.json
+++ b/symfony/framework-bundle/6.4/manifest.json
@@ -13,7 +13,7 @@
     },
     "env": {
         "APP_ENV": "dev",
-        "APP_SECRET": "%generate(secret)%"
+        "APP_SECRET": "NotSecure-%generate(secret)%"
     },
     "gitignore": [
         "/.env.local",

--- a/symfony/framework-bundle/7.0/manifest.json
+++ b/symfony/framework-bundle/7.0/manifest.json
@@ -13,7 +13,7 @@
     },
     "env": {
         "APP_ENV": "dev",
-        "APP_SECRET": "%generate(secret)%"
+        "APP_SECRET": "NotSecure-%generate(secret)%"
     },
     "gitignore": [
         "/.env.local",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | n/a

While it's ok to commit the `APP_SECRET` used for dev and test environments, in production, the `APP_SECRET` environment variable must be overridden by a local value that is not committed (using a secret vault, using Symfony Secrets, creating a local environment variable, or creating an unversioned `.env.prod` file are acceptable options).

With this patch, Flex will prefix the generated value with `NotSecure-` to make it clear that the committed value must not be used in production.

Brought to our attention by @ramsey's https://phpc.social/@ramsey/112437517679689885.
See also https://github.com/symfony/symfony/issues/38021.

We'll also have to document that `APP_SECRET` is used as the value for https://symfony.com/doc/current/reference/configuration/framework.html#secret