### PR TITLE
Split stateless CSRF config into form and security-csrf 8.2 recipes

### DIFF
--- a/symfony/form/8.2/config/packages/form.yaml
+++ b/symfony/form/8.2/config/packages/form.yaml
@@ -1,0 +1,9 @@
+# Enable stateless CSRF protection for forms
+framework:
+    form:
+        csrf_protection:
+            token_id: submit
+
+    csrf_protection:
+        stateless_token_ids:
+            - submit

--- a/symfony/form/8.2/manifest.json
+++ b/symfony/form/8.2/manifest.json
@@ -1,0 +1,5 @@
+{
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    }
+}

--- a/symfony/security-csrf/8.2/config/packages/csrf.yaml
+++ b/symfony/security-csrf/8.2/config/packages/csrf.yaml
@@ -1,0 +1,6 @@
+# Enable stateless CSRF protection
+framework:
+    csrf_protection:
+        stateless_token_ids:
+            - authenticate
+            - logout

--- a/symfony/security-csrf/8.2/manifest.json
+++ b/symfony/security-csrf/8.2/manifest.json
@@ -1,0 +1,6 @@
+{
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "aliases": ["csrf"]
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

Today the whole stateless CSRF config lives in a single `csrf.yaml` in the `symfony/form` recipe: the form `submit` token *and* the security `authenticate`/`logout` token ids. So the login/logout ids are only configured when you install `symfony/form`, and `symfony/security-csrf` has no recipe of its own — an app using security without forms gets no stateless login/logout CSRF.

This splits ownership cleanly, introduced at `8.2` so no shipped `7.2` app is affected:

- `symfony/form/8.2/form.yaml` owns the form `csrf_protection.token_id` and registers `submit` in `stateless_token_ids`.
- A new `symfony/security-csrf/8.2/csrf.yaml` (aliased `csrf`) registers the `authenticate`/`logout` stateless token ids.
- `symfony/form/7.2` is left as-is, keeping the combined config for existing apps.

Existing apps aren't left behind: `symfony/security-csrf` is installed (via `symfony/security-bundle`) but absent from `symfony.lock`, so Flex re-synthesises it as an install and applies the new recipe on the next `composer update`. New `8.2` projects get the clean split from the start.
