### PR TITLE
[FrameworkBundle] Use static closure in front controller (8.1)

### DIFF
--- a/symfony/framework-bundle/8.1/public/index.php
+++ b/symfony/framework-bundle/8.1/public/index.php
@@ -4,6 +4,6 @@ use App\Kernel;
 
 require_once dirname(__DIR__).'/vendor/autoload_runtime.php';
 
-return function (array $context) {
+return static function (array $context) {
     return new Kernel($context['APP_ENV'], (bool) $context['APP_DEBUG']);
 };


### PR DESCRIPTION
Added missing static for closure in public/index.php for framework-bundle version 8.1.

It looks to me like the recipe for 8.1 was missed in #1529.

| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  |
