### PR TITLE
Add recipe for `zenstruck/browser`

### DIFF
--- a/zenstruck/browser/1.9/manifest.json
+++ b/zenstruck/browser/1.9/manifest.json
@@ -1,0 +1,12 @@
+{
+    "aliases": ["browser"],
+    "add-lines": [
+        {
+            "file": "phpunit.xml.dist",
+            "content": "        <server name=\"BROWSER_ALWAYS_START_WEBSERVER\" value=\"1\"/>",
+            "position": "after_target",
+            "target": "<server name=\"SHELL_VERBOSITY\" value=\"-1\" />",
+            "warn_if_missing": true
+        }
+    ]
+}

--- a/zenstruck/browser/1.9/post-install.txt
+++ b/zenstruck/browser/1.9/post-install.txt
@@ -1,0 +1,5 @@
+  * You're ready to use zenstruck/browser:
+    1. Add the <info>HasBrowser</info> trait to "kernel" test cases
+    2. Start using <info>$this->browser()->...</info> in your tests
+
+  * <fg=blue>Read</> the documentation at <comment>https://github.com/zenstruck/browser#zenstruckbrowser</>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | n/a

Companion to https://github.com/zenstruck/browser/pull/156

I've been working on making it easier to get started using `zenstruck/browser` and `symfony/panther` together. Basically, adding a way to avoid [this "hack"](https://symfonycasts.com/screencast/last-stack/testing#loading-a-test-dev-server).

The fix in browser does the following:
1. Ensure a new webserver is always started by unsetting `SYMFONY_PROJECT_DEFAULT_ROUTE_URL`. This env var is added by the Symfony CLI when a server is running for the current project. For the most part, I think this is the user's dev environment which they don't want to run their tests on.
2. Set `PANTHER_APP_ENV` to `APP_ENV` to ensure the arrange/setup phase of your tests work with the same kernel Panther's webserver does. I know #643 specifically added `PANTHER_APP_ENV=panther` - a separate env to avoid mocked sessions but... I don't seem to be having this problem - Panther appears to work with mock_file session storage just fine. I've tested session auth and form submits (CSRF). Maybe something has changed since `PANTHER_APP_ENV` was introduced? Let me know if I'm missing something here!

To avoid BC breaks, `zenstruck/browser` requires you to opt-in but I think this should be the recipe default.
