### PR TITLE
[symfony/monolog-bundle]: Adding `php bin/console debug:container monolog`

### DIFF
--- a/symfony/monolog-bundle/3.7/config/packages/monolog.yaml
+++ b/symfony/monolog-bundle/3.7/config/packages/monolog.yaml
@@ -1,5 +1,5 @@
 monolog:
-    channels:
+    channels: # To show all channels built-in by Symfony, run: php bin/console debug:container monolog
         - deprecation # Deprecations are logged in the dedicated "deprecation" channel when it exists
 
 when@dev:

--- a/symfony/monolog-bundle/3.7/config/packages/monolog.yaml
+++ b/symfony/monolog-bundle/3.7/config/packages/monolog.yaml
@@ -1,5 +1,5 @@
 monolog:
-    channels: # To show all channels built-in by Symfony, run: php bin/console debug:container monolog
+    channels: # To see all channels, run bin/console debug:autowiring logger
         - deprecation # Deprecations are logged in the dedicated "deprecation" channel when it exists
 
 when@dev:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | none

Reason: Make it more obvious that the `channels` key here does not contain the full list of all channels.