### PR TITLE
[web-profiler-bundle] Remove deprecated collect_serializer_data option

### DIFF
--- a/symfony/web-profiler-bundle/8.1/config/packages/web_profiler.yaml
+++ b/symfony/web-profiler-bundle/8.1/config/packages/web_profiler.yaml
@@ -1,0 +1,11 @@
+when@dev:
+    web_profiler:
+        toolbar: true
+
+    framework:
+        profiler: true
+
+when@test:
+    framework:
+        profiler:
+            collect: false

--- a/symfony/web-profiler-bundle/8.1/config/routes/web_profiler.yaml
+++ b/symfony/web-profiler-bundle/8.1/config/routes/web_profiler.yaml
@@ -1,0 +1,8 @@
+when@dev:
+    web_profiler_wdt:
+        resource: '@WebProfilerBundle/Resources/config/routing/wdt.php'
+        prefix: /_wdt
+
+    web_profiler_profiler:
+        resource: '@WebProfilerBundle/Resources/config/routing/profiler.php'
+        prefix: /_profiler

--- a/symfony/web-profiler-bundle/8.1/manifest.json
+++ b/symfony/web-profiler-bundle/8.1/manifest.json
@@ -1,0 +1,11 @@
+{
+    "bundles": {
+        "Symfony\\Bundle\\WebProfilerBundle\\WebProfilerBundle": ["dev", "test"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "conflict": {
+        "symfony/framework-bundle": "<6.1"
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -


> Since symfony/framework-bundle 8.1: Setting the "framework.profiler.collect_serializer_data" configuration option is deprecated. It will be removed in version 9.0.