### PR TITLE
remove "useless" escape

### DIFF
--- a/symfony/stimulus-bundle/2.20/assets/controllers/csrf_protection_controller.js
+++ b/symfony/stimulus-bundle/2.20/assets/controllers/csrf_protection_controller.js
@@ -1,5 +1,5 @@
 const nameCheck = /^[-_a-zA-Z0-9]{4,22}$/;
-const tokenCheck = /^[-_\/+a-zA-Z0-9]{24,}$/;
+const tokenCheck = /^[-_/+a-zA-Z0-9]{24,}$/;
 
 // Generate and double-submit a CSRF token in a form field and a cookie, as defined by Symfony's SameOriginCsrfTokenManager
 document.addEventListener('submit', function (event) {


### PR DESCRIPTION
closes https://github.com/symfony/symfony/issues/60983

| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | symfony/symfony-docs#...

<!--
Please, carefully read the README before submitting a pull request.
-->
