### PR TITLE
Enable unsafe PR checkout in workflow

### DIFF
--- a/.github/workflows/callable-qa.yml
+++ b/.github/workflows/callable-qa.yml
@@ -30,6 +30,7 @@ jobs:
                 with:
                     fetch-depth: 0
                     ref: 'refs/pull/${{ github.event.number }}/merge'
+                    allow-unsafe-pr-checkout: true
 
             -
                 name: Install tools


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | n/a

Our recipes checker workflow is not running code from the checkout out codebase (it runs the recipes-checker tool fetched separately) so allowing the checkout is OK.

This is related to the new security measure of GitHub: https://github.blog/changelog/2026-06-18-safer-pull_request_target-defaults-for-github-actions-checkout/