### PR TITLE
[symfony/security-bundle] Allow the profiler without a trailing slash in the dev firewall

### DIFF
--- a/symfony/security-bundle/6.4/config/packages/security.yaml
+++ b/symfony/security-bundle/6.4/config/packages/security.yaml
@@ -7,7 +7,7 @@ security:
         users_in_memory: { memory: null }
     firewalls:
         dev:
-            pattern: ^/(_(profiler|wdt)|css|images|js)/
+            pattern: ^/(_(profiler|wdt)|css|images|js)(/|$)
             security: false
         main:
             lazy: true

--- a/symfony/security-bundle/7.4/config/packages/security.yaml
+++ b/symfony/security-bundle/7.4/config/packages/security.yaml
@@ -10,7 +10,7 @@ security:
     firewalls:
         dev:
             # Ensure dev tools and static assets are always allowed
-            pattern: ^/(_profiler|_wdt|assets|build)/
+            pattern: ^/(_profiler|_wdt|assets|build)(/|$)
             security: false
         main:
             lazy: true


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

Closes #1201.

The `dev` firewall pattern ends with a `/`, so a path like `/_profiler` (without the trailing slash) is not matched and falls through to the `main` firewall. With a catch-all `access_control` rule (e.g. `- { path: ^/, roles: IS_AUTHENTICATED_FULLY }`) accessing the profiler then requires authentication.

This applies @stof's suggestion from the issue: replace the trailing `/` with `(/|$)`, so both `/_profiler` and `/_profiler/...` match. The alternation stays anchored, so it does not over-match (`/_profilersection`, `/assetsfoo`, `/buildx` are still excluded, addressing @weaverryan's concern):

| Path | before | after |
| --- | --- | --- |
| `/_profiler` | no | yes |
| `/_profiler/foo` | yes | yes |
| `/_profilersection` | no | no |
| `/assetsfoo` | no | no |

I only touched the `7.4` recipe. The same pattern exists in the `<= 6.4` recipes (`^/(_(profiler|wdt)|css|images|js)/`); happy to apply the same change there if you'd like.

Thanks @aarong416 for the report and @stof for the suggested fix! 🙏
