### PR TITLE
[symfony/framework-bundle] Load preload files using glob pattern

### DIFF
--- a/symfony/framework-bundle/6.4/config/preload.php
+++ b/symfony/framework-bundle/6.4/config/preload.php
@@ -1,5 +1,5 @@
 <?php
 
-if (file_exists(dirname(__DIR__).'/var/cache/prod/App_KernelProdContainer.preload.php')) {
-    require dirname(__DIR__).'/var/cache/prod/App_KernelProdContainer.preload.php';
+foreach (glob(dirname(__DIR__).'/var/cache/prod/*.preload.php') ?: [] as $file) {
+    require $file;
 }

--- a/symfony/framework-bundle/7.4/config/preload.php
+++ b/symfony/framework-bundle/7.4/config/preload.php
@@ -1,5 +1,5 @@
 <?php
 
-if (file_exists(dirname(__DIR__).'/var/cache/prod/App_KernelProdContainer.preload.php')) {
-    require dirname(__DIR__).'/var/cache/prod/App_KernelProdContainer.preload.php';
+foreach (glob(dirname(__DIR__).'/var/cache/prod/*.preload.php') ?: [] as $file) {
+    require $file;
 }

--- a/symfony/framework-bundle/8.1/config/preload.php
+++ b/symfony/framework-bundle/8.1/config/preload.php
@@ -1,5 +1,5 @@
 <?php
 
-if (file_exists(dirname(__DIR__).'/var/cache/prod/App_KernelProdContainer.preload.php')) {
-    require dirname(__DIR__).'/var/cache/prod/App_KernelProdContainer.preload.php';
+foreach (glob(dirname(__DIR__).'/var/cache/prod/*.preload.php') ?: [] as $file) {
+    require $file;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Issue  | #1557

The preload used to be hardcoded on `App_KernelProdContainer.preload.php`. For users who use a custom Kernel, this file will never exist, and preload would **silently** fail.

This change allows userland to define an alternate kernel without having to overwrite their preload.php. Since there's no indication that anything is *wrong* when using a different Kernel, I think this solution would catch it and also future-proof the preload script if Symfony ever decides to add additional preload files (all they'd have to do is add then to the `/var/cache/prod` dir with the `.preload.php` suffix)

I only included changes for the **supported** Symfony versions.