### PR TITLE
[EasyAdmin] Add pretty admin URL routes

### DIFF
--- a/easycorp/easyadmin-bundle/4.14/config/routes/easyadmin.yaml
+++ b/easycorp/easyadmin-bundle/4.14/config/routes/easyadmin.yaml
@@ -1,0 +1,3 @@
+easyadmin:
+    resource: .
+    type: easyadmin.routes

--- a/easycorp/easyadmin-bundle/4.14/manifest.json
+++ b/easycorp/easyadmin-bundle/4.14/manifest.json
@@ -1,6 +1,9 @@
 {
     "bundles": {
         "EasyCorp\\Bundle\\EasyAdminBundle\\EasyAdminBundle": ["all"]
+    },    
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/",
     },
     "aliases": ["admin-gen", "admin-generator", "admin"]
 }

--- a/easycorp/easyadmin-bundle/4.14/manifest.json
+++ b/easycorp/easyadmin-bundle/4.14/manifest.json
@@ -3,7 +3,7 @@
         "EasyCorp\\Bundle\\EasyAdminBundle\\EasyAdminBundle": ["all"]
     },    
     "copy-from-recipe": {
-        "config/": "%CONFIG_DIR%/",
+        "config/": "%CONFIG_DIR%/"
     },
     "aliases": ["admin-gen", "admin-generator", "admin"]
 }

--- a/easycorp/easyadmin-bundle/4.14/manifest.json
+++ b/easycorp/easyadmin-bundle/4.14/manifest.json
@@ -1,0 +1,6 @@
+{
+    "bundles": {
+        "EasyCorp\\Bundle\\EasyAdminBundle\\EasyAdminBundle": ["all"]
+    },
+    "aliases": ["admin-gen", "admin-generator", "admin"]
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

This pull request adds a new route configuration for EasyAdmin in the `easyadmin.yaml` file. The new configuration defines autoload for new pretty URL
The support for pretty admin URLs was introduced in EasyAdmin 4.14.0.

