### PR TITLE
[SecurityBundle] Import the OIDC login routes

### DIFF
--- a/symfony/security-bundle/8.2/config/packages/security.yaml
+++ b/symfony/security-bundle/8.2/config/packages/security.yaml
@@ -1,0 +1,39 @@
+security:
+    # https://symfony.com/doc/current/security.html#registering-the-user-hashing-passwords
+    password_hashers:
+        Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface: 'auto'
+
+    # https://symfony.com/doc/current/security.html#loading-the-user-the-user-provider
+    providers:
+        users_in_memory: { memory: null }
+
+    firewalls:
+        dev:
+            # Ensure dev tools and static assets are always allowed
+            pattern: ^/(_profiler|_wdt|assets|build)/
+            security: false
+        main:
+            lazy: true
+            provider: users_in_memory
+
+            # Activate different ways to authenticate:
+            # https://symfony.com/doc/current/security.html#the-firewall
+
+            # https://symfony.com/doc/current/security/impersonating_user.html
+            # switch_user: true
+
+    # Note: Only the *first* matching rule is applied
+    access_control:
+        # - { path: ^/admin, roles: ROLE_ADMIN }
+        # - { path: ^/profile, roles: ROLE_USER }
+
+when@test:
+    security:
+        password_hashers:
+            # Password hashers are resource-intensive by design to ensure security.
+            # In tests, it's safe to reduce their cost to improve performance.
+            Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface:
+                algorithm: auto
+                cost: 4 # Lowest possible value for bcrypt
+                time_cost: 3 # Lowest possible value for argon
+                memory_cost: 10 # Lowest possible value for argon

--- a/symfony/security-bundle/8.2/config/routes/security.yaml
+++ b/symfony/security-bundle/8.2/config/routes/security.yaml
@@ -1,0 +1,7 @@
+_security_logout:
+    resource: security.route_loader.logout
+    type: service
+
+_security_oidc_login:
+    resource: security.authenticator.oidc_login.route_loader
+    type: service

--- a/symfony/security-bundle/8.2/manifest.json
+++ b/symfony/security-bundle/8.2/manifest.json
@@ -1,0 +1,9 @@
+{
+    "bundles": {
+        "Symfony\\Bundle\\SecurityBundle\\SecurityBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "aliases": ["security"]
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Doc issue/PR  | symfony/symfony-docs#22881

Symfony 8.2 adds an `oidc_login` firewall authenticator (symfony/symfony#64954). The OIDC provider redirects the user back to a callback path, and that path needs a route: without one the router answers the redirect with a 404 before the firewall ever sees it. Since symfony/symfony#65814, the same loader also declares a start route per firewall, which begins the flow by redirecting to the provider, so a login page can link to it.

Symfony declares these routes through a route loader the application imports, exactly as it does for the logout routes, so this adds the import next to `_security_logout`:

```yaml
# config/routes/security.yaml
_security_oidc_login:
    resource: security.authenticator.oidc_login.route_loader
    type: service
```

The loader is registered unconditionally since symfony/symfony#65800, and declares no route until a firewall uses the OIDC authenticator, so the import is safe in applications that do not use OIDC.

New `8.2` directory, copied from `7.4` with only that block added.
