### PR TITLE
[ci] Use BOT_TOKEN for the Flex endpoint push and PR diff comment

### DIFF
--- a/.github/workflows/callable-qa.yml
+++ b/.github/workflows/callable-qa.yml
@@ -68,7 +68,7 @@ jobs:
                     mv .github/flex-endpoint/*.json .
                     git add *.json
                     git commit -m 'Create Flex endpoint' || true
-                    git push origin -f flex/pull-${{ github.event.number }}
+                    git push -f "https://x-access-token:${{ secrets.token }}@github.com/${{ github.repository }}" "flex/pull-${{ github.event.number }}"
                     git switch pr
                     git stash pop -q
 
@@ -91,6 +91,8 @@ jobs:
                 name: Post diff between recipe versions
                 if: "always() && steps.checkout.outcome == 'success'"
                 uses: marocchino/sticky-pull-request-comment@v2
+                env:
+                    GITHUB_TOKEN: ${{ secrets.token }}
                 with:
                     path: .github/diff-recipe-versions.md
 


### PR DESCRIPTION
The QA workflow currently fails on every PR at two steps:

- **Generate Flex testing endpoint** — `git push origin -f flex/pull-N` returns `403` (exit code 128)
- **Post diff between recipe versions** — `Resource not accessible by integration`

Both steps relied on the *default* `GITHUB_TOKEN` persisted by `actions/checkout`. Since that token was reduced to read-only, neither the push nor the PR comment can succeed. The steps that were already migrated to `BOT_TOKEN` (`secrets.token`) — Automerge, MIT lint — keep working.

This authenticates both steps via `BOT_TOKEN`:

- The Flex endpoint push uses an explicit `https://x-access-token:<token>@github.com/<repo>` URL, so the write token is **not** persisted into the checkout credentials and is never exposed to the untrusted `pull_request_target` merge ref.
- The sticky-comment action receives the token via the `GITHUB_TOKEN` env var.

🤖 Generated with [Claude Code](https://claude.com/claude-code)