### PR TITLE
[AiBundle] fix generic platform recipe

### DIFF
--- a/symfony/ai-generic-platform/0.1/config/packages/ai_generic_platform.yaml
+++ b/symfony/ai-generic-platform/0.1/config/packages/ai_generic_platform.yaml
@@ -1,4 +1,5 @@
 ai:
     platform:
         generic:
-            base_url: '%env(GENERIC_BASE_URL)%'
+            default:
+                base_url: '%env(GENERIC_BASE_URL)%'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

STR for the generic platform issue
- clone https://github.com/symfony/ai-demo
- composer require symfony/ai-generic-platform

Fails with 
```Executing script cache:clear [KO]
 [KO]
Script cache:clear returned with error code 255
!!  TypeError {#1666
!!    #message: "Cannot access offset of type string on string"
!!    #code: 0
!!    #file: "./vendor/symfony/ai-bundle/src/AiBundle.php"
!!    #line: 722```