### PR TITLE
Add a remark to submit-eventListener

### DIFF
--- a/symfony/stimulus-bundle/2.20/assets/controllers/csrf_protection_controller.js
+++ b/symfony/stimulus-bundle/2.20/assets/controllers/csrf_protection_controller.js
@@ -2,6 +2,8 @@ const nameCheck = /^[-_a-zA-Z0-9]{4,22}$/;
 const tokenCheck = /^[-_\/+a-zA-Z0-9]{24,}$/;
 
 // Generate and double-submit a CSRF token in a form field and a cookie, as defined by Symfony's SameOriginCsrfTokenManager
+// Use `form.requestSubmit()` to ensure that the submit event is triggered. Using `form.submit()` will not trigger the event
+// and thus this event-listener will not be executed.
 document.addEventListener('submit', function (event) {
     generateCsrfToken(event.target);
 }, true);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | symfony/symfony-docs#...

This PR will add a remark to the submit-eventListener to help with the correct usage.
When the form is checked with the isValid()-function, it returned FALSE when using javascript with `form.submit()` instead of using `form.requestSubmit()`.

Error-Message:
```txt
CSRF validation failed: double-submit info was used in a previous request but is now missing.
```

Related to: https://github.com/symfony/recipes/issues/1370

