### PR TITLE
Update "runs-on" to use ubuntu-latest instead of deprecated 20.04

### DIFF
--- a/.github/workflows/callable-flex-cleanup.yml
+++ b/.github/workflows/callable-flex-cleanup.yml
@@ -6,7 +6,7 @@ on:
 jobs:
     flex-cleanup:
         name: Cleanup Flex testing endpoint
-        runs-on: Ubuntu-20.04
+        runs-on: ubuntu-latest
 
         steps:
             -

--- a/.github/workflows/callable-flex-update-archived.yml
+++ b/.github/workflows/callable-flex-update-archived.yml
@@ -11,7 +11,7 @@ on:
 jobs:
     flex-update-archived:
         name: Update Flex Archives
-        runs-on: Ubuntu-20.04
+        runs-on: ubuntu-latest
 
         steps:
             -

--- a/.github/workflows/callable-flex-update.yml
+++ b/.github/workflows/callable-flex-update.yml
@@ -17,7 +17,7 @@ on:
 jobs:
     flex-update:
         name: Update Flex endpoint
-        runs-on: Ubuntu-20.04
+        runs-on: ubuntu-latest
 
         steps:
             -


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Update GitHub runner versions to use `ubuntu-latest`

See https://github.com/symfony/recipes/pull/1382