### PR TITLE
[stimulus-bundle] Match name="_csrf_token" when looking for CSRF fields

### DIFF
--- a/symfony/stimulus-bundle/2.20/assets/controllers/csrf_protection_controller.js
+++ b/symfony/stimulus-bundle/2.20/assets/controllers/csrf_protection_controller.js
@@ -3,7 +3,7 @@ var tokenCheck = /^[-_/+a-zA-Z0-9]{24,}$/;
 
 // Generate and double-submit a CSRF token in a form field and a cookie, as defined by Symfony's SameOriginCsrfTokenManager
 document.addEventListener('submit', function (event) {
-    var csrfField = event.target.querySelector('input[data-controller="csrf-protection"]');
+    var csrfField = event.target.querySelector('input[data-controller="csrf-protection"], input[name="_csrf_token"]');
 
     if (!csrfField) {
         return;
@@ -26,7 +26,7 @@ document.addEventListener('submit', function (event) {
 // When @hotwired/turbo handles form submissions, send the CSRF token in a header in addition to a cookie
 // The `framework.csrf_protection.check_header` config option needs to be enabled for the header to be checked
 document.addEventListener('turbo:submit-start', function (event) {
-    var csrfField = event.detail.formSubmission.formElement.querySelector('input[data-controller="csrf-protection"]');
+    var csrfField = event.detail.formSubmission.formElement.querySelector('input[data-controller="csrf-protection"], input[name="_csrf_token"]');
 
     if (!csrfField) {
         return;
@@ -41,7 +41,7 @@ document.addEventListener('turbo:submit-start', function (event) {
 
 // When @hotwired/turbo handles form submissions, remove the CSRF cookie once a form has been submitted
 document.addEventListener('turbo:submit-end', function (event) {
-    var csrfField = event.detail.formSubmission.formElement.querySelector('input[data-controller="csrf-protection"]');
+    var csrfField = event.detail.formSubmission.formElement.querySelector('input[data-controller="csrf-protection"], input[name="_csrf_token"]');
 
     if (!csrfField) {
         return;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

Should ease upgrading apps. See https://github.com/symfony/symfony/issues/59111, https://github.com/symfony/symfony-docs/pull/20530 and https://github.com/symfony/maker-bundle/pull/1592