### PR TITLE
[WebpackEncoreBundle] Fix development server command for 2.20

### DIFF
--- a/symfony/webpack-encore-bundle/2.0/post-install.txt
+++ b/symfony/webpack-encore-bundle/2.0/post-install.txt
@@ -2,4 +2,4 @@
 
   * Compile your assets: <fg=green>npm run dev</>
 
-  * Or start the development server: <fg=green>npm run watch</>
+  * Or start the development server: <fg=green>npm run dev-server</>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | symfony/symfony-docs#...

<!--
Please, carefully read the README before submitting a pull request.
-->

The development server is launched with the `npm run dev-server` command, `npm run watch` is equivalent to `npm run dev --watch` and is different from the dev-server. 