### PR TITLE
[league/oauth2-server-bundle] Add v0.11 recipe

### DIFF
--- a/league/oauth2-server-bundle/0.11/config/packages/league_oauth2_server.yaml
+++ b/league/oauth2-server-bundle/0.11/config/packages/league_oauth2_server.yaml
@@ -1,0 +1,17 @@
+league_oauth2_server:
+    authorization_server:
+        private_key: '%env(resolve:OAUTH_PRIVATE_KEY)%'
+        private_key_passphrase: '%env(resolve:OAUTH_PASSPHRASE)%'
+        encryption_key: '%env(resolve:OAUTH_ENCRYPTION_KEY)%'
+    resource_server:
+        public_key: '%env(resolve:OAUTH_PUBLIC_KEY)%'
+    scopes:
+        available: ['email']
+        default: ['email']
+    persistence:
+        doctrine: null
+
+when@test:
+    league_oauth2_server:
+        persistence:
+            in_memory: null

--- a/league/oauth2-server-bundle/0.11/config/routes/league_oauth2_server.yaml
+++ b/league/oauth2-server-bundle/0.11/config/routes/league_oauth2_server.yaml
@@ -1,0 +1,3 @@
+oauth2_server:
+    resource: '@LeagueOAuth2ServerBundle/config/routes.php'
+    type: php

--- a/league/oauth2-server-bundle/0.11/config/routes/league_oauth2_server.yaml
+++ b/league/oauth2-server-bundle/0.11/config/routes/league_oauth2_server.yaml
@@ -1,3 +1,3 @@
-oauth2_server:
+league_oauth2_server:
     resource: '@LeagueOAuth2ServerBundle/config/routes.php'
     type: php

--- a/league/oauth2-server-bundle/0.11/manifest.json
+++ b/league/oauth2-server-bundle/0.11/manifest.json
@@ -1,0 +1,15 @@
+{
+    "bundles": {
+        "League\\Bundle\\OAuth2ServerBundle\\LeagueOAuth2ServerBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "env": {
+        "OAUTH_PRIVATE_KEY": "%kernel.project_dir%/%CONFIG_DIR%/jwt/private.pem",
+        "OAUTH_PUBLIC_KEY": "%kernel.project_dir%/%CONFIG_DIR%/jwt/public.pem",
+        "OAUTH_PASSPHRASE": "%generate(secret)%",
+        "OAUTH_ENCRYPTION_KEY": "%generate(secret)%"
+    },
+    "aliases": ["oauth2-server", "oauth-server"]
+}

--- a/league/oauth2-server-bundle/0.11/post-install.txt
+++ b/league/oauth2-server-bundle/0.11/post-install.txt
@@ -1,0 +1,8 @@
+  1. <bg=magenta;fg=white> Provide a key pair </>
+    * Generate a private/public key pair by running</> <comment>php bin/console league:oauth2-server:generate-keypair</>
+
+  2. <bg=magenta;fg=white> Update the database schema </>
+    * Update your database schema so that bundle entities can be managed by Doctrine
+
+  3. <bg=magenta;fg=white> Read the docs </>
+    * Read the documentation at <comment>https://github.com/thephpleague/oauth2-server-bundle/blob/master/docs/index.md</>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

- Simplify post-install instructions about the key/pair generation which is now handled by a built-in console command
- Update the routes file path as the bundle upgraded its directory structure to the recommended, modern one.

/cc @ajgarlag