### PR TITLE
[zenstruck/foundry] introduce flush_once config

### DIFF
--- a/zenstruck/foundry/2.5/config/packages/zenstruck_foundry.yaml
+++ b/zenstruck/foundry/2.5/config/packages/zenstruck_foundry.yaml
@@ -1,0 +1,8 @@
+when@dev: &dev
+    # See full configuration: https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#full-default-bundle-configuration
+    zenstruck_foundry:
+        persistence:
+            # Flush only once per call of `PersistentObjectFactory::create()` in userland
+            flush_once: true
+
+when@test: *dev

--- a/zenstruck/foundry/2.5/manifest.json
+++ b/zenstruck/foundry/2.5/manifest.json
@@ -1,0 +1,13 @@
+{
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "bundles": {
+        "Zenstruck\\Foundry\\ZenstruckFoundryBundle": ["dev", "test"]
+    },
+    "conflict": {
+        "doctrine/persistence": "<2.0",
+        "symfony/framework-bundle": "<6.4"
+    },
+    "aliases": ["foundry"]
+}

--- a/zenstruck/foundry/2.5/post-install.txt
+++ b/zenstruck/foundry/2.5/post-install.txt
@@ -1,0 +1,4 @@
+  * You're ready to use zenstruck/foundry. Create your first factory with
+    <info>bin/console make:factory</>.
+
+  * <fg=blue>Read</> the documentation at <comment>https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html</>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

update of Foundry's recipe for the new "flush_once" configuration which will land in `zenstruck/foundry` 2.5

/cc @kbond 

EDIT: CI is failing because it tries to update with `2.x-dev`, but it should use `2.5.x-dev`
