### PR TITLE
Adjust editorconfig for docker compose and markdown files

### DIFF
--- a/symfony/framework-bundle/7.3/.editorconfig
+++ b/symfony/framework-bundle/7.3/.editorconfig
@@ -1,3 +1,5 @@
+# editorconfig.org
+
 root = true
 
 [*]

--- a/symfony/framework-bundle/7.3/.editorconfig
+++ b/symfony/framework-bundle/7.3/.editorconfig
@@ -7,3 +7,9 @@ indent_size = 4
 indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[{compose.yaml,compose.*.yaml}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | symfony/symfony-docs#...

Symfony follows docker compose suggestions with 2 indents on docker compose files and so requires an own sections to set it. For markdown the trim_trailing_whitespace need be disabled as two spaces in markdown at end of line means a line break. Added also a link to editorconfig.org so people not familiar with find it easy.

/cc @kbond 