### PR TITLE
Symfony phpunit-bridge 7.3 recipe - Update manifest.json

### DIFF
--- a/symfony/phpunit-bridge/7.3/manifest.json
+++ b/symfony/phpunit-bridge/7.3/manifest.json
@@ -8,7 +8,7 @@
             "warn_if_missing": true
         }
     ],
-     "gitignore": [
+    "gitignore": [
         ".phpunit.result.cache",
         "/phpunit.xml"
     ],

--- a/symfony/phpunit-bridge/7.3/manifest.json
+++ b/symfony/phpunit-bridge/7.3/manifest.json
@@ -8,6 +8,10 @@
             "warn_if_missing": true
         }
     ],
+     "gitignore": [
+        ".phpunit.result.cache",
+        "/phpunit.xml"
+    ],
     "conflict": {
         "phpunit/phpunit": "<10.0",
         "symfony/framework-bundle": "<5.4"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | symfony/symfony-docs#...

Hey, I think we need to add the `.gitignore` configuration here like for the old version here: [6.3](https://github.com/symfony/recipes/blob/main/symfony/phpunit-bridge/6.3/manifest.json)

When I want to update the recipe currently, this missing configuration delete the `.gitignore` file.
