### PR TITLE
[symfony/form] Add `switch_user` to stateless CSRF token ids

### DIFF
--- a/symfony/form/8.2/config/packages/csrf.yaml
+++ b/symfony/form/8.2/config/packages/csrf.yaml
@@ -1,0 +1,12 @@
+# Enable stateless CSRF protection for forms, logins/logouts and user switching
+framework:
+    form:
+        csrf_protection:
+            token_id: submit
+
+    csrf_protection:
+        stateless_token_ids:
+            - submit
+            - authenticate
+            - logout
+            - switch_user

--- a/symfony/form/8.2/manifest.json
+++ b/symfony/form/8.2/manifest.json
@@ -1,0 +1,5 @@
+{
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | symfony/symfony-docs#...

Companion recipe for symfony/symfony#64879, which adds `path` and CSRF protection to the `switch_user` firewall listener (defaulting to the `switch_user` token id).