### PR TITLE
Add an empty .env.dev file for DotenvConfigurator

### DIFF
--- a/symfony/framework-bundle/7.2/.env.dev
+++ b/symfony/framework-bundle/7.2/.env.dev
@@ -1,0 +1,1 @@
+# Define your env variables for the development environment here

--- a/symfony/framework-bundle/7.2/manifest.json
+++ b/symfony/framework-bundle/7.2/manifest.json
@@ -3,6 +3,7 @@
         "Symfony\\Bundle\\FrameworkBundle\\FrameworkBundle": ["all"]
     },
     "copy-from-recipe": {
+        ".env.dev": ".env.dev",
         "config/": "%CONFIG_DIR%/",
         "public/": "%PUBLIC_DIR%/",
         "src/": "%SRC_DIR%/"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

Follows #1343 

The `.env.dev` file needs to exist for DotenvConfigurator to be able to generate APP_SECRET