### PR TITLE
[FrameworkBundle] Add AGENTS.md for AI coding agents

### DIFF
--- a/symfony/framework-bundle/8.1/AGENTS.md
+++ b/symfony/framework-bundle/8.1/AGENTS.md
@@ -29,12 +29,16 @@ because it isn't installed yet; installing it is one command.
 Follow https://symfony.com/doc/current/best_practices.html to write idiomatic
 Symfony:
 
-- Use PHP attributes for framework metadata: `#[Route]`, `#[Assert\...]`,
-  `#[MapRequestPayload]`, `#[IsGranted]`, `#[AsCommand]`. No YAML or XML routing.
+- Use PHP attributes for framework metadata, and not only on controllers:
+  `#[Route]`, `#[MapRequestPayload]`, `#[IsGranted]` on actions, `#[Assert\...]`
+  on properties, `#[AsCommand]`, `#[AsEventListener]`, `#[AsMessageHandler]`, and
+  `#[AsAlias]` / `#[AsTaggedItem]` / `#[Autoconfigure]` on services. No YAML or
+  XML routing.
 - Rely on autowiring and autoconfiguration. Type-hint constructor arguments and
-  let the container resolve them; write an explicit service definition only when
-  it genuinely can't be resolved (scalar arguments, several implementations of
-  one interface).
+  let the container resolve them. Where a type-hint can't express it, stay in the
+  class with `#[Autowire]` (parameters, env vars, expressions) or `#[Target]` (one
+  of several implementations of an interface). A YAML service definition is the
+  last resort, not the first.
 - Controllers extend `AbstractController`, stay thin, and delegate to services.
 - Use the framework for what it already does: Form for server-rendered forms,
   Validator for validation, Serializer for JSON, Messenger for async work,

--- a/symfony/framework-bundle/8.1/AGENTS.md
+++ b/symfony/framework-bundle/8.1/AGENTS.md
@@ -1,0 +1,76 @@
+# AGENTS.md
+
+This is a Symfony project. Check `composer.json` for the exact Symfony/PHP version
+in use, and read `symfony.lock` to see which recipes ran — don't assume Doctrine,
+Twig, API Platform, Messenger, or Lock are installed unless one of those says so.
+
+## Ask before generating
+
+If the task doesn't specify, ask rather than guess:
+
+- Persistence: Doctrine ORM, Doctrine ODM, or none?
+- Interface: server-rendered (Twig), API (Serializer, maybe API Platform), or both?
+- Auth: SecurityBundle, and which authenticator?
+
+If you can't ask (no interactive channel), state the assumption you're making and
+pick the smallest option (e.g. no persistence layer) rather than scaffolding a
+full stack nobody asked for.
+
+## Adding features: Flex, not hand-wiring
+
+Install new capabilities with `composer require <package>` (e.g. `symfony/lock`,
+`symfony/messenger`, `orm-pack`) and let the Flex recipe register the bundle and
+generate its config. Don't hand-edit `config/bundles.php` or hand-write a bundle's
+base config — that's what the recipe is for. Don't skip a good-fit component just
+because it isn't installed yet; installing it is one command.
+
+## Conventions
+
+- Routing: PHP attributes on controller methods (`#[Route(...)]`), not YAML/XML.
+- Controllers: extend `AbstractController`; use `#[MapRequestPayload]` /
+  `#[MapQueryString]` on action arguments to get Serializer + Validator wired
+  automatically, instead of hand-calling `json_decode()` or `SerializerInterface`.
+  Requires `symfony/serializer` and `symfony/validator` — if the interface is
+  API-only and neither is installed yet, `composer require` them first rather
+  than falling back to manual parsing.
+- Services: rely on autowiring/autoconfiguration; add an explicit service
+  definition only when it genuinely can't be resolved (scalar args, an interface
+  with multiple implementations).
+- Constructor property promotion + `readonly` for DTOs and plain value objects by
+  default. Skip `readonly` on a service if it might end up `lazy: true` — lazy
+  proxies can't extend a `readonly` class.
+- Validate with `symfony/validator` (`#[Assert\...]` + `ValidatorInterface`), not
+  custom validation code.
+- Locking / mutual exclusion: `symfony/lock` (`LockFactory`), not a hand-built
+  mechanism.
+- Long-running or background work: Messenger, not a custom queue.
+- If Doctrine ORM is installed: schema changes go through
+  `doctrine/doctrine-migrations-bundle` (`bin/console make:migration` +
+  `doctrine:migrations:migrate`), not `doctrine:schema:update` or hand-written SQL.
+- Secrets: `bin/console secrets:set` (the vault), read via `%env(...)%`. `.env` is
+  committed to the repo — real secrets go in `.env.local` or the vault, never in
+  `.env` itself.
+- Scaffolding: if `maker-bundle` is installed, prefer `bin/console make:*` with
+  all arguments passed up front and `--no-interaction` where supported — makers
+  prompt on a terminal by default, which hangs a non-interactive shell. If a
+  maker still needs interactive input, hand-write the code instead.
+
+## Testing
+
+Install `symfony/test-pack` if it isn't already. Functional/HTTP tests extend
+`WebTestCase`; service-level tests extend `KernelTestCase`. Run
+`php bin/phpunit` (falls back to `vendor/bin/phpunit`). A feature isn't done
+until it has a test that exercises it the way a caller would — an HTTP request
+for a controller, a service call for a service — not just "it didn't throw."
+
+## Code style
+
+Symfony's coding standard, the `@Symfony` php-cs-fixer ruleset (a PSR-12-derived
+superset). Run `vendor/bin/php-cs-fixer fix` if `friendsofphp/php-cs-fixer` is
+installed — it isn't part of the skeleton by default.
+
+## When training data might be stale
+
+Framework APIs and attribute names change between major versions. Prefer reading
+the installed package's own source/docblocks in `vendor/` over recollection; if
+you have web access, https://symfony.com/doc/current/ is the canonical reference.

--- a/symfony/framework-bundle/8.1/AGENTS.md
+++ b/symfony/framework-bundle/8.1/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS.md
 
 This is a Symfony project. Check `composer.json` for the exact Symfony/PHP version
-in use, and read `symfony.lock` to see which recipes ran — don't assume Doctrine,
+in use, and read `symfony.lock` to see which recipes ran. Don't assume Doctrine,
 Twig, API Platform, Messenger, or Lock are installed unless one of those says so.
 
 ## Ask before generating
@@ -21,56 +21,84 @@ full stack nobody asked for.
 Install new capabilities with `composer require <package>` (e.g. `symfony/lock`,
 `symfony/messenger`, `orm-pack`) and let the Flex recipe register the bundle and
 generate its config. Don't hand-edit `config/bundles.php` or hand-write a bundle's
-base config — that's what the recipe is for. Don't skip a good-fit component just
+base config; that's what the recipe is for. Don't skip a good-fit component just
 because it isn't installed yet; installing it is one command.
 
 ## Conventions
 
-- Routing: PHP attributes on controller methods (`#[Route(...)]`), not YAML/XML.
-- Controllers: extend `AbstractController`; use `#[MapRequestPayload]` /
-  `#[MapQueryString]` on action arguments to get Serializer + Validator wired
-  automatically, instead of hand-calling `json_decode()` or `SerializerInterface`.
-  Requires `symfony/serializer` and `symfony/validator` — if the interface is
-  API-only and neither is installed yet, `composer require` them first rather
-  than falling back to manual parsing.
-- Services: rely on autowiring/autoconfiguration; add an explicit service
-  definition only when it genuinely can't be resolved (scalar args, an interface
-  with multiple implementations).
-- Constructor property promotion + `readonly` for DTOs and plain value objects by
-  default. Skip `readonly` on a service if it might end up `lazy: true` — lazy
-  proxies can't extend a `readonly` class.
-- Validate with `symfony/validator` (`#[Assert\...]` + `ValidatorInterface`), not
-  custom validation code.
-- Locking / mutual exclusion: `symfony/lock` (`LockFactory`), not a hand-built
-  mechanism.
-- Long-running or background work: Messenger, not a custom queue.
-- If Doctrine ORM is installed: schema changes go through
-  `doctrine/doctrine-migrations-bundle` (`bin/console make:migration` +
-  `doctrine:migrations:migrate`), not `doctrine:schema:update` or hand-written SQL.
-- Secrets: `bin/console secrets:set` (the vault), read via `%env(...)%`. `.env` is
-  committed to the repo — real secrets go in `.env.local` or the vault, never in
-  `.env` itself.
-- Scaffolding: if `maker-bundle` is installed, prefer `bin/console make:*` with
-  all arguments passed up front and `--no-interaction` where supported — makers
-  prompt on a terminal by default, which hangs a non-interactive shell. If a
-  maker still needs interactive input, hand-write the code instead.
+Follow https://symfony.com/doc/current/best_practices.html to write idiomatic
+Symfony:
+
+- Use PHP attributes for framework metadata: `#[Route]`, `#[Assert\...]`,
+  `#[MapRequestPayload]`, `#[IsGranted]`, `#[AsCommand]`. No YAML or XML routing.
+- Rely on autowiring and autoconfiguration. Type-hint constructor arguments and
+  let the container resolve them; write an explicit service definition only when
+  it genuinely can't be resolved (scalar arguments, several implementations of
+  one interface).
+- Controllers extend `AbstractController`, stay thin, and delegate to services.
+- Use the framework for what it already does: Form for server-rendered forms,
+  Validator for validation, Serializer for JSON, Messenger for async work,
+  Security (voters, authenticators) for access control, Twig `path()`/`url()`
+  instead of hardcoded URLs.
+- Before hand-writing infrastructure (locks, queues, caches, HTTP clients,
+  mailers, schedulers) or reaching for a third-party library, check whether a
+  Symfony component covers it. It usually does.
+
+Three specifics worth spelling out, because they are easy to get wrong:
+
+- Bind request data with `#[MapRequestPayload]` / `#[MapQueryString]` on action
+  arguments, which wires up Serializer and Validator for you, instead of calling
+  `json_decode()` or `SerializerInterface` by hand. If neither package is
+  installed yet, `composer require` them rather than falling back to manual
+  parsing.
+- Use constructor property promotion, and `readonly` for DTOs and value objects.
+  Don't mark a service `readonly` if it might become `lazy: true`: a lazy proxy
+  can't extend a `readonly` class.
+- Use `symfony/lock` (`LockFactory`) for mutual exclusion. A hand-built flag or
+  lock file looks fine in review and is usually wrong under concurrency.
+
+## Everyday workflow
+
+- Run the app with `symfony serve -d`, and commands with `symfony console ...`
+  (or `bin/console` when the Symfony CLI isn't available).
+- When something fails, read `var/log/dev.log` and the web profiler
+  (`/_profiler`) before changing code.
+- If `maker-bundle` is installed, prefer `bin/console make:*` with every argument
+  passed up front and `--no-interaction` where supported: makers prompt on a
+  terminal by default, which hangs a non-interactive shell. If a maker still
+  needs interactive input, hand-write the code instead.
+- If Doctrine ORM is installed, schema changes go through migrations
+  (`bin/console make:migration`, then `doctrine:migrations:migrate`), never
+  `doctrine:schema:update` or hand-written SQL.
+- `.env` is committed and holds defaults only. Real secrets belong in `.env.local`
+  (git-ignored) or the secrets vault (`bin/console secrets:set`), read via
+  `%env(...)%`.
 
 ## Testing
 
 Install `symfony/test-pack` if it isn't already. Functional/HTTP tests extend
 `WebTestCase`; service-level tests extend `KernelTestCase`. Run
 `php bin/phpunit` (falls back to `vendor/bin/phpunit`). A feature isn't done
-until it has a test that exercises it the way a caller would — an HTTP request
-for a controller, a service call for a service — not just "it didn't throw."
+until it has a test that exercises it the way a caller would, an HTTP request for
+a controller or a service call for a service, not just "it didn't throw."
 
 ## Code style
 
 Symfony's coding standard, the `@Symfony` php-cs-fixer ruleset (a PSR-12-derived
 superset). Run `vendor/bin/php-cs-fixer fix` if `friendsofphp/php-cs-fixer` is
-installed — it isn't part of the skeleton by default.
+installed; it isn't part of the skeleton by default.
 
-## When training data might be stale
+## Discover, don't guess
 
-Framework APIs and attribute names change between major versions. Prefer reading
-the installed package's own source/docblocks in `vendor/` over recollection; if
-you have web access, https://symfony.com/doc/current/ is the canonical reference.
+Framework APIs change between versions and your training data may be stale. Look
+things up in the project instead of relying on memory:
+
+- `bin/console about`: versions, environment, paths.
+- `bin/console debug:router`, `debug:container`, `debug:autowiring <name>`,
+  `debug:config <bundle>`, `config:dump-reference <bundle>`: what exists and how
+  it is configured.
+- `bin/console lint:container`, plus `lint:twig templates/` and
+  `lint:yaml config/` where those packages are installed: validate before running.
+- Read the installed source and docblocks under `vendor/`.
+- Docs: https://symfony.com/doc/current/ (switch to the version matching
+  `composer.json` if it differs).

--- a/symfony/framework-bundle/8.1/CLAUDE.md
+++ b/symfony/framework-bundle/8.1/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/symfony/framework-bundle/8.1/CLAUDE.md
+++ b/symfony/framework-bundle/8.1/CLAUDE.md
@@ -1,1 +1,3 @@
+# CLAUDE.md
+
 @AGENTS.md

--- a/symfony/framework-bundle/8.1/manifest.json
+++ b/symfony/framework-bundle/8.1/manifest.json
@@ -7,7 +7,8 @@
         "public/": "%PUBLIC_DIR%/",
         "src/": "%SRC_DIR%/",
         ".editorconfig": ".editorconfig",
-        "AGENTS.md": "AGENTS.md"
+        "AGENTS.md": "AGENTS.md",
+        "CLAUDE.md": "CLAUDE.md"
     },
     "composer-scripts": {
         "cache:clear": "symfony-cmd",

--- a/symfony/framework-bundle/8.1/manifest.json
+++ b/symfony/framework-bundle/8.1/manifest.json
@@ -6,7 +6,8 @@
         "config/": "%CONFIG_DIR%/",
         "public/": "%PUBLIC_DIR%/",
         "src/": "%SRC_DIR%/",
-        ".editorconfig": ".editorconfig"
+        ".editorconfig": ".editorconfig",
+        "AGENTS.md": "AGENTS.md"
     },
     "composer-scripts": {
         "cache:clear": "symfony-cmd",


### PR DESCRIPTION
**Title:** [FrameworkBundle] Add AGENTS.md for AI coding agents

| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | n/a

AI coding agents on a fresh `symfony new` project don't reliably use idiomatic
Symfony patterns unless told (e.g. hand-rolled locking instead of
`symfony/lock`, `json_decode()` instead of Serializer/Validator). This adds a
lightweight `AGENTS.md` to the framework-bundle recipe covering the common
cases: ask before assuming persistence/interface/auth, use Flex instead of
hand-wiring config, prefer the framework's own components over custom code,
plus testing and code-style conventions. A minimal `CLAUDE.md` (`@AGENTS.md`)
is included too, since Claude Code looks for that filename specifically and
this way there's a single source of truth instead of duplicated content.

Note: `8.1` is already released, so per this repo's versioning rule a new
best-practice would normally target a `8.2` folder instead. Targeting `8.1`
directly here is deliberate (purely additive, already aligned within the core
team) — happy to move it to `8.2` if we decide to keep that rule strict.
