### PR TITLE
[twig-bundle] Render the FrankenPHP hot reload block only in debug mode

### DIFF
--- a/symfony/twig-bundle/6.4/templates/base.html.twig
+++ b/symfony/twig-bundle/6.4/templates/base.html.twig
@@ -11,7 +11,7 @@
         {% endblock %}
 
         {% set frankenphp_hot_reload = app.request.server.get('FRANKENPHP_HOT_RELOAD') %}
-        {% if frankenphp_hot_reload %}
+        {% if frankenphp_hot_reload and app.debug %}
         <meta name="frankenphp-hot-reload:url" content="{{ frankenphp_hot_reload }}">
         <script src="https://cdn.jsdelivr.net/npm/idiomorph"></script>
         <script src="https://cdn.jsdelivr.net/npm/frankenphp-hot-reload/+esm" type="module"></script>


### PR DESCRIPTION
## Summary

FrankenPHP's [hot reload documentation](https://frankenphp.dev/docs/hot-reload/) is explicit:

> This feature is intended for **development environments only**. Do not enable `hot_reload` in production, as this feature is not secure (exposes sensitive internal details) and slows down the application.

The template renders the block on the presence of the `FRANKENPHP_HOT_RELOAD` server variable alone, so any environment where that variable ends up set — including production — ships:

- two `<script>` tags pointing at unversioned jsDelivr URLs, with no `integrity` and no `crossorigin`, so whatever the CDN serves at that moment executes with the page's origin privileges;
- a `<meta>` tag publishing the Mercure hub URL, which is part of what the documentation means by "exposes sensitive internal details" — anyone able to publish on that topic can push DOM mutations to every connected browser, since that is exactly what the client library applies.

Adding `and app.debug` narrows *when* the block renders. It is defence in depth against a misconfiguration, in a template that ships to every new Symfony project.

## Why `app.debug` rather than `app.environment == 'dev'`

`app.debug` does not hardcode an environment name, so it keeps working for projects using a differently named development environment. The trade-off is that it stays true in a debug-enabled staging environment, where hot reload is also undesirable. If you prefer the stricter check, I am happy to switch to `app.environment == 'dev'` — just say which you want.

## On the "Updating Recipes" policy

`README.rst` says an existing recipe version should only change for a bug, and that new best practices go to the next version. I believe this falls under the "mis-configuration" bullet rather than "new best practice": the template contradicts the upstream documentation of the very feature it integrates — the doc says development only, the condition permits production. If you disagree and want this in a new version directory instead, tell me which version to target and I will move the file. Worth noting that projects already on the 6.4 recipe would then keep the unguarded snippet until they update, which is the population most exposed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
