### PR TITLE
`security.yaml`: Adding comment with info about voters

### DIFF
--- a/symfony/security-bundle/7.4/config/packages/security.yaml
+++ b/symfony/security-bundle/7.4/config/packages/security.yaml
@@ -25,7 +25,7 @@ security:
     # Note: Only the *first* matching rule is applied
     access_control:
         # - { path: ^/admin, roles: ROLE_ADMIN }
-        # - { path: ^/profile, roles: ROLE_USER }
+        # - { path: ^/profile/, roles: ROLE_USER } # Caution: This is not enough to restrict access, see https://symfony.com/doc/current/security/voters.html
 
 when@test:
     security:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | none

The line can easily be misunderstood in that it would only allow each user access to *their* profile (while in fact it allows every user access to every profile).