### PR TITLE
[symfony/webpack-encore-bundle] Remove the obsolete regenerator-runtime dependency

### DIFF
--- a/symfony/webpack-encore-bundle/2.2/package.json
+++ b/symfony/webpack-encore-bundle/2.2/package.json
@@ -5,7 +5,6 @@
         "@symfony/webpack-encore": "^7.0.0",
         "babel-plugin-polyfill-corejs3": "^1.0.0",
         "core-js": "^3.49.0",
-        "regenerator-runtime": "^0.13.9",
         "webpack": "^5.82",
         "webpack-cli": "^7.0.0"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

Closes #1537.

The `regenerator-runtime` package is [archived](https://github.com/facebook/regenerator) (last release 2 years ago) and is no longer needed by this recipe. As @stof and @Kocal noted on the issue, it was only required when Babel transpiled generators to the old external `regeneratorRuntime` global; the `2.2` recipe is on Babel 8 (`@babel/preset-env: ^8.0.0`), which inlines a self-contained regenerator helper instead.

Per @Kocal's request, I verified it empirically by reproducing the exact `2.2` setup (Babel 8, `@babel/preset-env`, `core-js` 3 + `babel-plugin-polyfill-corejs3`) **without** `regenerator-runtime`, adding code that uses a generator and `async`/`await`, and forcing an `ie 11` browserslist target (worst case):

- `encore production` and `encore dev` both compile successfully;
- there is **no** `regeneratorRuntime` reference anywhere in the output;
- the generator is still correctly transpiled for IE11, but through Babel's inlined `_regenerator()` helper (from `@babel/helpers`), with no external dependency.

I only touched the `2.2` recipe. The `1.x` recipes are on Babel 7 (`@babel/preset-env: ^7.16.0`), which still uses the regenerator transform for old browsers, so I left them untouched.

Thanks @leonboot for spotting this! 🙏
