### PR TITLE
Add PHPUnit 11 recipe, treat PHPUnitBridge only as a PHPUnit extension

### DIFF
--- a/doctrine/deprecations/1.0/manifest.json
+++ b/doctrine/deprecations/1.0/manifest.json
@@ -1,0 +1,11 @@
+{
+    "add-lines": [
+        {
+            "file": "phpunit.dist.xml",
+            "content": "            <method>Doctrine\\Deprecations\\Deprecation::trigger</method>\n            <method>Doctrine\\Deprecations\\Deprecation::delegateTriggerToBackend</method>",
+            "position": "after_target",
+            "target": "<deprecationTrigger>",
+            "warn_if_missing": false
+        }
+    ]
+}

--- a/phpunit/phpunit/11.1/.env.test
+++ b/phpunit/phpunit/11.1/.env.test
@@ -1,0 +1,3 @@
+# define your env variables for the test env here
+KERNEL_CLASS='App\Kernel'
+APP_SECRET='$ecretf0rt3st'

--- a/phpunit/phpunit/11.1/bin/phpunit
+++ b/phpunit/phpunit/11.1/bin/phpunit
@@ -1,0 +1,23 @@
+#!/usr/bin/env php
+<?php
+
+if (!ini_get('date.timezone')) {
+    ini_set('date.timezone', 'UTC');
+}
+
+if (is_file(dirname(__DIR__).'/vendor/phpunit/phpunit/phpunit')) {
+    if (PHP_VERSION_ID >= 80000) {
+        require dirname(__DIR__).'/vendor/phpunit/phpunit/phpunit';
+    } else {
+        define('PHPUNIT_COMPOSER_INSTALL', dirname(__DIR__).'/vendor/autoload.php');
+        require PHPUNIT_COMPOSER_INSTALL;
+        PHPUnit\TextUI\Command::main();
+    }
+} else {
+    if (!is_file(dirname(__DIR__).'/vendor/symfony/phpunit-bridge/bin/simple-phpunit.php')) {
+        echo "Unable to find the `simple-phpunit.php` script in `vendor/symfony/phpunit-bridge/bin/`.\n";
+        exit(1);
+    }
+
+    require dirname(__DIR__).'/vendor/symfony/phpunit-bridge/bin/simple-phpunit.php';
+}

--- a/phpunit/phpunit/11.1/manifest.json
+++ b/phpunit/phpunit/11.1/manifest.json
@@ -1,0 +1,21 @@
+{
+    "add-lines": [
+        {
+            "file": "phpunit.dist.xml",
+            "content": "            <method>Doctrine\\Deprecations\\Deprecation::trigger</method>\n            <method>Doctrine\\Deprecations\\Deprecation::delegateTriggerToBackend</method>",
+            "position": "after_target",
+            "target": "<deprecationTrigger>",
+            "requires": ["doctrine/deprecations"]
+        }
+    ],
+    "copy-from-recipe": {
+        ".env.test": ".env.test",
+        "phpunit.dist.xml": "phpunit.dist.xml",
+        "tests/": "tests/",
+        "bin/": "%BIN_DIR%/"
+    },
+    "gitignore": [
+        "/phpunit.xml",
+        "/.phpunit.cache/"
+    ]
+}

--- a/phpunit/phpunit/11.1/phpunit.dist.xml
+++ b/phpunit/phpunit/11.1/phpunit.dist.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- https://phpunit.readthedocs.io/en/latest/configuration.html -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         colors="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
+         failOnWarning="true"
+         bootstrap="tests/bootstrap.php"
+         cacheDirectory=".phpunit.cache"
+>
+    <php>
+        <ini name="display_errors" value="1" />
+        <ini name="error_reporting" value="-1" />
+        <server name="APP_ENV" value="test" force="true" />
+        <server name="SHELL_VERBOSITY" value="-1" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Project Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <source ignoreSuppressionOfDeprecations="true"
+            ignoreIndirectDeprecations="true"
+            restrictNotices="true"
+            restrictWarnings="true"
+    >
+        <include>
+            <directory>src</directory>
+        </include>
+
+        <deprecationTrigger>
+            <function>trigger_deprecation</function>
+        </deprecationTrigger>
+    </source>
+
+    <extensions>
+    </extensions>
+</phpunit>

--- a/phpunit/phpunit/11.1/post-install.txt
+++ b/phpunit/phpunit/11.1/post-install.txt
@@ -1,0 +1,3 @@
+  * <fg=blue>Write</> test cases in the <comment>tests/</> folder
+  * Use MakerBundle's <comment>make:test</> command as a shortcut!
+  * <fg=blue>Run</> the tests with <comment>php bin/phpunit</>

--- a/phpunit/phpunit/11.1/tests/bootstrap.php
+++ b/phpunit/phpunit/11.1/tests/bootstrap.php
@@ -1,0 +1,13 @@
+<?php
+
+use Symfony\Component\Dotenv\Dotenv;
+
+require dirname(__DIR__).'/vendor/autoload.php';
+
+if (method_exists(Dotenv::class, 'bootEnv')) {
+    (new Dotenv())->bootEnv(dirname(__DIR__).'/.env');
+}
+
+if ($_SERVER['APP_DEBUG']) {
+    umask(0000);
+}

--- a/symfony/phpunit-bridge/7.3/manifest.json
+++ b/symfony/phpunit-bridge/7.3/manifest.json
@@ -1,0 +1,16 @@
+{
+    "add-lines": [
+        {
+            "file": "phpunit.dist.xml",
+            "content": "        <bootstrap class=\"Symfony\\Bridge\\PhpUnit\\SymfonyExtension\">\n            <parameter name=\"clock-mock-namespaces\" value=\"App\" />\n            <parameter name=\"dns-mock-namespaces\" value=\"App\" />\n        </bootstrap>",
+            "position": "after_target",
+            "target": "<extensions>",
+            "warn_if_missing": true
+        }
+    ],
+    "conflict": {
+        "phpunit/phpunit": "<10.0",
+        "symfony/framework-bundle": "<5.4"
+    },
+    "aliases": ["simple-phpunit"]
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | I'll take care of this once we decide the direction for PHPUnit integration

This is a continuation of the effort to move the community towards PHPunit 11's deprecation features, in favor of the Symfony PHPUnit bridge. This is primarily based on what I submitted to the Symfony Demo a while ago: https://github.com/symfony/demo/pull/1549

This PR makes a couple important changes:

* **Add a recipe for PHPUnit 11.1+**. This version has a full replacement for the deprecation reporting capabilities of PhpunitBridge.
* **Change the recipe for PhpunitBridge 7.3 to no longer set-up testing (i.e. configure PHPUnit)**.

  Continueing https://github.com/symfony/recipes/pull/906 from 4 years ago, the only reason you might want to install PhpunitBridge in 7.2 is to use the Clock and DNS mock provided by the new `SymfonyExtension` for PHPUnit (introduced in 7.2).
  Since 6.2, we have a much better solution for ClockMock: the Clock component. DNS mocking is a very niche feature, unlikely to be commonly used in applications.

  On top of this, keeping the PHPUnit configuration in both the bridge and phpunit recipe creates a conflict: One creates a `phpunit.xml.dist` for PHPUnit 9, while the other creates a `phpunit.dist.xml` for PHPUnit 10+. Functionally, this doesn't create an issue as PHPUnit 10+ favors the new file name, but I think we do better to avoid this confusion of double PHPUnit configuration files.

  This recipe change depends on removing PhpunitBridge from the test-pack (https://github.com/symfony/test-pack/pull/24) for Symfony 7.3.


I'm also open to only doing the 2nd change in Symfony 7.4, where I propose to deprecate the PhpunitBridge's deprecation functionality.

cc @alexander-schranz as you've done great work in this effort as well