### PR TITLE
Add explicit value for csrf_protection.enable when adding stateless_token_ids

### DIFF
--- a/symfony/form/7.2/config/packages/csrf.yaml
+++ b/symfony/form/7.2/config/packages/csrf.yaml
@@ -5,6 +5,7 @@ framework:
             token_id: submit
 
     csrf_protection:
+        enabled: true
         stateless_token_ids:
             - submit
             - authenticate


### PR DESCRIPTION
Hello,

I had the recipe adding stateless_token_ids. I thought that csrf_protection will be enabled by default. But debug:config showed me that csrf_protection.enabled is null by default.

The current documentation does not explicitly mention that one should add `enable: true` when using the stateless_token_ids: https://symfony.com/doc/current/security/csrf.html#stateless-csrf-tokens

So I thought to add 'enable: true' by default, to be coherent with the comment of the recipe: `# Enable stateless CSRF protection for forms and logins/logouts`.

I hope this is correct.