### PR TITLE
[AssetMapper] Re-configure "missing_import_mode" in prod/non-prod envs

### DIFF
--- a/symfony/asset-mapper/6.4/config/packages/asset_mapper.yaml
+++ b/symfony/asset-mapper/6.4/config/packages/asset_mapper.yaml
@@ -3,3 +3,9 @@ framework:
         # The paths to make available to the asset mapper.
         paths:
             - assets/
+        missing_import_mode: strict
+
+when@prod:
+    framework:
+        asset_mapper:
+            missing_import_mode: warn


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | symfony/symfony-docs#...

<!--
Please, carefully read the README before submitting a pull request.
-->

When working on my project with the AssetMapper, it became frustrating to found that my relative import didn't work because `.js` was missing at the end of the import path.

I wanted to implement something which tells the user to specify `.js` if we found that `<import path>.js` exists, but... the feature already exist, through `missing_import_mode` configuration.

The thing is, defaulting to `warn` (which warns import errors in the profiler) by default is not very useful. 
When you work locally on your project, you want errors to be displayed clearly so you can quickly fix them.

This PR updates the `missing_import_mode` to `strict` (so exceptions are thrown) on all environment, but keep it to `warn` in prod environment.