### PR TITLE
[league/oauth2-server-bundle] Gitignore signature keypair

### DIFF
--- a/league/oauth2-server-bundle/0.11/manifest.json
+++ b/league/oauth2-server-bundle/0.11/manifest.json
@@ -11,5 +11,8 @@
         "OAUTH_PASSPHRASE": "%generate(secret)%",
         "OAUTH_ENCRYPTION_KEY": "%generate(secret)%"
     },
+    "gitignore": [
+        "/%CONFIG_DIR%/jwt/*.pem"
+    ],
     "aliases": ["oauth2-server", "oauth-server"]
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

I accidentally removed them from the manifest when adding the v0.11 recipe. 