### PR TITLE
[Webhook] Add recipe for 8.2 (standard signature format)

### DIFF
--- a/symfony/webhook/8.2/config/packages/webhook.yaml
+++ b/symfony/webhook/8.2/config/packages/webhook.yaml
@@ -1,0 +1,5 @@
+framework:
+    webhook:
+        # see https://www.standardwebhooks.com/
+        # use "transitional" to also emit the legacy signature while migrating existing subscribers
+        signature_format: standard

--- a/symfony/webhook/8.2/config/routes/webhook.yaml
+++ b/symfony/webhook/8.2/config/routes/webhook.yaml
@@ -1,0 +1,3 @@
+webhook:
+    resource: '@FrameworkBundle/Resources/config/routing/webhook.php'
+    prefix: /webhook

--- a/symfony/webhook/8.2/manifest.json
+++ b/symfony/webhook/8.2/manifest.json
@@ -1,0 +1,5 @@
+{
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    }
+}


### PR DESCRIPTION
Suggested by @nicolas-grekas in https://github.com/symfony/symfony-docs/pull/22776#issuecomment-5352378012.

`framework.webhook.signature_format` was added in symfony/symfony#62958 (8.2) and
defaults to `legacy` for BC reasons. New applications have no existing subscribers
to migrate, so this recipe opts them into the [Standard Webhooks](https://www.standardwebhooks.com/)
scheme from the start.

The `8.2` directory is a copy of `7.3` plus the new `config/packages/webhook.yaml`,
following the "do it for the next version of the dependency" rule for new best practices.
