### PR TITLE
Fix exit code handling for Symfony 6 compatibility message

### DIFF
--- a/.github/workflows/callable-qa.yml
+++ b/.github/workflows/callable-qa.yml
@@ -259,11 +259,17 @@ jobs:
                     composer config extra.symfony.allow-contrib ${{ inputs.contrib && 'true' || 'false' }}
                     composer config minimum-stability dev
                     export SYMFONY_ENDPOINT=https://raw.githubusercontent.com/${{ github.repository }}/flex/pull-${{ github.event.number }}/index.json
-                    composer require -W --ansi $PACKAGES
-                    EXIT_CODE=$?
+                    EXIT_CODE=0
+                    composer require -W --ansi $PACKAGES || EXIT_CODE=$?
 
-                    if [[ EXIT_CODE -eq 2 ]]; then
-                        echo -e "\n#\n#\n# You can ignore this error if your package does not support Symfony 6\n#\n#\n#\n"
+                    if [[ $EXIT_CODE -eq 2 ]]; then
+                        set +x
+                        printf '\n\n' >&2
+                        printf '\033[32m########################################################################\033[0m\n' >&2
+                        printf '\033[32m# You can ignore this error if your package does not support Symfony 6 #\033[0m\n' >&2
+                        printf '\033[32m########################################################################\033[0m\n' >&2
+                        printf '\n\n' >&2
+                        set -x
                     fi
 
                     exit $EXIT_CODE


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | n/a

<!--
Please, carefully read the README before submitting a pull request.
-->

## Title: Fix exit code handling in create-project job

### Summary
This PR fixes the exit code handling in the "Create-project with skeleton ^6" step so that the informational message is correctly displayed when a package doesn't support Symfony 6.

#### Related issues:
- https://github.com/symfony/recipes-contrib/issues/1172#issuecomment-891233725
- https://github.com/symfony/recipes-contrib/issues/1423

#### Issues Fixed
Missing `$` prefix: The condition `[[ EXIT_CODE -eq 2 ]]` was missing the `$` before `EXIT_CODE`, causing the check to always fail

Script exits before capturing exit code: GitHub Actions runs bash with -e flag, so when composer require fails, the script exits immediately before `EXIT_CODE=$?` can capture the exit code. Fixed by using `EXIT_CODE=0` followed by `composer require ... || EXIT_CODE=$?`

Improved message formatting: Added a green-colored border box for better visibility in the logs

Before
```bash
composer require -W --ansi $PACKAGES
EXIT_CODE=$?                          # Never reached if composer fails
if [[ EXIT_CODE -eq 2 ]]; then        # Missing $ prefix
```

After
```bash
EXIT_CODE=0
composer require -W --ansi $PACKAGES || EXIT_CODE=$?
if [[ $EXIT_CODE -eq 2 ]]; then
```