### PR TITLE
[symfony/framework-bundle/7.0 & 7.2] Add imports for services.yaml wi…

### DIFF
--- a/symfony/framework-bundle/7.0/config/services.yaml
+++ b/symfony/framework-bundle/7.0/config/services.yaml
@@ -1,6 +1,12 @@
 # This file is the entry point to configure your own services.
 # Files in the packages/ subdirectory configure your dependencies.
 
+# There comes imported service files, if you would like to split config to multiple files.
+# Symfony loads first the imported files and then it processes the parameters and services defined in this file itself.
+# Duplicating services will be overridden and last config wins.
+# https://symfony.com/doc/current/service_container/import.html
+imports:
+
 # Put parameters here that don't need to change on each machine where the app is deployed
 # https://symfony.com/doc/current/best_practices.html#use-parameters-for-application-configuration
 parameters:

--- a/symfony/framework-bundle/7.2/config/services.yaml
+++ b/symfony/framework-bundle/7.2/config/services.yaml
@@ -1,6 +1,12 @@
 # This file is the entry point to configure your own services.
 # Files in the packages/ subdirectory configure your dependencies.
 
+# There comes imported service files, if you would like to split config to multiple files.
+# Symfony loads first the imported files and then it processes the parameters and services defined in this file itself.
+# Duplicating services will be overridden and last config wins.
+# https://symfony.com/doc/current/service_container/import.html
+imports:
+
 # Put parameters here that don't need to change on each machine where the app is deployed
 # https://symfony.com/doc/current/best_practices.html#use-parameters-for-application-configuration
 parameters:


### PR DESCRIPTION
…th some comments for clarification

| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | .

This is tiny change for `config/services.yaml` file. I lost hours trying to understand how to use multiple service files correctly and everything I needed to know is the import order. Now it sounds obvious for me, but lots of stackoverflow questions shows that I am not the only one stuck on that. So I added some comments for imports statement to services.yaml. Hope it helps others to save time.

