### PR TITLE
Check for existence of vendor directory for better error message

### DIFF
--- a/symfony/framework-bundle/7.2/public/index.php
+++ b/symfony/framework-bundle/7.2/public/index.php
@@ -10,7 +10,9 @@ if (!is_file(dirname(__DIR__).'/vendor/autoload_runtime.php')) {
     throw new LogicException('Symfony Runtime is missing. Try running "composer require symfony/runtime".');
 }
 
-require_once dirname(__DIR__).'/vendor/autoload_runtime.php';
+if (false === include dirname(__DIR__).'/vendor/autoload_runtime.php') {
+    throw new LogicException('Symfony Runtime is missing. Try running "composer require symfony/runtime".');
+}
 
 return function (array $context) {
     return new Kernel($context['APP_ENV'], (bool) $context['APP_DEBUG']);

--- a/symfony/framework-bundle/7.2/public/index.php
+++ b/symfony/framework-bundle/7.2/public/index.php
@@ -2,6 +2,14 @@
 
 use App\Kernel;
 
+if (!is_dir(dirname(__DIR__).'/vendor')) {
+    throw new LogicException('Dependencies are missing. Try running "composer install".');
+}
+
+if (!is_file(dirname(__DIR__).'/vendor/autoload_runtime.php')) {
+    throw new LogicException('Symfony Runtime is missing. Try running "composer require symfony/runtime".');
+}
+
 require_once dirname(__DIR__).'/vendor/autoload_runtime.php';
 
 return function (array $context) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | .

replicates https://github.com/symfony/recipes/pull/1301 for the web entry point
I came across this on a recent project I boot up, inside `bin/console` but not `public/index`

please feel free to close if it is not relevant

