### PR TITLE
[stimulus-bundle] Fix broken CSRF header generation with Turbo forms

### DIFF
--- a/symfony/stimulus-bundle/2.20/assets/controllers/csrf_protection_controller.js
+++ b/symfony/stimulus-bundle/2.20/assets/controllers/csrf_protection_controller.js
@@ -9,7 +9,7 @@ document.addEventListener('submit', function (event) {
 // When @hotwired/turbo handles form submissions, send the CSRF token in a header in addition to a cookie
 // The `framework.csrf_protection.check_header` config option needs to be enabled for the header to be checked
 document.addEventListener('turbo:submit-start', function (event) {
-    const h = generateCsrfHeaders(event.detail.formSubmission);
+    const h = generateCsrfHeaders(event.detail.formSubmission.formElement);
     Object.keys(h).map(function (k) {
         event.detail.formSubmission.fetchRequest.headers[k] = h[k];
     });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

PR #1375 had a typo, resulting in `Uncaught TypeError: formElement.querySelector is not a function`.
