### PR TITLE
[WebProfilerBundle] Add `excluded_paths` config

### DIFF
--- a/symfony/web-profiler-bundle/8.2/config/packages/web_profiler.yaml
+++ b/symfony/web-profiler-bundle/8.2/config/packages/web_profiler.yaml
@@ -1,0 +1,15 @@
+when@dev:
+    web_profiler:
+        toolbar: true
+
+    framework:
+        profiler:
+            collect: true
+            excluded_paths:
+                - '^/\.well-known/'
+                - '^/favicon\.ico$'
+
+when@test:
+    framework:
+        profiler:
+            collect: false

--- a/symfony/web-profiler-bundle/8.2/config/routes/web_profiler.yaml
+++ b/symfony/web-profiler-bundle/8.2/config/routes/web_profiler.yaml
@@ -1,0 +1,8 @@
+when@dev:
+    web_profiler_wdt:
+        resource: '@WebProfilerBundle/Resources/config/routing/wdt.php'
+        prefix: /_wdt
+
+    web_profiler_profiler:
+        resource: '@WebProfilerBundle/Resources/config/routing/profiler.php'
+        prefix: /_profiler

--- a/symfony/web-profiler-bundle/8.2/manifest.json
+++ b/symfony/web-profiler-bundle/8.2/manifest.json
@@ -1,0 +1,11 @@
+{
+    "bundles": {
+        "Symfony\\Bundle\\WebProfilerBundle\\WebProfilerBundle": ["dev", "test"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "conflict": {
+        "symfony/framework-bundle": "<8.2"
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | 

From suggestion in https://github.com/symfony/symfony/pull/65427#pullrequestreview-4981554328

Symfony 8.2 will provide a new `excluded_paths` config to prevent profiler to collect data from defined paths.
Those paths were suggested in code PR but we may can find others that are common enough to warrant being added
