### PR TITLE
[CSRF][StimulusBundle] Dispatch event on CSRF form field value change

### DIFF
--- a/symfony/stimulus-bundle/2.20/assets/controllers/csrf_protection_controller.js
+++ b/symfony/stimulus-bundle/2.20/assets/controllers/csrf_protection_controller.js
@@ -15,6 +15,7 @@ document.addEventListener('submit', function (event) {
     if (!csrfCookie && nameCheck.test(csrfToken)) {
         csrfField.setAttribute('data-csrf-protection-cookie-value', csrfCookie = csrfToken);
         csrfField.defaultValue = csrfToken = btoa(String.fromCharCode.apply(null, (window.crypto || window.msCrypto).getRandomValues(new Uint8Array(18))));
+        csrfField.dispatchEvent(new Event('change', {bubbles: true}));
     }
 
     if (csrfCookie && tokenCheck.test(csrfToken)) {


### PR DESCRIPTION
| Q |	A 
| - | - |
| License | MIT
| Doc issue/PR | 	-

This allow support / compatibility with LiveComponent when action are done between form first render and submit 

(ex: another form submit with Turbo and double header check)

See https://github.com/symfony/ux/issues/2505

