### PR TITLE
Add doc about `debug:router`

### DIFF
--- a/symfony/routing/7.4/config/routes.yaml
+++ b/symfony/routing/7.4/config/routes.yaml
@@ -1,5 +1,8 @@
 # $schema: ../vendor/symfony/routing/Loader/schema/routing.schema.json
 
+# To see all the routes, use the debug command
+#   bin/console debug:router
+
 controllers:
     resource: attributes
     type: tagged_services

--- a/symfony/routing/7.4/config/routes.yaml
+++ b/symfony/routing/7.4/config/routes.yaml
@@ -1,6 +1,6 @@
 # $schema: ../vendor/symfony/routing/Loader/schema/routing.schema.json
 
-# To see all the routes, use the debug command
+# To list all registered routes, run the following command:
 #   bin/console debug:router
 
 controllers:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

One concern I have heard frequently regarding the use of attributes for routes is that it would be challenging to know the list of all routes in an application (unlike a dedicated routing file).
By adding these two lines of documentation, we are guiding developers toward the solution.