### PR TITLE
[Symfony UX Map] Add post-install steps for Leaflet and Google, add "ux_map.google_maps.default_map_id" config recipe

### DIFF
--- a/symfony/ux-google-map/2.19/post-install.txt
+++ b/symfony/ux-google-map/2.19/post-install.txt
@@ -1,0 +1,1 @@
+  * <fg=blue>Read</> the documentation at <comment>https://github.com/symfony/ux/blob/2.x/src/Map/src/Bridge/Google/README.md</>

--- a/symfony/ux-google-map/2.22/manifest.json
+++ b/symfony/ux-google-map/2.22/manifest.json
@@ -1,0 +1,20 @@
+{
+    "conflict": {
+        "symfony/flex": "<1.20.0 || >=2.0.0,<2.3.0"
+    },
+    "add-lines": [
+        {
+            "file": "config/packages/ux_map.yaml",
+            "position": "after_target",
+            "warn_if_missing": true,
+            "target": "    renderer: '%env(resolve:default::UX_MAP_DSN)%'",
+            "content": "    google_maps:\n        # define the default map id for all maps (https://developers.google.com/maps/documentation/get-map-id)\n        default_map_id: null"
+        }
+    ],
+    "env": {
+        "#1": "Options available at https://github.com/symfony/ux/blob/2.x/src/Map/src/Bridge/Google/README.md",
+        "#2": "",
+        "GOOGLE_MAPS_API_KEY": "# Get your API key at https://developers.google.com/maps/documentation/javascript/get-api-key",
+        "UX_MAP_DSN": "google://%env(GOOGLE_MAPS_API_KEY)%@default"
+    }
+}

--- a/symfony/ux-google-map/2.22/post-install.txt
+++ b/symfony/ux-google-map/2.22/post-install.txt
@@ -1,0 +1,1 @@
+  * <fg=blue>Read</> the documentation at <comment>https://github.com/symfony/ux/blob/2.x/src/Map/src/Bridge/Google/README.md</>

--- a/symfony/ux-leaflet-map/2.19/post-install.txt
+++ b/symfony/ux-leaflet-map/2.19/post-install.txt
@@ -1,0 +1,1 @@
+  * <fg=blue>Read</> the documentation at <comment>https://github.com/symfony/ux/blob/2.x/src/Map/src/Bridge/Leaflet/README.md</>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | symfony/symfony-docs#...

<!--
Please, carefully read the README before submitting a pull request.
-->

Follow https://github.com/symfony/ux/pull/2358, I've also added post-install steps.

Version 2.22 is not released yet, [but 2.19 is](https://packagist.org/packages/symfony/ux-google-map#v2.19.0)
<img width="756" alt="image" src="https://github.com/user-attachments/assets/1a62bec3-b512-4001-ae17-810bb7378745">
