### PR TITLE
[MercureBundle] Change Caddy config filename

### DIFF
--- a/symfony/mercure-bundle/0.3/manifest.json
+++ b/symfony/mercure-bundle/0.3/manifest.json
@@ -29,7 +29,7 @@
                 "    MERCURE_EXTRA_DIRECTIVES: |",
                 "      cors_origins http://127.0.0.1:8000",
                 "  # Comment the following line to disable the development mode",
-                "  command: /usr/bin/caddy run --config /etc/caddy/Caddyfile.dev",
+                "  command: /usr/bin/caddy run --config /etc/caddy/dev.Caddyfile",
                 "  healthcheck:",
                 "    test: [\"CMD\", \"curl\", \"-f\", \"https://localhost/healthz\"]",
                 "    timeout: 5s",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

The Caddy config file name has changed in a previous version, see https://github.com/dunglas/mercure/issues/919 and https://mercure.rocks/docs/hub/install#docker-compose

cc @dunglas 
