### PR TITLE
[symfony/mercure-bundle] Make `MERCURE_URL` optional

### DIFF
--- a/symfony/mercure-bundle/0.3/config/packages/mercure.yaml
+++ b/symfony/mercure-bundle/0.3/config/packages/mercure.yaml
@@ -2,7 +2,7 @@ mercure:
     hubs:
         default:
             url: '%env(MERCURE_URL)%'
-            public_url: '%env(MERCURE_PUBLIC_URL)%'
+            public_url: '%env(default::MERCURE_PUBLIC_URL)%'
             jwt:
                 secret: '%env(MERCURE_JWT_SECRET)%'
                 publish: '*'

--- a/symfony/mercure-bundle/0.4/config/packages/mercure.yaml
+++ b/symfony/mercure-bundle/0.4/config/packages/mercure.yaml
@@ -2,7 +2,7 @@ mercure:
     hubs:
         default:
             url: '%env(default::MERCURE_URL)%'
-            public_url: '%env(MERCURE_PUBLIC_URL)%'
+            public_url: '%env(default::MERCURE_PUBLIC_URL)%'
             jwt:
                 secret: '%env(MERCURE_JWT_SECRET)%'
                 publish: '*'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | Based on conversation https://github.com/symfony/recipes/pull/1514

Since `symfony/mercure-bundle` v0.3.0 (https://github.com/symfony/mercure-bundle/pull/42) the `public_url` config is optional and its default value is `null`.