### PR TITLE
[Webpack-Encore] Remove "ux" alias

### DIFF
--- a/symfony/webpack-encore-bundle/2.0/manifest.json
+++ b/symfony/webpack-encore-bundle/2.0/manifest.json
@@ -8,7 +8,7 @@
         "package.json": "package.json",
         "webpack.config.js": "webpack.config.js"
     },
-    "aliases": ["ux", "encore", "webpack", "webpack-encore"],
+    "aliases": ["encore", "webpack", "webpack-encore"],
     "gitignore": [
         "/node_modules/",
         "/%PUBLIC_DIR%/build/",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | symfony/symfony-docs#...

Currently if someones types "composer req ux" after a base symfony install ... he ends up with webpack encore.

Worse, the same thing happens if user installed symfony "--webapp", as they will end up with both AssetMapper and Webpack Encore installed.

Finally, and the initial reason I checked this: we will soon need the "ux" alias for the UX Bundle.

cc @Kocal 

PS: not sure if this would require a release to be effective... and hope it does not 😅
