### PR TITLE
Add env variable for `router.default_uri` configuration option

### DIFF
--- a/symfony/routing/7.0/config/packages/routing.yaml
+++ b/symfony/routing/7.0/config/packages/routing.yaml
@@ -2,7 +2,7 @@ framework:
     router:
         # Configure how to generate URLs in non-HTTP contexts, such as CLI commands.
         # See https://symfony.com/doc/current/routing.html#generating-urls-in-commands
-        #default_uri: http://localhost
+        default_uri: '%env(DEFAULT_URI)%'
 
 when@prod:
     framework:

--- a/symfony/routing/7.0/manifest.json
+++ b/symfony/routing/7.0/manifest.json
@@ -5,5 +5,10 @@
     "aliases": ["router"],
     "conflict": {
         "symfony/framework-bundle": "<7.0"
+    },
+    "env": {
+        "#1": "Configure how to generate URLs in non-HTTP contexts, such as CLI commands.",
+        "#2": "See https://symfony.com/doc/current/routing.html#generating-urls-in-commands",
+        "DEFAULT_URI": "http://localhost"
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | symfony/symfony-docs#...

Like database connection, domains are mostly managed OPS team and not by developers. To skip that the developer team need to keep in mind to add a env variable for the default_uri it would be nice if its out of the box a env variable exists – which can always be set by the ops team without have a developer to change the symfony app before.
