### PR TITLE
[AssetMapper] Add `minimum_release_age` config

### DIFF
--- a/symfony/asset-mapper/8.2/assets/app.js
+++ b/symfony/asset-mapper/8.2/assets/app.js
@@ -1,0 +1,9 @@
+/*
+ * Welcome to your app's main JavaScript file!
+ *
+ * This file will be included onto the page via the importmap() Twig function,
+ * which should already be in your base.html.twig.
+ */
+import './styles/app.css';
+
+console.log('This log comes from assets/app.js - welcome to AssetMapper! 🎉');

--- a/symfony/asset-mapper/8.2/assets/styles/app.css
+++ b/symfony/asset-mapper/8.2/assets/styles/app.css
@@ -1,0 +1,3 @@
+body {
+    background-color: skyblue;
+}

--- a/symfony/asset-mapper/8.2/config/packages/asset_mapper.yaml
+++ b/symfony/asset-mapper/8.2/config/packages/asset_mapper.yaml
@@ -1,0 +1,12 @@
+framework:
+    asset_mapper:
+        # The paths to make available to the asset mapper.
+        paths:
+            - assets/
+        missing_import_mode: strict
+        minimum_release_age: 604800
+
+when@prod:
+    framework:
+        asset_mapper:
+            missing_import_mode: warn

--- a/symfony/asset-mapper/8.2/importmap.php
+++ b/symfony/asset-mapper/8.2/importmap.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * Returns the importmap for this application.
+ *
+ * - "path" is a path inside the asset mapper system. Use the
+ *     "debug:asset-map" command to see the full list of paths.
+ *
+ * - "entrypoint" (JavaScript only) set to true for any module that will
+ *     be used as an "entrypoint" (and passed to the importmap() Twig function).
+ *
+ * The "importmap:require" command can be used to add new entries to this file.
+ */
+return [
+    'app' => [
+        'path' => './assets/app.js',
+        'entrypoint' => true,
+    ],
+];

--- a/symfony/asset-mapper/8.2/manifest.json
+++ b/symfony/asset-mapper/8.2/manifest.json
@@ -1,0 +1,26 @@
+{
+    "copy-from-recipe": {
+        "assets/": "assets/",
+        "config/": "%CONFIG_DIR%/",
+        "importmap.php": "importmap.php"
+    },
+    "aliases": ["asset-mapper", "importmap"],
+    "gitignore": [
+        "/%PUBLIC_DIR%/assets/",
+        "/assets/vendor/"
+    ],
+    "composer-scripts": {
+        "importmap:install": "symfony-cmd"
+    },
+    "add-lines": [
+        {
+            "file": "templates/base.html.twig",
+            "content": [
+                "            {% block importmap %}{{ importmap('app') }}{% endblock %}"
+            ],
+            "position": "after_target",
+            "target": "{% block javascripts %}",
+            "warn_if_missing": true
+        }
+    ]
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | 

Following https://github.com/symfony/symfony/pull/65074#discussion_r3810543995

`604800` seconds is a week, this sounds to me to be a decent time to prevent an upgrade to a compromised version. Maybe it's a bit too long.
This setting can be overridden, and it is also possible to ignore it using `importmap:require` but pushing a value to this config can help to improve security in projects. 