### PR TITLE
[twig-bundle] Use snake_case for the FrankenPHP hot reload Twig variable

### DIFF
--- a/symfony/twig-bundle/6.4/templates/base.html.twig
+++ b/symfony/twig-bundle/6.4/templates/base.html.twig
@@ -10,9 +10,9 @@
         {% block javascripts %}
         {% endblock %}
 
-        {% set frankenphpHotReload = app.request.server.get('FRANKENPHP_HOT_RELOAD') %}
-        {% if frankenphpHotReload %}
-        <meta name="frankenphp-hot-reload:url" content="{{ frankenphpHotReload }}">
+        {% set frankenphp_hot_reload = app.request.server.get('FRANKENPHP_HOT_RELOAD') %}
+        {% if frankenphp_hot_reload %}
+        <meta name="frankenphp-hot-reload:url" content="{{ frankenphp_hot_reload }}">
         <script src="https://cdn.jsdelivr.net/npm/idiomorph"></script>
         <script src="https://cdn.jsdelivr.net/npm/frankenphp-hot-reload/+esm" type="module"></script>
         {% endif %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | n/a

Fix #1530

The `base.html.twig` shipped since #1526 uses `frankenphpHotReload` as a Twig variable name, which violates the [Twig coding standards](https://twig.symfony.com/doc/3.x/coding_standards.html) (snake_case) and makes Twig CS Fixer report an error in freshly created projects:

> The var name must use snake_case; expected frankenphp_hot_reload.

Verified with `vincentlanglet/twig-cs-fixer` 4.0.2: the current template triggers the error (with `VariableNameRule` enabled, which requires `allowNonFixableRules()` since the rule is not auto-fixable), the renamed one lints clean with no other violation.
