### PR TITLE
[symfonycasts/tailwind-bundle] remove default config

### DIFF
--- a/symfonycasts/tailwind-bundle/0.14/manifest.json
+++ b/symfonycasts/tailwind-bundle/0.14/manifest.json
@@ -1,0 +1,6 @@
+{
+    "bundles": {
+        "Symfonycasts\\TailwindBundle\\SymfonycastsTailwindBundle": ["all"]
+    },
+    "aliases": ["tailwind", "tailwindcss"]
+}

--- a/symfonycasts/tailwind-bundle/0.14/post-install.txt
+++ b/symfonycasts/tailwind-bundle/0.14/post-install.txt
@@ -1,0 +1,6 @@
+  * <fg=green>Tailwind CSS is installed!</> Time to get rolling:
+
+  * <fg=blue>Run</> <comment>php bin/console tailwind:init</> to set up your Tailwind configuration
+  * <fg=blue>Then</> start the watcher with <comment>php bin/console tailwind:build --watch</>
+
+  * <fg=blue>Read</> the docs at <comment>https://symfony.com/bundles/TailwindBundle/current/index.html</>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | SymfonyCasts/tailwind-bundle#96

We want users to run `tailwind:init` after installation to choose their preferred tailwind version.

