### PR TITLE
[symfony/monolog-bundle] Don't log deprecations twice in prod

### DIFF
--- a/symfony/monolog-bundle/3.7/config/packages/monolog.yaml
+++ b/symfony/monolog-bundle/3.7/config/packages/monolog.yaml
@@ -45,6 +45,7 @@ when@prod:
                 action_level: error
                 handler: nested
                 excluded_http_codes: [404, 405]
+                channels: ["!deprecation"]
                 buffer_size: 50 # How many messages should be saved? Prevent memory leaks
             nested:
                 type: stream


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | N/A

<!--
Please, carefully read the README before submitting a pull request.
-->

In a fresh Symfony app using monolog-bundle default configuration, if a deprecation occurs in the same request as an uncaught exception in `prod` environment, that deprecation is logged twice. This is why:

1. A request comes in and causes a deprecation to be logged at `info` level on the `deprecation` channel
2. The `main` (`fingers_crossed`) is not activated so the deprecation is buffered (not logged)
3. The remaining handlers are evaluated, the `deprecation` handler listening to the `deprecation` channel matches and the deprecation is logged immediately (**this is the first time the deprecation is logged**)
4. On that same request there is an uncaught exception
6. This causes a `critical` level log on the `request` channel which is higher than `main` handler's `action_level: error`. No `channels` are explicitly defined on `main` handler therefore `main` handler activates
8. When `main` activates all buffered messages are logged immediately, including the deprecation from step 2 (**this is the second time the deprecation is logged**)

Adding `channels: [!deprecation]` to the `main` handler stops any `deprecation` channel logs from ever being logged by the `main`/`nested` handlers, fully relying on the `deprecation` handler to log deprecations - meaning they only appear a maximum of once.