### PR TITLE
[UX Turbo] Fix recipe does not install bundle

### DIFF
--- a/symfony/ux-turbo/2.19/manifest.json
+++ b/symfony/ux-turbo/2.19/manifest.json
@@ -1,0 +1,5 @@
+{
+    "bundles": {
+        "Symfony\\UX\\Turbo\\TurboBundle": ["all"]
+    }
+}

--- a/symfony/ux-turbo/2.20/manifest.json
+++ b/symfony/ux-turbo/2.20/manifest.json
@@ -1,4 +1,7 @@
 {
+    "bundles": {
+        "Symfony\\UX\\Turbo\\TurboBundle": ["all"]
+    },
     "conflict": {
         "symfony/framework-bundle": "<7.2",
         "symfony/security-csrf": "<7.2"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | https://github.com/symfony/ux/issues/2391

Turbo is not installed correctly now (i guess now having this recipe, we do need to add the `bundles` entry in the manifest)

Issue: https://github.com/symfony/ux/issues/2391

The "conflict" should not prevent the bundle to be configured, as the same thing occurs in the Stimulus Bundle with no problem

---

**Update 1**: not enough 😢 

```
13 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
  - Skipping recipe for symfony/ux-turbo: all versions of the recipe conflict with your package versions.
```

---

**Update2**: added a 2.19 recipe

---

**Update3**:  nope :/

It worked once, but i cannot make it work another time 🤔 

```
Generating autoload files
> post-autoload-dump: Symfony\Component\Runtime\Internal\ComposerPlugin_composer_tmp1->updateAutoloadFile
113 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
> post-update-cmd: Symfony\Flex\Flex_composer_tmp0->update
Reading /Users/simonandre/Library/Caches/composer/repo/flex/symfony-recipes-flex-pull-1357-symfony.ux-turbo.2.19.json from cache
Downloading https://raw.githubusercontent.com/symfony/recipes/flex/pull-1357/symfony.ux-turbo.2.19.json
[304] https://raw.githubusercontent.com/symfony/recipes/flex/pull-1357/symfony.ux-turbo.2.19.json

Symfony operations: 1 recipe (be9bca5f1f656f87cb5b712afbd456f8)
  - Configuring symfony/ux-turbo (>=2.19): From github.com/symfony/recipes:main
    Enabling the package as a Symfony bundle
> post-update-cmd: Symfony\Thanks\Thanks_composer_tmp3->displayReminder
> post-update-cmd: @auto-scripts
> auto-scripts: Symfony\Flex\Flex_composer_tmp0->executeAutoScripts
Executing script cache:clear
Executed script cache:clear  [OK]
```
