### PR TITLE
[symfony/translation] remove `fallbacks` config

### DIFF
--- a/symfony/translation/6.3/config/packages/translation.yaml
+++ b/symfony/translation/6.3/config/packages/translation.yaml
@@ -2,6 +2,4 @@ framework:
     default_locale: en
     translator:
         default_path: '%kernel.project_dir%/translations'
-        fallbacks:
-            - en
         providers:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | n/a

I was a confused why this `fallbacks` is needed - turns out it isn't, and uses the `default_locale` if not set. I suggest removing and letting the `default_locale` be used - this feels like the 90%+ case.

Having multiple fallbacks feels like a pretty advanced case.
