### PR TITLE
[SymfonyAiDockerModelRunnerPlatform] Fix configuration

### DIFF
--- a/symfony/ai-docker-model-runner-platform/0.1/config/packages/ai_docker_model_runner_platform.yaml
+++ b/symfony/ai-docker-model-runner-platform/0.1/config/packages/ai_docker_model_runner_platform.yaml
@@ -1,3 +1,3 @@
 ai:
     platform:
-        docker_model_runner: null
+        dockermodelrunner: null


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | 

The correct property name is `ai.platform.dockermodelrunner`. See https://github.com/symfony/ai/blob/main/src/ai-bundle/src/AiBundle.php#L1027