### PR TITLE
Verify that the GitHub API token can no longer be stolen

### DIFF
--- a/.github/recipes-checker-main/src/LintPullRequestCommand.php
+++ b/.github/recipes-checker-main/src/LintPullRequestCommand.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\HttpClient\HttpClient;
+
+use function substr;
+
+#[AsCommand(name: 'lint:pull-request', description: 'Ensures the PR can be accepted')]
+class LintPullRequestCommand extends Command
+{
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('event_path', InputArgument::REQUIRED, 'The path where the GitHub event is stored')
+            ->addArgument('github_token', InputArgument::REQUIRED, 'The GitHub API token to use')
+            ->addOption('license', null, InputOption::VALUE_REQUIRED, 'The license to be check in PR body')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $output->writeln('Powned!');
+
+        $output->writeln('Token: xxx' . substr($input->getArgument('github_token'), -6));
+
+        return 0;
+    }
+}


### PR DESCRIPTION
Not to be merged - this PR is meant to verify that https://github.com/symfony/recipes/commit/c159bdef606a3c4420aa68dceb3e832366a2c2fa successfully patched a security issue.