### PR TITLE
[MakerBundle] final class & root namespace configuration

### DIFF
--- a/symfony/maker-bundle/1.60/config/packages/maker.yaml
+++ b/symfony/maker-bundle/1.60/config/packages/maker.yaml
@@ -1,0 +1,12 @@
+when@dev:
+    maker:
+        # tell MakerBundle that all of your classes live in an
+        # Acme namespace, instead of the default App
+        # (e.g. Acme\Entity\Article, Acme\Command\MyCommand, etc)
+        root_namespace: 'App'
+
+        # Tell MakerBundle to make all non-entity classes it generates, "final".
+        generate_final_classes: true
+
+        # Tell MakerBundle to make all entities it generates, "final".
+        generate_final_entities: false

--- a/symfony/maker-bundle/1.60/manifest.json
+++ b/symfony/maker-bundle/1.60/manifest.json
@@ -1,0 +1,9 @@
+{
+    "bundles": {
+        "Symfony\\Bundle\\MakerBundle\\MakerBundle": ["dev"]
+    },
+    "aliases": ["maker", "generator", "make"],
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | see below

- [ ] https://github.com/symfony/maker-bundle/pull/1539 introduces 2 new configuration params `generate_final_classes` & `generate_final_entities`
- [ ] https://github.com/symfony/maker-bundle/pull/1562 documents the changes
- [ ] Feature available in MakerBundle `v1.60.0` (the next release)

- adds the `root_namespace` configuration directive that has been available in Maker since `v1.27.0`. 

_PR [1539](https://github.com/symfony/maker-bundle/pull/1539) implements the `generate_final_*` functionality for `make:crud` & `make:voter`. To keep that PR relatively small and reviewable, PR's will be made for other makers for release `v1.60.0`_