### PR TITLE
[symfony/security-bundle] set default algorithm to plaintext

### DIFF
--- a/symfony/security-bundle/6.4/config/packages/security.yaml
+++ b/symfony/security-bundle/6.4/config/packages/security.yaml
@@ -30,10 +30,11 @@ when@test:
         password_hashers:
             # By default, password hashers are resource intensive and take time. This is
             # important to generate secure password hashes. In tests however, secure hashes
-            # are not important, waste resources and increase test times. The following
-            # reduces the work factor to the lowest possible values.
+            # are not important, waste resources and increase test times.
             Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface:
-                algorithm: auto
-                cost: 4 # Lowest possible value for bcrypt
-                time_cost: 3 # Lowest possible value for argon
-                memory_cost: 10 # Lowest possible value for argon
+                algorithm: plaintext # disable hashing all together
+                # You can also use the following configuration to use the lowest possible values for bcrypt and argon:
+                # algorithm: auto
+                # cost: 4 # Lowest possible value for bcrypt
+                # time_cost: 3 # Lowest possible value for argon
+                # memory_cost: 10 # Lowest possible value for argon


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

I think its nice to have default hashing set to `plaintext` and show the option to have lowest configuration the docs also start with mention of `plaintext` see: https://symfony.com/doc/6.4/security/passwords.html#:~:text=algorithm%3A%20plaintext%20%23%20disable%20hashing%20(only%20do%20this%20in%20tests!)