### PR TITLE
[WebpackEncoreBundle] Bump @symfony/stimulus-bridge to ^4.0.0

### DIFF
--- a/symfony/webpack-encore-bundle/1.10/package.json
+++ b/symfony/webpack-encore-bundle/1.10/package.json
@@ -3,7 +3,7 @@
         "@babel/core": "^7.17.0",
         "@babel/preset-env": "^7.16.0",
         "@hotwired/stimulus": "^3.0.0",
-        "@symfony/stimulus-bridge": "^3.2.0",
+        "@symfony/stimulus-bridge": "^4.0.0",
         "@symfony/webpack-encore": "^4.0.0",
         "core-js": "^3.23.0",
         "regenerator-runtime": "^0.13.9",

--- a/symfony/webpack-encore-bundle/1.9/package.json
+++ b/symfony/webpack-encore-bundle/1.9/package.json
@@ -1,7 +1,7 @@
 {
     "devDependencies": {
         "@hotwired/stimulus": "^3.0.0",
-        "@symfony/stimulus-bridge": "^3.0.0",
+        "@symfony/stimulus-bridge": "^4.0.0",
         "@symfony/webpack-encore": "^1.7.0",
         "core-js": "^3.0.0",
         "regenerator-runtime": "^0.13.2",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | symfony/symfony-docs#...

<!--
Please, carefully read the README before submitting a pull request.
-->

https://github.com/symfony/stimulus-bridge/releases/tag/v4.0.0 has been released today, let's update the recipes containing this package.