### PR TITLE
[symfony/phpunit-bridge] Disable deprecations helper on 7.3

### DIFF
--- a/symfony/phpunit-bridge/7.3/manifest.json
+++ b/symfony/phpunit-bridge/7.3/manifest.json
@@ -2,6 +2,13 @@
     "add-lines": [
         {
             "file": "phpunit.dist.xml",
+            "content": "        <server name=\"SYMFONY_DEPRECATIONS_HELPER\" value=\"disabled\" />",
+            "position": "after_target",
+            "target": "<php>",
+            "warn_if_missing": true
+        },
+        {
+            "file": "phpunit.dist.xml",
             "content": "        <bootstrap class=\"Symfony\\Bridge\\PhpUnit\\SymfonyExtension\">\n            <parameter name=\"clock-mock-namespaces\" value=\"App\" />\n            <parameter name=\"dns-mock-namespaces\" value=\"App\" />\n        </bootstrap>",
             "position": "after_target",
             "target": "<extensions>",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

As mentioned in #1401, the plan is to replace the deprecation reporting capabilities of PhpunitBridge with PHPUnit 11's built-in deprecation feature. Because the `DeprecationErrorHandler` is registered in a [file required by the bridge's `composer.json`](https://github.com/symfony/symfony/blob/158dff8106151b943fad16f85bcf8b70b7bb1178/src/Symfony/Bridge/PhpUnit/composer.json#L32), it is automatically enabled as soon as the package is required.
This PR proposes disabling the helper for Symfony >= 7.3.

@wouterj Any thoughts on this?