### PR TITLE
uncomment `MAILER_DSN` env for `symfony/mailer`

### DIFF
--- a/symfony/mailer/4.3/manifest.json
+++ b/symfony/mailer/4.3/manifest.json
@@ -3,7 +3,7 @@
         "config/": "%CONFIG_DIR%/"
     },
     "env": {
-        "#1": "MAILER_DSN=null://null"
+        "MAILER_DSN": "null://null"
     },
     "docker-compose": {
         "docker-compose.override.yml": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | n/a

Currently, when installing `symfony/mailer`, the `MAILER_DSN` is commented out so you get an error when trying to send an email. I feel this is a bit of a DX bummer.

I think it should default to `null://null` so you can start using it right away (preview in the profiler and use in your tests).

Any bridge you install for production sending would configure `MAILER_DSN` elsewhere (ie secrets or `.env.local`).
