### PR TITLE
Introduce APP_CACHE_POOLS_DIR to ease splitting app from system pools

### DIFF
--- a/symfony/framework-bundle/5.4/config/packages/cache.yaml
+++ b/symfony/framework-bundle/5.4/config/packages/cache.yaml
@@ -4,7 +4,8 @@ framework:
         #prefix_seed: your_vendor_name/app_name
 
         # The "app" cache stores to the filesystem by default.
-        # The data in this cache should persist between deploys.
+        directory: '%env(default:kernel.cache_dir:APP_CACHE_POOLS_DIR)%/pools/app'
+
         # Other options include:
 
         # Redis

--- a/symfony/framework-bundle/6.2/config/packages/cache.yaml
+++ b/symfony/framework-bundle/6.2/config/packages/cache.yaml
@@ -4,7 +4,8 @@ framework:
         #prefix_seed: your_vendor_name/app_name
 
         # The "app" cache stores to the filesystem by default.
-        # The data in this cache should persist between deploys.
+        directory: '%env(default:kernel.cache_dir:APP_CACHE_POOLS_DIR)%/pools/app'
+
         # Other options include:
 
         # Redis

--- a/symfony/framework-bundle/6.4/config/packages/cache.yaml
+++ b/symfony/framework-bundle/6.4/config/packages/cache.yaml
@@ -4,7 +4,8 @@ framework:
         #prefix_seed: your_vendor_name/app_name
 
         # The "app" cache stores to the filesystem by default.
-        # The data in this cache should persist between deploys.
+        directory: '%env(default:kernel.cache_dir:APP_CACHE_POOLS_DIR)%/pools/app'
+
         # Other options include:
 
         # Redis

--- a/symfony/framework-bundle/7.0/config/packages/cache.yaml
+++ b/symfony/framework-bundle/7.0/config/packages/cache.yaml
@@ -4,7 +4,8 @@ framework:
         #prefix_seed: your_vendor_name/app_name
 
         # The "app" cache stores to the filesystem by default.
-        # The data in this cache should persist between deploys.
+        directory: '%env(default:kernel.cache_dir:APP_CACHE_POOLS_DIR)%/pools/app'
+
         # Other options include:
 
         # Redis

--- a/symfony/framework-bundle/7.2/config/packages/cache.yaml
+++ b/symfony/framework-bundle/7.2/config/packages/cache.yaml
@@ -4,7 +4,8 @@ framework:
         #prefix_seed: your_vendor_name/app_name
 
         # The "app" cache stores to the filesystem by default.
-        # The data in this cache should persist between deploys.
+        directory: '%env(default:kernel.cache_dir:APP_CACHE_POOLS_DIR)%/pools/app'
+
         # Other options include:
 
         # Redis


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

So that splitting app from system pools becomes just a matter of setting an env var.