### PR TITLE
[ci] Fix BOT_TOKEN auth for Flex endpoint push and PR diff comment

### DIFF
--- a/.github/workflows/callable-qa.yml
+++ b/.github/workflows/callable-qa.yml
@@ -68,6 +68,7 @@ jobs:
                     mv .github/flex-endpoint/*.json .
                     git add *.json
                     git commit -m 'Create Flex endpoint' || true
+                    git config --local --unset-all http.https://github.com/.extraheader || true
                     git push -f "https://x-access-token:${{ secrets.token }}@github.com/${{ github.repository }}" "flex/pull-${{ github.event.number }}"
                     git switch pr
                     git stash pop -q
@@ -91,9 +92,8 @@ jobs:
                 name: Post diff between recipe versions
                 if: "always() && steps.checkout.outcome == 'success'"
                 uses: marocchino/sticky-pull-request-comment@v2
-                env:
-                    GITHUB_TOKEN: ${{ secrets.token }}
                 with:
+                    GITHUB_TOKEN: ${{ secrets.token }}
                     path: .github/diff-recipe-versions.md
 
             -


### PR DESCRIPTION
Follow-up to #1539, which did not fully fix the QA failures. Two issues remained:

**Flex endpoint push** — embedding `BOT_TOKEN` in the push URL was not enough. `actions/checkout` persists an `http.https://github.com/.extraheader` Authorization header (carrying the default, now read-only `GITHUB_TOKEN`) into `.git/config`, and git sends that header in preference to URL-embedded credentials. The push therefore authenticated as `github-actions[bot]`:

```
remote: Permission to symfony/recipes.git denied to github-actions[bot].
fatal: ... error: 403
```

Fixed by unsetting that header before pushing, so the `BOT_TOKEN` in the URL is used.

**PR diff comment** — `marocchino/sticky-pull-request-comment` reads its token from the `GITHUB_TOKEN` **input** (default `${{ github.token }}`), not from the `GITHUB_TOKEN` env var. The env var added in #1539 was ignored and the read-only default token was still used (`Resource not accessible by integration`). Fixed by passing the token via `with:` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)