### PR TITLE
Updating workflows to use Ubuntu-24.04 & avoid EOL

### DIFF
--- a/.github/workflows/callable-flex-cleanup.yml
+++ b/.github/workflows/callable-flex-cleanup.yml
@@ -6,7 +6,7 @@ on:
 jobs:
     flex-cleanup:
         name: Cleanup Flex testing endpoint
-        runs-on: Ubuntu-20.04
+        runs-on: Ubuntu-24.04
 
         steps:
             -

--- a/.github/workflows/callable-flex-update-archived.yml
+++ b/.github/workflows/callable-flex-update-archived.yml
@@ -11,7 +11,7 @@ on:
 jobs:
     flex-update-archived:
         name: Update Flex Archives
-        runs-on: Ubuntu-20.04
+        runs-on: Ubuntu-24.04
 
         steps:
             -

--- a/.github/workflows/callable-flex-update.yml
+++ b/.github/workflows/callable-flex-update.yml
@@ -17,7 +17,7 @@ on:
 jobs:
     flex-update:
         name: Update Flex endpoint
-        runs-on: Ubuntu-20.04
+        runs-on: Ubuntu-24.04
 
         steps:
             -


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | not needed

Ubuntu 20 is deprecated & we've started to get hit with brownouts before it disappears entirely.

I haven't tested this. I think we just need to merge & try it.

Thanks!