### PR TITLE
[AiMate] Add recipe

### DIFF
--- a/symfony/ai-mate/0.1/manifest.json
+++ b/symfony/ai-mate/0.1/manifest.json
@@ -1,0 +1,6 @@
+{
+    "composer-scripts": {
+        "vendor/bin/mate discover --composer --ignore-missing-file": "script"
+    },
+    "aliases": ["mate"]
+}

--- a/symfony/ai-mate/0.1/post-install.txt
+++ b/symfony/ai-mate/0.1/post-install.txt
@@ -1,0 +1,3 @@
+  <bg=blue;fg=white>AI Mate installed! Run the following to get started:</>
+
+    <comment>vendor/bin/mate init</>


### PR DESCRIPTION
Adds the Symfony Flex recipe for `symfony/ai-mate`, replacing the behaviour previously provided by the `symfony/ai-mate-composer-plugin` package. Tracking issue: symfony/ai#1994.

## Cross-repo PRs

| # | Repo | PR | What | Status |
|---|---|---|---|---|
| 1 | symfony/ai | [symfony/ai#2027](https://github.com/symfony/ai/pull/2027) | `mate discover --ignore-missing-file` | open |
| 2 | symfony/ai | [symfony/ai#2026](https://github.com/symfony/ai/pull/2026) | Drop `symfony/ai-mate-composer-plugin` from `symfony/ai-mate`'s require list (depends on symfony/ai#2027) | draft |
| 3 | symfony/flex | [symfony/flex#1089](https://github.com/symfony/flex/pull/1089) | Auto-wire `@auto-scripts` into `post-install-cmd` / `post-update-cmd` | draft |
| 4 | symfony/recipes | [symfony/recipes#1535](https://github.com/symfony/recipes/pull/1535) | The `symfony/ai-mate` recipe | **this PR (draft)** |
| 5 | symfony/ai | _follow-up_ | Delete the composer plugin source | not started |

## Summary

- Registers `vendor/bin/mate discover --composer --ignore-missing-file` as a `composer-scripts` entry.
- Prints the "run `vendor/bin/mate init`" banner via `post-install.txt`.
- Adds a `mate` alias.

## Usage

After `composer require symfony/ai-mate`, Flex applies the recipe automatically: the discover script is wired into `@auto-scripts` and runs on every `composer install` / `composer update`, and the install banner is shown once.

Marking as draft until symfony/ai#2027, symfony/ai#2026 and symfony/flex#1089 are merged and a Flex release is cut.