### PR TITLE
[symfony/panther] Set PANTHER_APP_ENV to an environment the Symfony 8 kernel allows

### DIFF
--- a/symfony/panther/1.0/manifest.json
+++ b/symfony/panther/1.0/manifest.json
@@ -20,7 +20,7 @@
     ],
     "dotenv": {
         "test": {
-            "PANTHER_APP_ENV": "panther",
+            "PANTHER_APP_ENV": "test",
             "PANTHER_ERROR_SCREENSHOT_DIR": "./var/error-screenshots",
             "PANTHER_DEVTOOLS": "0"
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | -

Fixes #1565.

`symfony/panther` writes `PANTHER_APP_ENV=panther` into `.env.test`, and the `symfony/framework-bundle` 8.1 recipe generates a kernel whose `getAllowedEnvs()` returns `['prod', 'dev', 'test']`. Panther starts the web server with `APP_ENV` taken from `PANTHER_APP_ENV`, so on Symfony 8 the server boots into an environment the kernel rejects, and every Panther test asserts against Symfony's error page instead of the application.

This is the first of the two options the issue lists. I checked each claim against the sources rather than taking the report as read:

- the value is in `symfony/panther/1.0/manifest.json`, and the allow-list in `symfony/framework-bundle/8.1/src/Kernel.php`;
- `KernelTrait::getKernelParameters()` throws `The environment "%s" is not registered as allowed by "%s::getAllowedEnvs()"`, and only when the list is non-empty, which is why returning `[]` is also a workaround;
- `WebServerManager::__construct()` sets `$env['APP_ENV']` from `PANTHER_APP_ENV` when it is present.

Two things that were not in the issue and that make the trade-off smaller than it looks:

- **The `panther` environment configures nothing.** No recipe ships a `config/packages/panther/`, and Panther's own documentation never suggests that value; its CHANGELOG describes `PANTHER_APP_ENV` only as a way to override `APP_ENV`. The value came in through #1239 (a PHPUnit 10 recipe change) and was carried over unchanged when the `dotenv` configurator replaced the `add-lines` entry.
- **`symfony/panther` is the only recipe in this repository that sets a non-standard `APP_ENV` value.** Every other occurrence is the `APP_ENV=dev` of `symfony/framework-bundle`, which the allow-list covers. So the wider convention question raised at the end of the issue currently has exactly one case, this one.

I kept the variable rather than removing it, even though Panther works without it: when it is unset the web server inherits its environment from the test process, which depends on how the application propagates `APP_ENV`, whereas setting it explicitly does not.

Happy to close this if you would rather document the kernel change instead, which is the other option in the issue.
