### PR TITLE
[symfony/mailgun-mailer] Align env examples with README

### DIFF
--- a/symfony/mailgun-mailer/4.4/manifest.json
+++ b/symfony/mailgun-mailer/4.4/manifest.json
@@ -1,6 +1,7 @@
 {
     "env": {
-        "#1": "MAILER_DSN=mailgun://KEY:DOMAIN@default?region=us",
-        "#2": "MAILER_DSN=mailgun+smtp://USERNAME:PASSWORD@default?region=us"
+        "#1": "MAILER_DSN=mailgun+smtp://USERNAME:PASSWORD@default?region=us",
+        "#2": "MAILER_DSN=mailgun+https://KEY:DOMAIN@default?region=us",
+        "#3": "MAILER_DSN=mailgun+api://KEY:DOMAIN@default?region=us"
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | N/A

The existing examples only show the bare `mailgun://` scheme (which resolves to `MailgunHttpTransport`) and `mailgun+smtp://`. The `mailgun+api://` scheme is missing, and `mailgun://` is easily misinterpreted as "the default/API transport" while it actually uses the raw MIME endpoint that lacks first-class support for features like `recipient-variables`.

This aligns the recipe with the three explicit schemes documented in the current mailgun-mailer [README](https://github.com/symfony/mailgun-mailer/blob/8.1/README.md):

- `mailgun+smtp://` (SMTP)
- `mailgun+https://` (HTTP, raw MIME)
- `mailgun+api://` (API)

Making each transport explicit helps users pick the right one for their use case.