### PR TITLE
[Turbo] Fix `check_header` configuration

### DIFF
--- a/symfony/ux-turbo/2.20/manifest.json
+++ b/symfony/ux-turbo/2.20/manifest.json
@@ -9,10 +9,10 @@
     },
     "add-lines": [
         {
-            "file": "config/packages/framework.yaml",
+            "file": "config/packages/csrf.yaml",
             "position": "after_target",
-            "target": "        csrf_protection:",
-            "content": "            check_header: true"
+            "target": "    csrf_protection:",
+            "content": "        check_header: true"
         }
     ]
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | symfony/symfony-docs#...

<!--
Please, carefully read the README before submitting a pull request.
-->

Since https://github.com/symfony/recipes/commit/b06f1ce2f7c3f7d5cb18fcce68c08a02cc1b271c, the (stateless) CSRF configuration now lives in `config/packages/csrf.yaml` file:
```yaml
# Enable stateless CSRF protection for forms and logins/logouts
framework:
    form:
        csrf_protection:
            token_id: submit

    csrf_protection:
        stateless_token_ids:
            - submit
            - authenticate
            - logout
```

Some spaces from `target` and `content` were removed since we want to add `check_header: true` for [`framework.csrf_protection` configuration ](https://symfony.com/doc/current/reference/configuration/framework.html#check-header), which is one-level under `framework.form.csrf_protection`