### PR TITLE
[symfony/framework-bundle] keep `.editorconfig` only in 7.3

### DIFF
--- a/symfony/framework-bundle/6.4/.editorconfig
+++ b/symfony/framework-bundle/6.4/.editorconfig
@@ -1,9 +1,0 @@
-root = true
-
-[*]
-charset = utf-8
-end_of_line = lf
-indent_size = 4
-indent_style = space
-insert_final_newline = true
-trim_trailing_whitespace = true

--- a/symfony/framework-bundle/6.4/manifest.json
+++ b/symfony/framework-bundle/6.4/manifest.json
@@ -5,8 +5,7 @@
     "copy-from-recipe": {
         "config/": "%CONFIG_DIR%/",
         "public/": "%PUBLIC_DIR%/",
-        "src/": "%SRC_DIR%/",
-        ".editorconfig": ".editorconfig"
+        "src/": "%SRC_DIR%/"
     },
     "composer-scripts": {
         "cache:clear": "symfony-cmd",

--- a/symfony/framework-bundle/7.2/.editorconfig
+++ b/symfony/framework-bundle/7.2/.editorconfig
@@ -1,9 +1,0 @@
-root = true
-
-[*]
-charset = utf-8
-end_of_line = lf
-indent_size = 4
-indent_style = space
-insert_final_newline = true
-trim_trailing_whitespace = true

--- a/symfony/framework-bundle/7.2/manifest.json
+++ b/symfony/framework-bundle/7.2/manifest.json
@@ -5,8 +5,7 @@
     "copy-from-recipe": {
         "config/": "%CONFIG_DIR%/",
         "public/": "%PUBLIC_DIR%/",
-        "src/": "%SRC_DIR%/",
-        ".editorconfig": ".editorconfig"
+        "src/": "%SRC_DIR%/"
     },
     "composer-scripts": {
         "cache:clear": "symfony-cmd",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | n/a

Fixes https://github.com/symfony/recipes/pull/1413#issuecomment-2886991608
