### PR TITLE
[Turbo] Correctly fix `framework.csrf_protection.check_header` configuration

### DIFF
--- a/symfony/ux-turbo/2.20/config/packages/ux_turbo.yaml
+++ b/symfony/ux-turbo/2.20/config/packages/ux_turbo.yaml
@@ -1,0 +1,4 @@
+# Enable stateless CSRF protection for forms and logins/logouts
+framework:
+    csrf_protection:
+        check_header: true

--- a/symfony/ux-turbo/2.20/manifest.json
+++ b/symfony/ux-turbo/2.20/manifest.json
@@ -2,17 +2,12 @@
     "bundles": {
         "Symfony\\UX\\Turbo\\TurboBundle": ["all"]
     },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
     "aliases": ["turbo"],
     "conflict": {
         "symfony/framework-bundle": "<7.2",
         "symfony/security-csrf": "<7.2"
-    },
-    "add-lines": [
-        {
-            "file": "config/packages/csrf.yaml",
-            "position": "after_target",
-            "target": "    csrf_protection:",
-            "content": "        check_header: true"
-        }
-    ]
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | symfony/symfony-docs#...

<!--
Please, carefully read the README before submitting a pull request.
-->

Following https://github.com/symfony/recipes/pull/1439#issuecomment-3122053728 

<details>
<summary>Old alternative with `position: 'bottom'`</summary>

The solution is fragile and kind of ugly (note the extra line before `check_header: true`, as it generates the following file:
```yaml
# Enable stateless CSRF protection for forms and logins/logouts
framework:
    form:
        csrf_protection:
            token_id: submit

    csrf_protection:
        stateless_token_ids:
            - submit
            - authenticate
            - logout

        check_header: true
```

But it works: 
```
➜  app-flex-1440 git:(main) ✗ sfc debug:config framework csrf_protection

Current configuration for "framework.csrf_protection"
=====================================================

stateless_token_ids:
    - submit
    - authenticate
    - logout
check_header: true
enabled: null
cookie_name: csrf-token
```

There are other alternatives, like:
1. introducing position `before_target` for `add-lines` modifier but it requires to update Flex code and people to upgrade Flex
2. or drop UX Turbo recipe and add `# check_header: true` (with a comment) to the `csrf.yaml` from Form recipe

</details>


Applied @xabbuh 's suggestion from https://github.com/symfony/recipes/pull/1440#issuecomment-3123382896