### PR TITLE
Add recipe for yaovicoder/intl-region 1.0

### DIFF
--- a/yaovicoder/intl-region/1.0/manifest.json
+++ b/yaovicoder/intl-region/1.0/manifest.json
@@ -1,0 +1,5 @@
+{
+    "bundles": {
+        "Ydee\\IntlRegion\\Bundle\\IntlRegionBundle": ["all"]
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | N/A

Add recipe for `yaovicoder/intl-region` 1.0

This package provides UN M49 region-based country filtering (continents and subregions) with Symfony integration. It includes:
- A console command: `intl-region:list`
- A service: `Ydee\IntlRegion\RegionProvider`
- Full Symfony 6.4+ and 7+ support

The recipe ensures the bundle is auto-registered in `config/bundles.php`.

GitHub: https://github.com/yaovicoder/intl-region  
Packagist: https://packagist.org/packages/yaovicoder/intl-region

