### PR TITLE
[Reprise] Rename `rollupOptions` to `rolldownOptions`

### DIFF
--- a/symfony/reprise/0.1/post-install.txt
+++ b/symfony/reprise/0.1/post-install.txt
@@ -24,7 +24,8 @@
 
     export default defineConfig({
         build: {
-            rollupOptions: {
+            // On Vite 7 or older, use `rollupOptions` instead
+            rolldownOptions: {
                 input: {
                     app: './assets/app.js',
                 },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | symfony/symfony-docs#...

Just a quick update on the `post-install.txt`, I've just seen https://vite.dev/config/build-options#build-rollupoptions is deprecated in favor of `build.rolldownOptions`
