### PR TITLE
[doctrine/doctrine-bundle] Disable automapping when using FWB >= 7.1

### DIFF
--- a/doctrine/doctrine-bundle/2.12/config/packages/doctrine.yaml
+++ b/doctrine/doctrine-bundle/2.12/config/packages/doctrine.yaml
@@ -23,7 +23,7 @@ doctrine:
                 prefix: 'App\Entity'
                 alias: App
         controller_resolver:
-            auto_mapping: true
+            auto_mapping: false
 
 when@test:
     doctrine:

--- a/doctrine/doctrine-bundle/2.12/manifest.json
+++ b/doctrine/doctrine-bundle/2.12/manifest.json
@@ -49,8 +49,6 @@
         }
     },
     "conflict": {
-        "doctrine/orm": "<2.14",
-        "symfony/dependency-injection": "<6.2",
-        "symfony/framework-bundle": "<5.3"
+        "symfony/framework-bundle": "<7.1"
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

Follows #1299 and #1302

Possible after https://github.com/symfony/symfony/pull/54720

Use explicit mappings instead, e.g.:
`#[Route('/conference/{id:conference}/{slug:conference}')]`

/cc @bobvandevijver we could now deprecate *enabling* automapping in doctrine-bundle. Up to send a PR doing so?