### PR TITLE
[symfony/webhook] Default to standard signatures and no-private-network

### DIFF
--- a/symfony/webhook/8.2/config/packages/webhook.yaml
+++ b/symfony/webhook/8.2/config/packages/webhook.yaml
@@ -1,0 +1,4 @@
+framework:
+    webhook:
+        signature_format: standard
+        no_private_network: true

--- a/symfony/webhook/8.2/config/routes/webhook.yaml
+++ b/symfony/webhook/8.2/config/routes/webhook.yaml
@@ -1,0 +1,3 @@
+webhook:
+    resource: '@FrameworkBundle/Resources/config/routing/webhook.php'
+    prefix: /webhook

--- a/symfony/webhook/8.2/manifest.json
+++ b/symfony/webhook/8.2/manifest.json
@@ -1,0 +1,8 @@
+{
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "conflict": {
+        "symfony/framework-bundle": "<8.2"
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | symfony/symfony-docs#...

Depends on symfony/symfony#62958, which adds `framework.webhook.signature_format` in 8.2. Not mergeable before it.

New applications start on the [Standard Webhooks](https://www.standardwebhooks.com/) signature instead of Symfony's historical scheme, so that what they emit is verifiable by any off-the-shelf Standard Webhooks library, the event type travels inside the signed body rather than in an unsigned `Webhook-Event` header, and the replay window applies.

```yaml
# config/packages/webhook.yaml
framework:
    webhook:
        signature_format: standard
```

The default in `Configuration.php` stays `legacy`, since changing it would re-sign the webhooks of every application on upgrade. The recipe is the only lever that reaches new installations only, hence the `8.2` directory: the option throws on `symfony/webhook` below 8.2, so 7.3 installations keep the current recipe.

`config/routes/webhook.yaml` and `manifest.json` are carried over from `7.3` unchanged.

One thing worth a second opinion. The recipe also runs when an existing application requires `symfony/webhook` explicitly for the first time, for instance to consume a third-party provider's webhooks. That case is unaffected in practice, since those go through provider-specific parsers that ignore `signature_format`, but an application that had the package only as a transitive dependency and was already sending webhooks would see its signature change. Happy to drop the config file and keep the routing-only recipe if that is judged too sharp.
