### PR TITLE
Renaming `bootstrap.js` to `stimulus_bootstrap.js`

### DIFF
--- a/symfony/stimulus-bundle/2.20/manifest.json
+++ b/symfony/stimulus-bundle/2.20/manifest.json
@@ -21,7 +21,7 @@
         },
         {
             "file": "assets/app.js",
-            "content": "import './bootstrap.js';",
+            "content": "import './stimulus_bootstrap.js';",
             "position": "top",
             "warn_if_missing": true
         },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | symfony/symfony-docs#...

Second attempt to finally fix https://github.com/symfony/webpack-encore-bundle/issues/150 and https://github.com/symfony/webpack-encore-bundle/issues/160