### PR TITLE
[stimulus-bundle] Export CSRF protection helpers

### DIFF
--- a/symfony/stimulus-bundle/2.20/assets/controllers/csrf_protection_controller.js
+++ b/symfony/stimulus-bundle/2.20/assets/controllers/csrf_protection_controller.js
@@ -1,61 +1,79 @@
-var nameCheck = /^[-_a-zA-Z0-9]{4,22}$/;
-var tokenCheck = /^[-_/+a-zA-Z0-9]{24,}$/;
+const nameCheck = /^[-_a-zA-Z0-9]{4,22}$/;
+const tokenCheck = /^[-_\/+a-zA-Z0-9]{24,}$/;
 
 // Generate and double-submit a CSRF token in a form field and a cookie, as defined by Symfony's SameOriginCsrfTokenManager
 document.addEventListener('submit', function (event) {
-    var csrfField = event.target.querySelector('input[data-controller="csrf-protection"], input[name="_csrf_token"]');
-
-    if (!csrfField) {
-        return;
-    }
-
-    var csrfCookie = csrfField.getAttribute('data-csrf-protection-cookie-value');
-    var csrfToken = csrfField.value;
-
-    if (!csrfCookie && nameCheck.test(csrfToken)) {
-        csrfField.setAttribute('data-csrf-protection-cookie-value', csrfCookie = csrfToken);
-        csrfField.defaultValue = csrfToken = btoa(String.fromCharCode.apply(null, (window.crypto || window.msCrypto).getRandomValues(new Uint8Array(18))));
-        csrfField.dispatchEvent(new Event('change', {bubbles: true}));
-    }
-
-    if (csrfCookie && tokenCheck.test(csrfToken)) {
-        var cookie = csrfCookie + '_' + csrfToken + '=' + csrfCookie + '; path=/; samesite=strict';
-        document.cookie = window.location.protocol === 'https:' ? '__Host-' + cookie + '; secure' : cookie;
-    }
-});
+    generateCsrfToken(event.target);
+}, true);
 
 // When @hotwired/turbo handles form submissions, send the CSRF token in a header in addition to a cookie
 // The `framework.csrf_protection.check_header` config option needs to be enabled for the header to be checked
 document.addEventListener('turbo:submit-start', function (event) {
-    var csrfField = event.detail.formSubmission.formElement.querySelector('input[data-controller="csrf-protection"], input[name="_csrf_token"]');
-
-    if (!csrfField) {
-        return;
-    }
-
-    var csrfCookie = csrfField.getAttribute('data-csrf-protection-cookie-value');
-
-    if (tokenCheck.test(csrfField.value) && nameCheck.test(csrfCookie)) {
-        event.detail.formSubmission.fetchRequest.headers[csrfCookie] = csrfField.value;
-    }
+    const h = generateCsrfHeaders(event.detail.formSubmission);
+    Object.keys(h).map(function (k) {
+        event.detail.formSubmission.fetchRequest.headers[k] = h[k];
+    });
 });
 
 // When @hotwired/turbo handles form submissions, remove the CSRF cookie once a form has been submitted
 document.addEventListener('turbo:submit-end', function (event) {
-    var csrfField = event.detail.formSubmission.formElement.querySelector('input[data-controller="csrf-protection"], input[name="_csrf_token"]');
+    removeCsrfToken(event.detail.formSubmission.formElement);
+});
+
+export function generateCsrfToken (formElement) {
+    const csrfField = formElement.querySelector('input[data-controller="csrf-protection"], input[name="_csrf_token"]');
 
     if (!csrfField) {
         return;
     }
 
-    var csrfCookie = csrfField.getAttribute('data-csrf-protection-cookie-value');
+    let csrfCookie = csrfField.getAttribute('data-csrf-protection-cookie-value');
+    let csrfToken = csrfField.value;
+
+    if (!csrfCookie && nameCheck.test(csrfToken)) {
+        csrfField.setAttribute('data-csrf-protection-cookie-value', csrfCookie = csrfToken);
+        csrfField.defaultValue = csrfToken = btoa(String.fromCharCode.apply(null, (window.crypto || window.msCrypto).getRandomValues(new Uint8Array(18))));
+        csrfField.dispatchEvent(new Event('change', { bubbles: true }));
+    }
+
+    if (csrfCookie && tokenCheck.test(csrfToken)) {
+        const cookie = csrfCookie + '_' + csrfToken + '=' + csrfCookie + '; path=/; samesite=strict';
+        document.cookie = window.location.protocol === 'https:' ? '__Host-' + cookie + '; secure' : cookie;
+    }
+}
+
+export function generateCsrfHeaders (formElement) {
+    const headers = {};
+    const csrfField = formElement.querySelector('input[data-controller="csrf-protection"], input[name="_csrf_token"]');
+
+    if (!csrfField) {
+        return headers;
+    }
+
+    const csrfCookie = csrfField.getAttribute('data-csrf-protection-cookie-value');
 
     if (tokenCheck.test(csrfField.value) && nameCheck.test(csrfCookie)) {
-        var cookie = csrfCookie + '_' + csrfField.value + '=0; path=/; samesite=strict; max-age=0';
+        headers[csrfCookie] = csrfField.value;
+    }
+
+    return headers;
+}
+
+export function removeCsrfToken (formElement) {
+    const csrfField = formElement.querySelector('input[data-controller="csrf-protection"], input[name="_csrf_token"]');
+
+    if (!csrfField) {
+        return;
+    }
+
+    const csrfCookie = csrfField.getAttribute('data-csrf-protection-cookie-value');
+
+    if (tokenCheck.test(csrfField.value) && nameCheck.test(csrfCookie)) {
+        const cookie = csrfCookie + '_' + csrfField.value + '=0; path=/; samesite=strict; max-age=0';
 
         document.cookie = window.location.protocol === 'https:' ? '__Host-' + cookie + '; secure' : cookie;
     }
-});
+}
 
 /* stimulusFetch: 'lazy' */
 export default 'csrf-protection-controller';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

Here is my first proposal addressing #1370:

* Fixes the issue where the CSRF token is updated after the form is submitted (e.g., when using fetch requests) ;
* Avoids code duplication when reusing this logic in multiple places ;
* Replaces `var` by `const` or `let` for better modern JavaScript practices.

This code can be used without Turbo. Here's an example:

```js
import { generateCsrfHeaders, removeCsrfToken } from './csrf_protection.js';

// ...

document.addEventListener('before-event-with-jquery-or-custom-fetch-event', function (event) {
	Object.entries(generateCsrfHeaders(event.detail.form)).forEach(([name, value]) => {
	    // add header
	});
});

document.addEventListener('after-event-with-jquery-or-custom-fetch-event', function (event) {
	removeCsrfToken(event.detail.form);
});
```

It can also be used without relying on the form's submit event :

```js
import { generateCsrfToken, generateCsrfHeaders, removeCsrfToken } from './csrf_protection.js';

// ...

link.addEventListener('click', function (event) {
	const form = document.getElementById('my-form');
	generateCsrfToken(form);
	// Send form with fetch (or jquery) with generateCsrfHeaders and removeCsrfToken functions
});
```



I have made these changes in version 2.20 (the existing version). However, since the behavior of the files is modified, I assume it is necessary to create a new version.
