### PR TITLE
Symfony/framework bundle/merge dummy kernel

### DIFF
--- a/symfony/console/7.4/bin/console
+++ b/symfony/console/7.4/bin/console
@@ -1,8 +1,9 @@
 #!/usr/bin/env php
 <?php
 
-use App\Kernel;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Component\HttpKernel\Kernel;
 
 if (!is_dir(dirname(__DIR__).'/vendor')) {
     throw new LogicException('Dependencies are missing. Try running "composer install".');
@@ -15,7 +16,9 @@ if (!is_file(dirname(__DIR__).'/vendor/autoload_runtime.php')) {
 require_once dirname(__DIR__).'/vendor/autoload_runtime.php';
 
 return function (array $context) {
-    $kernel = new Kernel($context['APP_ENV'], (bool) $context['APP_DEBUG']);
+    $kernel = new class($context['APP_ENV'], (bool) $context['APP_DEBUG']) extends Kernel {
+        use MicroKernelTrait;
+    };
 
     return new Application($kernel);
 };

--- a/symfony/console/7.4/bin/console
+++ b/symfony/console/7.4/bin/console
@@ -1,0 +1,21 @@
+#!/usr/bin/env php
+<?php
+
+use App\Kernel;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+
+if (!is_dir(dirname(__DIR__).'/vendor')) {
+    throw new LogicException('Dependencies are missing. Try running "composer install".');
+}
+
+if (!is_file(dirname(__DIR__).'/vendor/autoload_runtime.php')) {
+    throw new LogicException('Symfony Runtime is missing. Try running "composer require symfony/runtime".');
+}
+
+require_once dirname(__DIR__).'/vendor/autoload_runtime.php';
+
+return function (array $context) {
+    $kernel = new Kernel($context['APP_ENV'], (bool) $context['APP_DEBUG']);
+
+    return new Application($kernel);
+};

--- a/symfony/console/7.4/manifest.json
+++ b/symfony/console/7.4/manifest.json
@@ -1,0 +1,6 @@
+{
+    "copy-from-recipe": {
+        "bin/": "%BIN_DIR%/"
+    },
+    "aliases": ["cli"]
+}

--- a/symfony/framework-bundle/7.4/.editorconfig
+++ b/symfony/framework-bundle/7.4/.editorconfig
@@ -1,0 +1,17 @@
+# editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[{compose.yaml,compose.*.yaml}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/symfony/framework-bundle/7.4/config/packages/cache.yaml
+++ b/symfony/framework-bundle/7.4/config/packages/cache.yaml
@@ -1,0 +1,19 @@
+framework:
+    cache:
+        # Unique name of your app: used to compute stable namespaces for cache keys.
+        #prefix_seed: your_vendor_name/app_name
+
+        # The "app" cache stores to the filesystem by default.
+        # The data in this cache should persist between deploys.
+        # Other options include:
+
+        # Redis
+        #app: cache.adapter.redis
+        #default_redis_provider: redis://localhost
+
+        # APCu (not recommended with heavy random-write workloads as memory fragmentation can cause perf issues)
+        #app: cache.adapter.apcu
+
+        # Namespaced pools use the above "app" backend by default
+        #pools:
+            #my.dedicated.cache: null

--- a/symfony/framework-bundle/7.4/config/packages/framework.yaml
+++ b/symfony/framework-bundle/7.4/config/packages/framework.yaml
@@ -1,0 +1,15 @@
+# see https://symfony.com/doc/current/reference/configuration/framework.html
+framework:
+    secret: '%env(APP_SECRET)%'
+
+    # Note that the session will be started ONLY if you read or write from it.
+    session: true
+
+    #esi: true
+    #fragments: true
+
+when@test:
+    framework:
+        test: true
+        session:
+            storage_factory_id: session.storage.factory.mock_file

--- a/symfony/framework-bundle/7.4/config/preload.php
+++ b/symfony/framework-bundle/7.4/config/preload.php
@@ -1,0 +1,5 @@
+<?php
+
+if (file_exists(dirname(__DIR__).'/var/cache/prod/App_KernelProdContainer.preload.php')) {
+    require dirname(__DIR__).'/var/cache/prod/App_KernelProdContainer.preload.php';
+}

--- a/symfony/framework-bundle/7.4/config/routes/framework.yaml
+++ b/symfony/framework-bundle/7.4/config/routes/framework.yaml
@@ -1,0 +1,4 @@
+when@dev:
+    _errors:
+        resource: '@FrameworkBundle/Resources/config/routing/errors.php'
+        prefix: /_error

--- a/symfony/framework-bundle/7.4/config/services.yaml
+++ b/symfony/framework-bundle/7.4/config/services.yaml
@@ -1,0 +1,20 @@
+# This file is the entry point to configure your own services.
+# Files in the packages/ subdirectory configure your dependencies.
+
+# Put parameters here that don't need to change on each machine where the app is deployed
+# https://symfony.com/doc/current/best_practices.html#use-parameters-for-application-configuration
+parameters:
+
+services:
+    # default configuration for services in *this* file
+    _defaults:
+        autowire: true      # Automatically injects dependencies in your services.
+        autoconfigure: true # Automatically registers your services as commands, event subscribers, etc.
+
+    # makes classes in src/ available to be used as services
+    # this creates a service per class whose id is the fully-qualified class name
+    App\:
+        resource: '../src/'
+
+    # add more service definitions when explicit configuration is needed
+    # please note that last definitions always *replace* previous ones

--- a/symfony/framework-bundle/7.4/manifest.json
+++ b/symfony/framework-bundle/7.4/manifest.json
@@ -1,0 +1,33 @@
+{
+    "bundles": {
+        "Symfony\\Bundle\\FrameworkBundle\\FrameworkBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/",
+        "public/": "%PUBLIC_DIR%/",
+        "src/": "%SRC_DIR%/",
+        ".editorconfig": ".editorconfig"
+    },
+    "composer-scripts": {
+        "cache:clear": "symfony-cmd",
+        "assets:install %PUBLIC_DIR%": "symfony-cmd"
+    },
+    "env": {
+        "APP_ENV": "dev",
+        "APP_SECRET": ""
+    },
+    "dotenv": {
+        "dev": {
+            "APP_SECRET": "%generate(secret)%"
+        }
+    },
+    "gitignore": [
+        "/.env.local",
+        "/.env.local.php",
+        "/.env.*.local",
+        "/%CONFIG_DIR%/secrets/prod/prod.decrypt.private.php",
+        "/%PUBLIC_DIR%/bundles/",
+        "/%VAR_DIR%/",
+        "/vendor/"
+    ]
+}

--- a/symfony/framework-bundle/7.4/post-install.txt
+++ b/symfony/framework-bundle/7.4/post-install.txt
@@ -1,0 +1,6 @@
+  * <fg=blue>Run</> your application:
+    1. Go to the project directory
+    2. Create your code repository with the <comment>git init</comment> command
+    3. Download the Symfony CLI at <comment>https://symfony.com/download</> to install a development web server
+
+  * <fg=blue>Read</> the documentation at <comment>https://symfony.com/doc</>

--- a/symfony/framework-bundle/7.4/public/index.php
+++ b/symfony/framework-bundle/7.4/public/index.php
@@ -1,0 +1,9 @@
+<?php
+
+use App\Kernel;
+
+require_once dirname(__DIR__).'/vendor/autoload_runtime.php';
+
+return function (array $context) {
+    return new Kernel($context['APP_ENV'], (bool) $context['APP_DEBUG']);
+};

--- a/symfony/framework-bundle/7.4/public/index.php
+++ b/symfony/framework-bundle/7.4/public/index.php
@@ -1,9 +1,12 @@
 <?php
 
-use App\Kernel;
+use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Component\HttpKernel\Kernel;
 
 require_once dirname(__DIR__).'/vendor/autoload_runtime.php';
 
 return function (array $context) {
-    return new Kernel($context['APP_ENV'], (bool) $context['APP_DEBUG']);
+    return new class($context['APP_ENV'], (bool) $context['APP_DEBUG']) extends Kernel {
+        use MicroKernelTrait;
+    };
 };


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | symfony/symfony-docs#...

Hello,
During SymfonyCon's Keynote, Fabien showed the Symfony Solo initiative, as the final form of the DX refinement. It makes me wonder if it was possible to merge our tiny Kernel.php with our tiny index.php file; It sounds like a bad idea, but given how dummy-ish their code is, It may be a win.

So please find here 2 commits:
- 1 to create the 7.4 folder in framework bundle dir,
- The other one that delete the src/Kernel.php file, and integrate its logic in public/index.php.

So it works on my projects (no idea of all the side effects), and the question still: why?
1. Uncouple the framework with the src/ folder (if you want to rename it whatever/ or create 3 bases it's easier)
2. Somehow it improves the SRP, as now the public.php script really "boot up" Symfony, knowing that mid-term Kernel class was just a bump to achieve it. As it's now a anonymous class, it doesn't break the "1 class per file" rule neither.
3. Less files, more elegant code; You see only 1 less file? I see a 50% reduction of the number of files in src!
4. Hypothetical but I suppose not having this Kernel.php class around the personal codebase will diminish the bad practice to call it wrongly (unintendedly, or worse.. Intendedly)
5. Improve DX by removing this weird sensation as a beginner "is src/ MY folder to code? But why is there a file that is not mine? And with a very intimidating name??". Don't laugh, I had it for few times.

Sorry if it's a bad idea or if there is a lot of side effects!