### PR TITLE
Generate APP_SECRET in .env.dev

### DIFF
--- a/symfony/framework-bundle/7.2/manifest.json
+++ b/symfony/framework-bundle/7.2/manifest.json
@@ -16,7 +16,7 @@
         "APP_SECRET": ""
     },
     "dotenv": {
-        "local": {
+        "dev": {
             "APP_SECRET": "%generate(secret)%"
         }
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

Follows #1342 

As spotted by @stof:

> As the .env.local file is not committed, the dev running the recipe will get the change, but it will be missing for everyone else in the team.

This PR stores the APP_SECRET in `.env.dev`, which is committed, but used only for the dev env.