### PR TITLE
[symfony/framework-bundle] Remove "csrf_protection" line as its enabled by default

### DIFF
--- a/symfony/framework-bundle/6.4/config/packages/framework.yaml
+++ b/symfony/framework-bundle/6.4/config/packages/framework.yaml
@@ -1,7 +1,6 @@
 # see https://symfony.com/doc/current/reference/configuration/framework.html
 framework:
     secret: '%env(APP_SECRET)%'
-    #csrf_protection: true
     annotations: false
     http_method_override: false
     handle_all_throwables: true

--- a/symfony/framework-bundle/7.2/config/packages/framework.yaml
+++ b/symfony/framework-bundle/7.2/config/packages/framework.yaml
@@ -1,7 +1,6 @@
 # see https://symfony.com/doc/current/reference/configuration/framework.html
 framework:
     secret: '%env(APP_SECRET)%'
-    #csrf_protection: true
 
     # Note that the session will be started ONLY if you read or write from it.
     session: true


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

Not needed since https://github.com/symfony/symfony/pull/25508