### PR TITLE
Make PHPUnit 10 config more consistent with PHPUnitBridge behavior

### DIFF
--- a/phpunit/phpunit/10.0/phpunit.dist.xml
+++ b/phpunit/phpunit/10.0/phpunit.dist.xml
@@ -5,6 +5,8 @@
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          backupGlobals="false"
          colors="true"
+         failOnNotice="true"
+         failOnWarning="true"
          bootstrap="tests/bootstrap.php"
          cacheDirectory=".phpunit.cache"
 >
@@ -13,8 +15,6 @@
         <ini name="error_reporting" value="-1" />
         <server name="APP_ENV" value="test" force="true" />
         <server name="SHELL_VERBOSITY" value="-1" />
-        <server name="SYMFONY_PHPUNIT_REMOVE" value="" />
-        <server name="SYMFONY_PHPUNIT_VERSION" value="10.5" />
     </php>
 
     <testsuites>
@@ -23,7 +23,7 @@
         </testsuite>
     </testsuites>
 
-    <source restrictDeprecations="true" restrictNotices="true" restrictWarnings="true">
+    <source ignoreSuppressionOfDeprecations="true" restrictNotices="true" restrictWarnings="true">
         <include>
             <directory>src</directory>
         </include>

--- a/phpunit/phpunit/10.0/tests/bootstrap.php
+++ b/phpunit/phpunit/10.0/tests/bootstrap.php
@@ -7,3 +7,7 @@ require dirname(__DIR__).'/vendor/autoload.php';
 if (method_exists(Dotenv::class, 'bootEnv')) {
     (new Dotenv())->bootEnv(dirname(__DIR__).'/.env');
 }
+
+if ($_SERVER['APP_DEBUG']) {
+    umask(0000);
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | symfony/symfony-docs#...

* The `failOnNotice`/`failOnWarning` options are part of PHPUnit's own recommended configuration file, I think it's worth adding these to our recommendation as well
* `restrictDeprecations="true"` only reports deprecations *triggered* by application code (which is not related to "direct" deprecations). We should not recommend it. PHPUnit 11 comes with the correct alternative (see https://github.com/symfony/recipes/pull/1401)
* `ignoreSuppressionOfDeprecations="true"` is a must-have for Symfony deprecations, given we silence all deprecation triggers.
* https://github.com/symfony/recipes/pull/889 was only applied to the PHPUnitBridge, I think we should add it to the PHPUnit recipe as well

I know we normally don't edit existing recipe versions, but I think especially (2) and (3) are worth considering a bug. Besides this, the PHPUnit 10 recipe is relatively new (https://github.com/symfony/recipes/pull/1239)