### PR TITLE
[Panther] Configure env `PANTHER_DEVTOOLS=0`

### DIFF
--- a/symfony/panther/1.0/manifest.json
+++ b/symfony/panther/1.0/manifest.json
@@ -21,7 +21,8 @@
     "dotenv": {
         "test": {
             "PANTHER_APP_ENV": "panther",
-            "PANTHER_ERROR_SCREENSHOT_DIR": "./var/error-screenshots"
+            "PANTHER_ERROR_SCREENSHOT_DIR": "./var/error-screenshots",
+            "PANTHER_DEVTOOLS": "0"
         }
     },
     "add-lines": [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | symfony/symfony-docs#...

<!--
Please, carefully read the README before submitting a pull request.
-->

Following https://github.com/symfony/panther/issues/675 and https://github.com/symfony/ux/pull/2873, passing `PANTHER_DEVTOOLS=0` ([it is enabled by default](https://symfony.com/doc/current/testing/end_to_end.html#configuring-panther-through-environment-variables)) fixes issues when using Chrome 137+.

I agree this is not the best fix, surely something must be fixed upstream, but for the moment, disabling devtools allows Panther to be usable again in some situations.
