### PR TITLE
[nelmio/security-bundle] Remove xss_protection config

### DIFF
--- a/nelmio/security-bundle/2.4/config/packages/nelmio_security.yaml
+++ b/nelmio/security-bundle/2.4/config/packages/nelmio_security.yaml
@@ -8,12 +8,6 @@ nelmio_security:
     content_type:
         nosniff: true
 
-    # forces Microsoft's XSS-Protection with
-    # its block mode
-    xss_protection:
-        enabled: true
-        mode_block: true
-
     # Send a full URL in the `Referer` header when performing a same-origin request,
     # only send the origin of the document to secure destination (HTTPS->HTTPS),
     # and send no header to a less secure destination (HTTPS->HTTP).


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

This header is deprecated, see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection
We shouldn't enable it by default.