### PR TITLE
Add `symfonycasts/tailwind-bundle` recipe

### DIFF
--- a/symfonycasts/tailwind-bundle/0.8/config/packages/symfonycasts_tailwind.yaml
+++ b/symfonycasts/tailwind-bundle/0.8/config/packages/symfonycasts_tailwind.yaml
@@ -1,0 +1,6 @@
+symfonycasts_tailwind:
+    # Specify the EXACT version of Tailwind CSS you want to use
+    binary_version: 'v3.4.17'
+
+    # Alternatively, you can specify the path to the binary that you manage yourself
+    #binary: 'node_modules/.bin/tailwindcss'

--- a/symfonycasts/tailwind-bundle/0.8/manifest.json
+++ b/symfonycasts/tailwind-bundle/0.8/manifest.json
@@ -1,0 +1,9 @@
+{
+    "bundles": {
+        "Symfonycasts\\TailwindBundle\\SymfonycastsTailwindBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "aliases": ["tailwind", "tailwindcss"]
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | https://github.com/SymfonyCasts/tailwind-bundle/pull/91

Starting with 0.8, not setting the exact version or path to a binary is deprecated.

Prior to 0.8, the latest tailwind was downloaded if not set explicitly. This was causing v4 to be downloaded on projects that don't support it. The easiest way to fix was to require an exact version be defined to *lock* the version your app uses.
